### PR TITLE
fix EXE_PATH error

### DIFF
--- a/util/__init__.py
+++ b/util/__init__.py
@@ -35,8 +35,15 @@ def get_application_tmp_path() -> str:
     os.makedirs(os.path.join(FILES_ROOT_PATH, "tmp"), exist_ok=True)
     return os.path.join(FILES_ROOT_PATH, "tmp")
 
+def get_exec_path() -> str:
+    if len(sys.argv[0]) > 0 and sys.argv[0].endswith(".py"):    # sometime, argv[0] of `python main.py` is main.py
+        return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    else:
+        return os.path.dirname(os.path.realpath(sys.executable))
 
-EXE_PATH: str = os.path.dirname(os.path.realpath(sys.executable))  # 应用目录
+
+EXE_PATH: str = get_exec_path()  # 应用目录
+
 TEMP_PATH: str = get_application_tmp_path()  # 临时目录
 LOG_DIR: str = os.path.join(EXE_PATH, "btb_logs")
 loguru_config(LOG_DIR, "app.log", enable_console=True, file_colorize=False)


### PR DESCRIPTION
## 概述

实现/解决/优化的内容: 

在`python 3.11.2 venv`及`zsh 5.9 (aarch64-unknown-linux-gnu)`环境下，使用`python main.py`运行btb，会产生
```
PermissionError: [Errno 13] Permission denied: '/usr/bin/btb_logs'
```
报错原因可能是由于argv[0]被简化成main.py，进而sys.executable识别错误，此pr尝试解决此问题。

### 事务

- [ ] 已与维护者在issues或其他平台沟通此PR大致内容

## 以下内容可在起草PR后、合并PR前逐步完成

### 功能

- [ ] 已编写完善的配置文件字段说明（若有新增）
- [ ] 已编写面向用户的新功能说明（若有必要）
- [ ] 已测试新功能或更改

### 兼容性

- [x] 已处理版本兼容性
- [x] 已处理插件兼容问题

### 风险

可能导致或已知的问题: 
