### PR TITLE
fix: 二维码接口使用 getPayParam；二维码显示尺寸限定为 300x300 且避免说明挡住二维码图片

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,10 +18,18 @@ short_js = """
 <script src="https://static.geetest.com/static/js/gt.0.4.9.js"></script>
 """
 
+custom_css = """
+.pay_qrcode img {
+  width: 300px !important;
+  height: 300px !important;
+  margin-top: 20px; /* 避免二维码头部的说明文字挡住二维码 */
+}
+"""
+
 if __name__ == "__main__":
     logger.add("app.log")
 
-    with gr.Blocks(head=short_js) as demo:
+    with gr.Blocks(head=short_js, css=custom_css) as demo:
         gr.Markdown(header)
         with gr.Tab("配置"):
             setting_tab()

--- a/tab/go.py
+++ b/tab/go.py
@@ -153,8 +153,6 @@ def start_go(tickets_info_str, time_start, interval, mode, total_attempts):
             if errno == 0:
                 qrcode_url = get_qrcode_url(
                     _request,
-                    request_result["data"]["token"],
-                    tickets_info["project_id"],
                     request_result["data"]["orderId"],
                 )
                 qr_gen = qrcode.QRCode()
@@ -263,7 +261,7 @@ def go_tab():
                 max_lines=10,
 
             )
-            qr_image = gr.Image(label="使用微信或者支付宝扫码支付", visible=False)
+            qr_image = gr.Image(label="使用微信或者支付宝扫码支付", visible=False, elem_classes="pay_qrcode")
 
         with gr.Row(visible=False) as gt_row:
             gt_html_btn = gr.Button("点击打开抢票验证码（请勿多点！！）")

--- a/util/order_qrcode.py
+++ b/util/order_qrcode.py
@@ -1,12 +1,13 @@
 import time
 
 
-def get_qrcode_url(_request, token, project_id, order_id):
-    url = f"https://show.bilibili.com/api/ticket/order/createstatus?token={token}"
-    f"&timestamp={int(round(time.time() * 1000))}"
-    f"&project_id={project_id}&orderId={order_id}"
+def get_qrcode_url(_request, order_id):
+    url = f"https://show.bilibili.com/api/ticket/order/getPayParam?order_id={order_id}"
     data = _request.get(url).json()
-    if data["errno"] == 0:
-        return data["data"]["payParam"]["code_url"]
-    else:
+    try:
+        if data["errno"] == 0:
+            return data["data"]["code_url"]
+        else:
+            raise Exception
+    except Exception:
         return None


### PR DESCRIPTION
## 概述

实现/解决/优化的内容: 
- 「获取支付二维码接口」功能改为使用 `show.bilibili.com/api/ticket/order/getPayParam` 接口来实现
-  通过编写一段自定义 CSS 并在 `gr.Image` 上加入自定义类名，把二维码图片缩小到 300x300，以解决需要整屏滚动到下方才能看到二维码 & 二维码图片在一屏内可能展示不下 & 影响扫码效率 的问题

### 事务

- [x] 已与维护者在issues或其他平台沟通此PR大致内容：已提出 Issue #73，暂未进一步沟通

## 以下内容可在起草PR后、合并PR前逐步完成

### 功能

- [x] 已编写完善的配置文件字段说明：无配置文件变更
- [x] 已编写面向用户的新功能说明（若有必要）：非必要
- [x] 已测试新功能或更改：已自测通过

### 兼容性

- [x] 已处理版本兼容性：无需处理
- [x] 已处理插件兼容问题：无需处理

### 风险

可能导致或已知的问题: 影响范围包括二维码显示功能，但该功能不是核心功能，风险可控
