### PR TITLE
fix: 修复gradio.launch()函数中share相关参数可能报错的问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,6 +46,6 @@ if __name__ == "__main__":
     # 运行应用
     print("点击下面的网址运行程序     ↓↓↓↓↓↓↓↓↓↓↓↓↓↓")
     if args.port == -1:
-        demo.launch(share=False, inbrowser=True)
+        demo.launch(inbrowser=True)
     else:
-        demo.launch(share=True, server_port=args.port, inbrowser=True)
+        demo.launch(server_port=args.port, inbrowser=True)

--- a/main.py
+++ b/main.py
@@ -29,6 +29,7 @@ custom_css = """
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--port", type=int, default=-1, help="server port")
+    parser.add_argument("--share", type=bool, default=False, help="create a public link")
     args = parser.parse_args()
 
     logger.add("app.log")
@@ -46,6 +47,6 @@ if __name__ == "__main__":
     # 运行应用
     print("点击下面的网址运行程序     ↓↓↓↓↓↓↓↓↓↓↓↓↓↓")
     if args.port == -1:
-        demo.launch(inbrowser=True)
+        demo.launch(inbrowser=True, share=args.share)
     else:
-        demo.launch(server_port=args.port, inbrowser=True)
+        demo.launch(server_port=args.port, inbrowser=True, share=args.share)


### PR DESCRIPTION
- 新增一个启动参数`--share=True/False`可选择是否启动分享链接
- 对于大部分本地用户以及具有公网服务器的用户都不需要这个本地连接，因此参数默认设为`False`以避免墙内网络不稳定时导致的错误和启动缓慢
- 如无法创建本地链接或者需要分享本地的WebUI远程访问，可手动设置`--share=True`