### PR TITLE
如果本地验证码加载失败，启用模式二

### DIFF
--- a/dynimport.py
+++ b/dynimport.py
@@ -1,0 +1,14 @@
+from loguru import logger
+import importlib
+
+global bili_ticket_gt_python
+
+try:
+	logger.info("尝试加载本地验证码模块")
+	bili_ticket_gt_python = importlib.import_module("bili_ticket_gt_python")
+	logger.info("加载成功")
+except Exception as e:
+	logger.error(f"本地验证码模块加载失败，错误信息：{e}")
+	logger.info("正在使用不带有本地验证模块的模式启动")
+	logger.warning("此模式下请勿使用本地验证码功能，否则会报错")
+	bili_ticket_gt_python = None

--- a/geetest/AmorterValidator.py
+++ b/geetest/AmorterValidator.py
@@ -1,9 +1,6 @@
-import bili_ticket_gt_python
 import loguru
-
-from config import cookies_config_path
 from geetest.Validator import Validator
-from util.bili_request import BiliRequest
+from dynimport import bili_ticket_gt_python
 
 
 class AmorterValidator(Validator):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ Pillow~=10.3.0
 retry~=0.9.2
 bili-ticket-gt-python~=0.2.4
 aiohttp~=3.9.5
+importlib~=1.0.4

--- a/tab/go.py
+++ b/tab/go.py
@@ -12,16 +12,21 @@ from loguru import logger
 
 from common import format_dictionary_to_string
 from config import cookies_config_path, global_cookieManager
-from geetest.AmorterValidator import AmorterValidator
+# from geetest.AmorterValidator import AmorterValidator
 from geetest.CapSolverValidator import CapSolverValidator
 from geetest.NormalValidator import NormalValidator
 from geetest.RROCRValidator import RROCRValidator
 from util.bili_request import BiliRequest
 from util.error import ERRNO_DICT, withTimeString
 from util.order_qrcode import get_qrcode_url
+from dynimport import bili_ticket_gt_python
+import importlib
 
 ways = ["手动", "使用 rrocr", "使用 CapSolver", "本地过验证码（Amorter提供）"]
-ways_detail = [NormalValidator(), RROCRValidator(), CapSolverValidator(), AmorterValidator()]
+ways_detail = [NormalValidator(), RROCRValidator(), CapSolverValidator()]
+if bili_ticket_gt_python is not None:
+    AmorterValidator = importlib.import_module("geetest.AmorterValidator").AmorterValidator()
+    ways_detail.append(AmorterValidator)
 
 
 def go_tab():


### PR DESCRIPTION
### 仍有少量用户使用本地验证码会出现bug
#### 故做出如下更改
- 启动时动态加载本地验证码模块
- 如果加载失败，则使用不带本地验证码模块的模式启动