### PR TITLE
WebUI抢票选项卡中新增系统时间检查功能

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ Pillow~=10.3.0
 retry~=0.9.2
 tinydb~=4.8.0
 bili-ticket-gt-python~=0.2.5
+ntplib~=0.4.0

--- a/tab/go.py
+++ b/tab/go.py
@@ -13,6 +13,7 @@ import retry
 from gradio import SelectData
 from loguru import logger
 from requests import HTTPError, RequestException
+import ntplib
 
 from config import global_cookieManager, main_request, configDB
 from geetest.CapSolverValidator import CapSolverValidator
@@ -73,6 +74,9 @@ def go_tab():
             label="选择抢票的时间",
             show_label=True,
         )
+
+        time_valid_btn = gr.Button("点击检查系统时间")
+        time_valid_result = gr.Text(label="系统时间检查结果",info="该功能仅可检测当前系统时间是否准确, 避免错过开票时间, 如发现系统时间不准确请到设置中手动同步时间")
 
         def upload(filepath):
             try:
@@ -497,6 +501,30 @@ def go_tab():
     def stop():
         nonlocal isRunning
         isRunning = False
+
+    def ntp_time_valid():
+        ntp_server='ntp.aliyun.com'
+        client = ntplib.NTPClient()
+        try:
+            response = client.request(ntp_server, version=3)
+        except Exception:
+            return "时钟服务器("+ntp_server+")错误, 请重试"
+        ntp_time = response.tx_time
+        device_time=time.time()
+        time_diff=device_time-ntp_time
+        if time_diff>0.8:
+            return "您的系统时间比中国标准时间(UTC+8)快了: "+str(format(time_diff,'.2f'))+"秒, 请进行时间同步"
+        if time_diff<-0.8:
+            return "您的系统时间比中国标准时间(UTC+8)慢了: "+str(format(time_diff,'.2f'))+"秒, 请进行时间同步"
+        else:
+            return "您的时间准确无误。[授时精度: ±0.8 秒, NTP服务器: "+ntp_server+", 参考时间偏移: "+str(time_diff)+"]"
+
+
+    time_valid_btn.click(
+        fn=ntp_time_valid,
+        inputs=None,
+        outputs=time_valid_result
+    )
 
     go_btn.click(
         fn=start_go,


### PR DESCRIPTION
在WebUI的抢票选项卡中新增了检查当前系统时间的功能。在抢票前可以检查当前系统时间与阿里云NTP(ntp.aliyun.com)提供的标准时间是否一致，避免因系统时间偏差导致错过开票时间。