### PR TITLE
fix: 修复后端重启前端仍沿用原会话可能导致错误的问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -48,4 +48,4 @@ if __name__ == "__main__":
     if args.port == -1:
         demo.launch(share=False, inbrowser=True)
     else:
-        demo.launch(share=True, server_port=args.port)
+        demo.launch(share=True, server_port=args.port, inbrowser=True)

--- a/main.py
+++ b/main.py
@@ -46,6 +46,6 @@ if __name__ == "__main__":
     # 运行应用
     print("点击下面的网址运行程序     ↓↓↓↓↓↓↓↓↓↓↓↓↓↓")
     if args.port == -1:
-        demo.launch(share=True)
+        demo.launch(share=False, inbrowser=True)
     else:
         demo.launch(share=True, server_port=args.port)


### PR DESCRIPTION
- 通过在Gradio本地启动时自动打开一个新的浏览器页面，引导用户始终在最新的会话中与后端进行交互，避免出现前后端数据不一致及前端数据渲染错误的问题 (尝试修复 #359 中的问题)
- 在Windows中运行而不是在doker中运行时(一般也没有人用windows服务器来部署吧，用win的一般都是本地用户)，不再打开分享连接，提高程序启动速度，并避免在不使用VPN时可能导致的报错