### PR TITLE
refactor: 重构启动WebUI部分的逻辑

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ COPY requirements.txt .
 RUN python -m pip install --no-cache-dir -r requirements.txt  -i https://pypi.tuna.tsinghua.edu.cn/simple
 COPY . .
 ENV GRADIO_SERVER_NAME="0.0.0.0"
-CMD ["python", "main.py","--port","7860"]
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Running on local URL:  http://127.0.0.1:xxx
 
 访问对应的网址即可
 
+使用源码手动启动 `main.py` 时可带有如下参数：
+
+- `--port` 可设置WebUI使用的端口，需传入一个 `1-65535` 的整数，默认为 `7860`
+- `--share` 选择是否创建sharelink，需传入布尔值 `True/False` ，默认为 `False`
+
 [点我前往更加详细的使用说明书](https://github.com/mikumifa/biliTickerBuy/wiki/%E6%8A%A2%E7%A5%A8%E8%AF%B4%E6%98%8E)
 
 | 抢票过程                                                     | 滑块过程                                                     |

--- a/main.py
+++ b/main.py
@@ -46,6 +46,6 @@ if __name__ == "__main__":
     # 运行应用
     print("点击下面的网址运行程序     ↓↓↓↓↓↓↓↓↓↓↓↓↓↓")
     if args.port == -1:
-        demo.launch(share=False, inbrowser=True)
+        demo.launch(inbrowser=True)
     else:
-        demo.launch(share=True, server_port=args.port, inbrowser=True)
+        demo.launch(server_port=args.port, inbrowser=True)

--- a/main.py
+++ b/main.py
@@ -29,6 +29,7 @@ custom_css = """
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--port", type=int, default=-1, help="server port")
+    parser.add_argument("--share", type=bool, default=False, help="create a public link")
     args = parser.parse_args()
 
     logger.add("app.log")
@@ -46,6 +47,6 @@ if __name__ == "__main__":
     # 运行应用
     print("点击下面的网址运行程序     ↓↓↓↓↓↓↓↓↓↓↓↓↓↓")
     if args.port == -1:
-        demo.launch(inbrowser=True)
+        demo.launch(inbrowser=True, share=args.share)
     else:
-        demo.launch(server_port=args.port, inbrowser=True)
+        demo.launch(server_port=args.port, inbrowser=True, share=args.share)

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ custom_css = """
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--port", type=int, default=-1, help="server port")
+    parser.add_argument("--port", type=int, default=7860, help="server port")
     parser.add_argument("--share", type=bool, default=False, help="create a public link")
     args = parser.parse_args()
 
@@ -46,7 +46,4 @@ if __name__ == "__main__":
 
     # 运行应用
     print("点击下面的网址运行程序     ↓↓↓↓↓↓↓↓↓↓↓↓↓↓")
-    if args.port == -1:
-        demo.launch(inbrowser=True, share=args.share)
-    else:
-        demo.launch(server_port=args.port, inbrowser=True, share=args.share)
+    demo.launch(server_port=args.port, share=args.share, inbrowser=True)


### PR DESCRIPTION
- 新增一个启动参数`--share=True/False`可选择是否启动分享链接
- 对于大部分本地用户以及具有公网服务器的用户都不需要这个分享连接，因此参数默认设为`False`以避免墙内网络不稳定时导致的错误和启动缓慢
- 设置`--port`参数默认为7860，doker启动时无需再传入此参数，一并也修改了相应的`dokerfile`。原版本的的`args.port == -1`这个判断逻辑重复，因此将这个判断去掉了，现在各平台可以共用一个启动函数了，便于后期维护。
- 如无法创建本地链接或者需要分享本地的WebUI远程访问，可手动设置`--share=True`