### PR TITLE
Add delivery_info

### DIFF
--- a/menu/SelectProfileTable.py
+++ b/menu/SelectProfileTable.py
@@ -3,19 +3,24 @@ from tkinter import ttk
 
 from config import cookies_config_path
 from util.BiliRequest import BiliRequest
-from util.JsonUtil import ProfileInfo
+from util.JsonUtil import ProfileInfo, AddrInfo
 
 
 class SelectProfileTable:
-    def __init__(self, master, data, max_selections, onSubmitPersons):
+    def __init__(self, master, data, addr_data, max_selections,onSubmitPersons,onSubmitAddr):
         self.profileInfo = ProfileInfo(data)
+        self.addrInfo = AddrInfo(addr_data)
         self.master = master
         self.onSubmitPersons = onSubmitPersons
+        self.onSubmitAddr = onSubmitAddr
         self.master.title("选人")
         self.persons = self.profileInfo.get_persons()
+        self.addrs = self.addrInfo.get_addrs()
         self.max_selections = max_selections
         self.selected_indices = set()
+        self.addr_indices=set()
 
+        # select person
         self.listbox = tk.Listbox(master, selectmode=tk.MULTIPLE, width=50)
         self.listbox.grid(row=0, column=0, padx=10, pady=10, sticky=tk.W)
         for person in self.persons:
@@ -23,8 +28,19 @@ class SelectProfileTable:
             self.listbox.insert(tk.END, f"{name}")
             self.listbox.itemconfig(tk.END, {'fg': "black"})
 
+        # select address
+        self.addr_listbox = tk.Listbox(master, selectmode=tk.SINGLE, width=50)
+        self.addr_listbox.grid(row=1, column=0, padx=10, pady=10, sticky=tk.W)
+        for addr in self.addrs:
+            name = addr['name']
+            self.addr_listbox.insert(tk.END, f"{name}")
+            self.addr_listbox.itemconfig(tk.END, {'fg': "black"})
+
         self.detail_text = tk.Text(master, height=10, width=40)
         self.detail_text.grid(row=0, column=1, padx=10, pady=10, sticky=tk.W)
+
+        self.addr_text=tk.Text(master, height=10, width=40)
+        self.addr_text.grid(row=1, column=1, padx=10, pady=10, sticky=tk.W)
 
         self.submit_button = ttk.Button(master, text="提交", command=self.submit_booking)
         self.submit_button.grid(row=2, column=0, columnspan=2, pady=10)
@@ -33,8 +49,10 @@ class SelectProfileTable:
         self.displayed_number_label.grid(row=2, column=0, pady=10)
 
         self.listbox.bind('<<ListboxSelect>>', self.display_ticket_details)
+        self.addr_listbox.bind('<<ListboxSelect>>', self.display_address_details)
 
-    def display_ticket_details(self, event):
+
+    def display_ticket_details(self,event):
         selected_indices = self.listbox.curselection()
         if selected_indices:
             self.selected_indices = set(selected_indices)
@@ -47,10 +65,26 @@ class SelectProfileTable:
             self.detail_text.delete(1.0, tk.END)
             self.detail_text.insert(tk.END, details)
 
+    def display_address_details(self,event):
+        addr_indices = self.addr_listbox.curselection()
+        if addr_indices:
+            self.addr_indices = set(addr_indices)
+            details = ""
+            for index in addr_indices:
+                selected_ticket = self.addrs[index]
+                details += f"名字: {selected_ticket['name']}\n" \
+                           f"电话: {selected_ticket['phone']}\n" \
+                           f"地址: {selected_ticket['prov'] + selected_ticket['city'] + selected_ticket['area'] + selected_ticket['addr']}\n\n"
+
+            self.addr_text.delete(1.0, tk.END)
+            self.addr_text.insert(tk.END, details)
+
     def submit_booking(self):
         if len(self.selected_indices) == self.max_selections:
             persons = [self.persons[index] for index in self.selected_indices]
+            addr=[self.addrs[index] for index in self.addr_indices]
             self.onSubmitPersons(persons)
+            self.onSubmitAddr(addr)
             self.master.destroy()
             self.master.quit()  # Exit the mainloop
         else:
@@ -63,7 +97,9 @@ if __name__ == "__main__":
     _request = BiliRequest(cookies_config_path=cookies_config_path)
     res = _request.get(url="https://show.bilibili.com/api/ticket/buyer/list?is_default&projectId=74924")
     print(res.text)
+    addr_res = _request.get(url="https://show.bilibili.com/api/ticket/addr/list")
+    print(addr_res.text)
 
     root = tk.Tk()
-    app = SelectProfileTable(root, res.json(), max_selections=3)
+    app = SelectProfileTable(root, res.json(), addr_res.json(), max_selections=3,onSubmitPersons=lambda x: print(x))
     root.mainloop()

--- a/util/JsonUtil.py
+++ b/util/JsonUtil.py
@@ -21,3 +21,10 @@ class ProfileInfo:
 
     def get_persons(self):
         return self.personList
+
+class AddrInfo:
+    def __init__(self, data):
+        self.addrList = data["data"]["addr_list"]
+
+    def get_addrs(self):
+        return self.addrList


### PR DESCRIPTION
## 概述

实现/解决/优化的内容:  
- resolve #22 
- 新增实体票配送地址功能，地址从会员购的地址中获取默认地址
### 事务

- [ ] 已与维护者在issues或其他平台沟通此PR大致内容

## 以下内容可在起草PR后、合并PR前逐步完成

### 功能

- [x] 可购买实体票
- [x] 向用户说明应当先在会员购中添加地址再使用（无论是否电子票都应选择地址才能进行下一步，不影响后续功能）
- [x] 省去填写一次联系人信息（通过挪用buyer_info中的信息）
- [ ] 暂未实现选座功能，未找到合适的测试场次

### 兼容性

- [x] 已测试到付、需运费两种实体票（测试id：78907,80373）
- [x] 已测试电子票（带地址提交也可成功创建）

### 风险

可能导致或已知的问题: 
- [ ] 暂未测试包邮实体票（未找到），理论可行
