### PR TITLE
docker配置环境变量: GRADIO_SERVER_NAME -> BTB_SERVER_NAME

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV TZ=Asia/Shanghai
 COPY requirements.txt .
 RUN python -m pip install --no-cache-dir -r requirements.txt  -i https://pypi.tuna.tsinghua.edu.cn/simple
 COPY . .
-ENV GRADIO_SERVER_NAME="0.0.0.0"
+ENV BTB_SERVER_NAME="0.0.0.0"
 ENV GRADIO_SERVER_PORT 7860
 
 CMD ["python", "main.py"]


### PR DESCRIPTION
## 概述

实现/解决/优化的内容: dockerfile 有个环境变量设错了, 应该用BTB_SERVER_NAME="0.0.0.0"

看了下是Commit `7d8cc3e` 引入的`--server_name`参数和`BTB_SERVER_NAME`这个环境变量

### 事务

- [ ] 已与维护者在issues或其他平台沟通此PR大致内容

## 以下内容可在起草PR后、合并PR前逐步完成

### 功能

- [x] 已编写完善的配置文件字段说明（若有新增）
- [x] 已编写面向用户的新功能说明（若有必要）
- [x] 已测试新功能或更改

### 兼容性

- [x] 已处理版本兼容性
- [x] 已处理插件兼容问题

### 风险

可能导致或已知的问题: 无
