### PR TITLE
feat: 新增Server酱3推送支持 & 推送重构

### DIFF
--- a/app_cmd/buy.py
+++ b/app_cmd/buy.py
@@ -83,6 +83,7 @@ def buy_cmd(args: Namespace):
         args.serverchanKey,
         args.barkToken,
         args.https_proxys,
+        args.serverchan3ApiUrl,
         args.ntfy_url,
         args.ntfy_username,
         args.ntfy_password,

--- a/main.py
+++ b/main.py
@@ -58,6 +58,12 @@ def main():
         help="ServerChan key (optional).",
     )
     buy_parser.add_argument(
+        "--serverchan3ApiUrl",
+        type=str,
+        default=os.environ.get("BTB_SERVERCHAN3APIURL", ""),
+        help="ServerChan3 API URL (optional).",
+    )
+    buy_parser.add_argument(
         "--barkToken",
         type=str,
         default=os.environ.get("BTB_BARKTOKEN", ""),

--- a/service/WorkerService.py
+++ b/service/WorkerService.py
@@ -4,6 +4,7 @@ from loguru import logger
 from pydantic import BaseModel
 
 from task.buy import buy_stream
+from util.Notifier import NotifierConfig
 
 cancel_event = threading.Event()
 
@@ -22,6 +23,7 @@ class BuyRequest(BaseModel):
     ntfy_username: str | None
     ntfy_password: str | None
     serverchanKey: str | None
+    serverchan3ApiUrl: str | None
 
 
 current_task_thread: threading.Thread | None = None
@@ -47,6 +49,17 @@ def create_worker_app(app: FastAPI, args):
             cancel_event.clear()
 
             def stream():
+                # 创建NotifierConfig对象
+                notifier_config = NotifierConfig(
+                    serverchan_key=data.serverchanKey,
+                    serverchan3_api_url=data.serverchan3ApiUrl,
+                    pushplus_token=data.pushplusToken,
+                    bark_token=data.barkToken,
+                    ntfy_url=data.ntfy_url,
+                    ntfy_username=data.ntfy_username,
+                    ntfy_password=data.ntfy_password
+                )
+                
                 for msg in buy_stream(
                     tickets_info_str=data.train_info,
                     time_start=data.time_start,
@@ -54,12 +67,7 @@ def create_worker_app(app: FastAPI, args):
                     mode=data.mode,
                     total_attempts=data.total_attempts,
                     audio_path=data.audio_path,
-                    pushplusToken=data.pushplusToken,
-                    serverchanKey=data.serverchanKey,
-                    barkToken=data.barkToken,
-                    ntfy_url=data.ntfy_url,
-                    ntfy_username=data.ntfy_username,
-                    ntfy_password=data.ntfy_password,
+                    notifier_config=notifier_config,
                     https_proxys=args.https_proxys,
                 ):
                     if cancel_event.is_set():

--- a/service/WorkerService.py
+++ b/service/WorkerService.py
@@ -57,7 +57,8 @@ def create_worker_app(app: FastAPI, args):
                     bark_token=data.barkToken,
                     ntfy_url=data.ntfy_url,
                     ntfy_username=data.ntfy_username,
-                    ntfy_password=data.ntfy_password
+                    ntfy_password=data.ntfy_password,
+                    audio_path=data.audio_path
                 )
                 
                 for msg in buy_stream(
@@ -66,7 +67,6 @@ def create_worker_app(app: FastAPI, args):
                     interval=data.interval,
                     mode=data.mode,
                     total_attempts=data.total_attempts,
-                    audio_path=data.audio_path,
                     notifier_config=notifier_config,
                     https_proxys=args.https_proxys,
                 ):

--- a/tab/go.py
+++ b/tab/go.py
@@ -192,29 +192,37 @@ def go_tab(demo: gr.Blocks):
                 🗨️ **抢票成功提醒**
     
                 > 你需要去对应的网站获取 key 或 token，然后填入下面的输入框  
-                > [Server酱](https://sct.ftqq.com/sendkey) | [pushplus](https://www.pushplus.plus/uc.html) | [ntfy](https://ntfy.sh/) | [Bark](https://bark.day.app/)  
+                > [Server酱<sup>Turbo</sup>](https://sct.ftqq.com/sendkey) | [pushplus](https://www.pushplus.plus/uc.html) | [Server酱<sup>3</sup>](https://sc3.ft07.com/sendkey) | [ntfy](https://ntfy.sh/) | [Bark](https://bark.day.app/)  
                 > 留空以不启用提醒功能
     
                 ### 🔍 推送服务对比
     
                 | 服务     | 优点                               | 缺点                            |
                 |----------|------------------------------------|---------------------------------|
-                | Server酱 | 简单易用，微信推送              | 微信推送很难看到 |
+                | Server酱<sup>Turbo</sup> | 简单易用，微信推送              | 微信推送很难看到 |
                 | pushplus | 简单易用，微信推送| 微信推送很难看到               |
-                | ntfy     | APP推送 | 配置复杂，需要手动搭建或注册公网地址 |
+                | Server酱<sup>3</sup> | APP推送，有中文文档              | 配置复杂 |
+                | ntfy     | APP推送, 功能强大, 支持长期响铃 | 配置复杂，需要手动搭建或注册公网地址 |
                 | Bark     | iOS通知推送，配置简单，无视静音和勿扰模式，支持APP跳转 | 仅支持iOS设备 |
     
-                ✅ 推荐：初次使用建议选择 **pushplus** 或 **Server酱**，配置最简单  
+                ✅ 推荐：初次使用建议选择 **pushplus** 或 **Server酱ᵀᵘʳᵇᵒ**，配置最简单  
                 🍎 iOS用户推荐使用 **Bark**，通知效果最佳  
-                🛠️ 追求高度自由或有自建服务器建议用 **ntfy**
+                🛠️ 追求高度自由/有自建服务器/需要在抢票成功时通过手机播放铃声时，建议用 **ntfy** 或 **Server酱³**
                 """
             )
             with gr.Row():
                 serverchan_ui = gr.Textbox(
                     value=lambda: (ConfigDB.get("serverchanKey") or ""),
-                    label="Server酱的SendKey｜输入完成后，回车键保存",
+                    label="Server酱ᵀᵘʳᵇᵒ的SendKey｜输入完成后，回车键保存",
                     interactive=True,
                     info="https://sct.ftqq.com/",
+                )
+
+                serverchan3_ui = gr.Textbox(
+                    value=lambda: (ConfigDB.get("serverchan3ApiUrl") or ""),
+                    label="Server酱³的API URL｜输入完成后，回车键保存",
+                    interactive=True,
+                    info="https://sc3.ft07.com/",
                 )
 
                 pushplus_ui = gr.Textbox(
@@ -231,63 +239,67 @@ def go_tab(demo: gr.Blocks):
                     info="iOS Bark App的“服务器”页面获取，例如: jmGYK*****(并非Device Token)",
                 )
 
-            with gr.Row():
+            with gr.Accordion(label="Ntfy配置", open=False):
                 ntfy_ui = gr.Textbox(
                     value=lambda: (ConfigDB.get("ntfyUrl") or ""),
                     label="Ntfy服务器URL｜输入完成后，回车键保存",
                     interactive=True,
                     info="例如: https://ntfy.sh/your-topic",
                 )
+                
+                with gr.Accordion(label="Ntfy认证配置[可选]", open=False):
+                    with gr.Row():
+                        ntfy_username_ui = gr.Textbox(
+                            value=lambda: (ConfigDB.get("ntfyUsername") or ""),
+                            label="Ntfy用户名",
+                            interactive=True,
+                            info="如果你的Ntfy服务器需要认证",
+                        )
 
-            with gr.Accordion(label="Ntfy认证配置[可选]", open=False):
-                with gr.Row():
-                    ntfy_username_ui = gr.Textbox(
-                        value=lambda: (ConfigDB.get("ntfyUsername") or ""),
-                        label="Ntfy用户名",
-                        interactive=True,
-                        info="如果你的Ntfy服务器需要认证",
+                        ntfy_password_ui = gr.Textbox(
+                            value=lambda: (ConfigDB.get("ntfyPassword") or ""),
+                            label="Ntfy密码",
+                            interactive=True,
+                            type="password",
+                        )
+
+                    def test_ntfy_connection():
+                        url = ConfigDB.get("ntfyUrl")
+                        username = ConfigDB.get("ntfyUsername")
+                        password = ConfigDB.get("ntfyPassword")
+
+                        if not url:
+                            return "错误: 请先设置Ntfy服务器URL"
+
+                        from util import NtfyUtil
+
+                        success, message = NtfyUtil.test_connection(
+                            url, username, password
+                        )
+
+                        if success:
+                            return f"成功: {message}"
+                        else:
+                            return f"错误: {message}"
+
+                    test_ntfy_button = gr.Button("测试Ntfy连接")
+                    test_ntfy_result = gr.Textbox(label="测试结果", interactive=False)
+                    test_ntfy_button.click(
+                        fn=test_ntfy_connection, inputs=[], outputs=test_ntfy_result
                     )
-
-                    ntfy_password_ui = gr.Textbox(
-                        value=lambda: (ConfigDB.get("ntfyPassword") or ""),
-                        label="Ntfy密码",
-                        interactive=True,
-                        type="password",
-                    )
-
-                def test_ntfy_connection():
-                    url = ConfigDB.get("ntfyUrl")
-                    username = ConfigDB.get("ntfyUsername")
-                    password = ConfigDB.get("ntfyPassword")
-
-                    if not url:
-                        return "错误: 请先设置Ntfy服务器URL"
-
-                    from util import NtfyUtil
-
-                    success, message = NtfyUtil.test_connection(
-                        url, username, password
-                    )
-
-                    if success:
-                        return f"成功: {message}"
-                    else:
-                        return f"错误: {message}"
-
-                test_ntfy_button = gr.Button("测试Ntfy连接")
-                test_ntfy_result = gr.Textbox(label="测试结果", interactive=False)
-                test_ntfy_button.click(
-                    fn=test_ntfy_connection, inputs=[], outputs=test_ntfy_result
-                )
 
             # 推送测试按钮区域
             with gr.Row():
-                test_bark_button = gr.Button("🍎 测试Bark推送")
+                test_all_push_button = gr.Button("🧪 测试所有推送")
                 test_push_result = gr.Textbox(label="推送测试结果", interactive=False)
 
             def inner_input_serverchan(x):
                 ConfigDB.insert("serverchanKey", x)
                 return gr.update(value=ConfigDB.get("serverchanKey"))
+
+            def inner_input_serverchan3(x):
+                ConfigDB.insert("serverchan3ApiUrl", x)
+                return gr.update(value=ConfigDB.get("serverchan3ApiUrl"))
 
             def inner_input_pushplus(x):
                 ConfigDB.insert("pushplusToken", x)
@@ -309,30 +321,22 @@ def go_tab(demo: gr.Blocks):
                 ConfigDB.insert("ntfyPassword", x)
                 return gr.update(value=ConfigDB.get("ntfyPassword"))
 
-            def test_bark_push():
-                token = ConfigDB.get("barkToken")
-                if not token:
-                    return "错误: 请先设置Bark Token"
+            def inner_input_audio_path(x):
+                ConfigDB.insert("audioPath", x)
+                return gr.update(value=ConfigDB.get("audioPath"))
 
+            def test_all_push():
+                """调用NotifierManager统一测试所有推送渠道"""
                 try:
-                    from util.BarkUtil import BarkNotifier
-
-                    notifier = BarkNotifier(
-                        token=token,
-                        title="抢票提醒",
-                        content="测试推送",
-                        interval_seconds=10,
-                        duration_minutes=10
-                    )
-
-                    notifier.send_message("🎫 抢票测试", "这是一条测试推送消息，如果你收到了这条消息，说明Bark配置成功！")
-                    return "成功: 测试推送已发送，请检查你的iOS设备"
-
+                    from util.Notifier import NotifierManager
+                    return NotifierManager.test_all_notifiers()
                 except Exception as e:
                     logger.exception(e)
-                    return f"错误: 推送失败 - {str(e)}"
+                    return f"错误: 测试过程中发生异常 - {str(e)}"
 
             serverchan_ui.submit(fn=inner_input_serverchan, inputs=serverchan_ui, outputs=serverchan_ui)
+
+            serverchan3_ui.submit(fn=inner_input_serverchan3, inputs=serverchan3_ui, outputs=serverchan3_ui)
 
             pushplus_ui.submit(fn=inner_input_pushplus, inputs=pushplus_ui, outputs=pushplus_ui)
 
@@ -344,7 +348,9 @@ def go_tab(demo: gr.Blocks):
 
             ntfy_password_ui.submit(fn=inner_input_ntfy_password, inputs=ntfy_password_ui, outputs=ntfy_password_ui)
 
-            test_bark_button.click(fn=test_bark_push, inputs=[], outputs=test_push_result)
+            test_all_push_button.click(fn=test_all_push, inputs=[], outputs=test_push_result)
+
+            audio_path_ui.upload(fn=inner_input_audio_path, inputs=audio_path_ui, outputs=audio_path_ui)
         with gr.Accordion(label="杂项配置", open=False):
             show_random_message_ui = gr.Checkbox(
                 label="关闭群友语录",
@@ -453,6 +459,7 @@ def go_tab(demo: gr.Blocks):
                         "audio_path": audio_path,
                         "pushplusToken": ConfigDB.get("pushplusToken"),
                         "serverchanKey": ConfigDB.get("serverchanKey"),
+                        "serverchan3ApiUrl": ConfigDB.get("serverchan3ApiUrl"),
                         "barkToken": ConfigDB.get("barkToken"),
                         "ntfy_url": ConfigDB.get("ntfyUrl"),
                         "ntfy_username": ConfigDB.get("ntfyUsername"),
@@ -479,6 +486,7 @@ def go_tab(demo: gr.Blocks):
                     audio_path=audio_path,
                     pushplusToken=ConfigDB.get("pushplusToken"),
                     serverchanKey=ConfigDB.get("serverchanKey"),
+                    serverchan3ApiUrl=ConfigDB.get("serverchan3ApiUrl"),
                     barkToken=ConfigDB.get("barkToken"),
                     ntfy_url=ConfigDB.get("ntfyUrl"),
                     ntfy_username=ConfigDB.get("ntfyUsername"),

--- a/tab/go.py
+++ b/tab/go.py
@@ -136,7 +136,7 @@ def go_tab(demo: gr.Blocks):
             https_proxy_ui = gr.Textbox(
                 label="填写抢票时候的代理服务器地址，使用逗号隔开|输入完成后，回车键保存",
                 info="例如： http://127.0.0.1:8080,https://127.0.0.1:8081,socks5://127.0.0.1:1080",
-                value=get_latest_proxy,
+                value=(ConfigDB.get("https_proxy") or ""),
             )
 
             def input_https_proxy(_https_proxy):
@@ -184,7 +184,8 @@ def go_tab(demo: gr.Blocks):
         with gr.Accordion(label="配置抢票成功后播放音乐[可选]", open=False):
             with gr.Row():
                 audio_path_ui = gr.Audio(
-                    label="上传提示声音[只支持格式wav]", type="filepath", loop=True
+                    label="上传提示声音[只支持格式wav]", type="filepath", loop=True,
+                    value=(ConfigDB.get("audioPath") or None)
                 )
         with gr.Accordion(label="配置抢票推送消息[可选]", open=False):
             gr.Markdown(
@@ -212,36 +213,36 @@ def go_tab(demo: gr.Blocks):
             )
             with gr.Row():
                 serverchan_ui = gr.Textbox(
-                    value=lambda: (ConfigDB.get("serverchanKey") or ""),
+                    value=(ConfigDB.get("serverchanKey") or ""),
                     label="Server酱ᵀᵘʳᵇᵒ的SendKey｜输入完成后，回车键保存",
                     interactive=True,
                     info="https://sct.ftqq.com/",
                 )
 
                 serverchan3_ui = gr.Textbox(
-                    value=lambda: (ConfigDB.get("serverchan3ApiUrl") or ""),
+                    value=(ConfigDB.get("serverchan3ApiUrl") or ""),
                     label="Server酱³的API URL｜输入完成后，回车键保存",
                     interactive=True,
                     info="https://sc3.ft07.com/",
                 )
 
                 pushplus_ui = gr.Textbox(
-                    value=lambda: (ConfigDB.get("pushplusToken") or ''),
+                    value=(ConfigDB.get("pushplusToken") or ''),
                     label="PushPlus的Token｜输入完成后，回车键保存",
                     interactive=True,
                     info="https://www.pushplus.plus/",
                 )
 
                 bark_ui = gr.Textbox(
-                    value=lambda: (ConfigDB.get("barkToken") or ""),
+                    value=(ConfigDB.get("barkToken") or ""),
                     label="Bark的Token｜输入完成后，回车键保存",
                     interactive=True,
-                    info="iOS Bark App的“服务器”页面获取，例如: jmGYK*****(并非Device Token)",
+                    info='iOS Bark App的"服务器"页面获取，例如: jmGYK*****(并非Device Token)',
                 )
 
             with gr.Accordion(label="Ntfy配置", open=False):
                 ntfy_ui = gr.Textbox(
-                    value=lambda: (ConfigDB.get("ntfyUrl") or ""),
+                    value=(ConfigDB.get("ntfyUrl") or ""),
                     label="Ntfy服务器URL｜输入完成后，回车键保存",
                     interactive=True,
                     info="例如: https://ntfy.sh/your-topic",
@@ -250,14 +251,14 @@ def go_tab(demo: gr.Blocks):
                 with gr.Accordion(label="Ntfy认证配置[可选]", open=False):
                     with gr.Row():
                         ntfy_username_ui = gr.Textbox(
-                            value=lambda: (ConfigDB.get("ntfyUsername") or ""),
+                            value=(ConfigDB.get("ntfyUsername") or ""),
                             label="Ntfy用户名",
                             interactive=True,
                             info="如果你的Ntfy服务器需要认证",
                         )
 
                         ntfy_password_ui = gr.Textbox(
-                            value=lambda: (ConfigDB.get("ntfyPassword") or ""),
+                            value=(ConfigDB.get("ntfyPassword") or ""),
                             label="Ntfy密码",
                             interactive=True,
                             type="password",

--- a/util/AudioUtil.py
+++ b/util/AudioUtil.py
@@ -1,0 +1,34 @@
+from util.Notifier import NotifierBase
+import loguru
+
+
+class AudioNotifier(NotifierBase):
+    """音频通知器，播放本地音频文件"""
+    def __init__(
+        self,
+        audio_path,
+        title="",
+        content="",
+        interval_seconds=10,
+        duration_minutes=10
+    ):
+        super().__init__(title, content, interval_seconds, duration_minutes)
+        self.audio_path = audio_path
+
+    def send_message(self, title, message):
+        """播放音频文件作为通知"""
+        try:
+            from playsound3 import playsound
+            playsound(self.audio_path)
+            loguru.logger.info(f"音频通知已播放: {self.audio_path}")
+        except Exception as e:
+            loguru.logger.error(f"音频播放失败: {e}")
+            raise
+
+    def run(self):
+        """重写run方法，音频只播放一次，不需要循环"""
+        try:
+            self.send_message(self.title, self.content)
+            loguru.logger.info("音频通知播放完成")
+        except Exception as e:
+            loguru.logger.error(f"音频通知播放失败: {e}") 

--- a/util/NtfyUtil.py
+++ b/util/NtfyUtil.py
@@ -98,6 +98,9 @@ def send_message(server_url, content, title=None, username=None, password=None):
         # 方法1: 不指定Content-Type，让服务器自动判断
         headers = {}
 
+        # 设置最高优先级 (5)
+        headers["Priority"] = "5"
+
         # 如果标题存在，处理中文标题
         if title:
             # 如果标题不是ASCII字符，则使用一个英文标题

--- a/util/NtfyUtil.py
+++ b/util/NtfyUtil.py
@@ -240,3 +240,61 @@ def test_connection(server_url, username=None, password=None):
         return False, f"连接失败: {str(e)}"
     except Exception as e:
         return False, f"测试过程中发生错误: {str(e)}"
+
+
+# 添加NtfyNotifier类，和其他推送渠道一样的静态类
+from util.Notifier import NotifierBase
+
+
+class NtfyNotifier(NotifierBase):
+    """Ntfy通知器，继承自NotifierBase，实现统一接口"""
+    def __init__(
+        self,
+        url,
+        username=None,
+        password=None,
+        title="",
+        content="",
+        interval_seconds=15,
+        duration_minutes=5
+    ):
+        super().__init__(title, content, interval_seconds, duration_minutes)
+        self.url = url
+        self.username = username
+        self.password = password
+    
+    def send_message(self, title, message):
+        """使用send_message函数发送单次通知"""
+        send_message(self.url, message, title, self.username, self.password)
+
+    def run(self):
+        """重写run方法，实现Ntfy特有的重复通知逻辑"""
+        start_time = time.time()
+        end_time = start_time + (self.duration_minutes * 60)
+        count = 0
+
+        while time.time() < end_time and not self.stop_event.is_set():
+            try:
+                count += 1
+                # 构建消息内容，包含计数和剩余时间
+                remaining_minutes = int((end_time - time.time()) / 60)
+                remaining_seconds = int((end_time - time.time()) % 60)
+                message = f"{self.content} [#{count}, 剩余 {remaining_minutes}分{remaining_seconds}秒]"
+
+                # 使用send_message方法发送
+                self.send_message(
+                    f"{self.title} ({count}/{self.duration_minutes * 60 // self.interval_seconds})" if self.title else "Bili Ticket Notification",
+                    message
+                )
+
+                # 等待指定的间隔时间或直到收到停止信号
+                for _ in range(int(self.interval_seconds * 10)):  # 分成更小的步骤检查停止事件
+                    if self.stop_event.is_set():
+                        break
+                    time.sleep(0.1)
+
+            except Exception as e:
+                loguru.logger.error(f"Ntfy重复通知发送失败: {e}")
+                time.sleep(self.interval_seconds)  # 发生错误时仍然等待
+
+        loguru.logger.info(f"Ntfy重复通知完成，共发送了{count}条通知")

--- a/util/ServerChanUtil.py
+++ b/util/ServerChanUtil.py
@@ -3,7 +3,7 @@ import requests
 
 from util.Notifier import NotifierBase
 
-class ServerChanNotifier(NotifierBase):
+class ServerChanTurboNotifier(NotifierBase):
     def __init__(
         self,
         token,
@@ -21,3 +21,21 @@ class ServerChanNotifier(NotifierBase):
 
         data = {"desp": message, "title": title}
         requests.post(url, headers=headers, data=json.dumps(data))
+
+
+class ServerChan3Notifier(NotifierBase):
+    def __init__(
+        self,
+        api_url,
+        title,
+        content,
+        interval_seconds=10,
+        duration_minutes=10
+    ):
+        super().__init__(title, content, interval_seconds, duration_minutes)
+        self.api_url = api_url
+
+    def send_message(self, title, message):
+        headers = {"Content-Type": "application/json"}
+        data = {"title": title, "desp": message}
+        requests.post(self.api_url, headers=headers, data=json.dumps(data))


### PR DESCRIPTION
## 概述

实现/解决/优化的内容: 
- 支持ServerChan3
- #590 补全；将音频播放和ntfy纳入推送框架中
- 添加推送测试按钮

### 事务

- [ ] 已与维护者在issues或其他平台沟通此PR大致内容

## 以下内容可在起草PR后、合并PR前逐步完成

### 功能

- [X] 已编写完善的配置文件字段说明（若有新增）
- [X] 已编写面向用户的新功能说明（若有必要）
- [x] 已测试新功能或更改

### 兼容性

- [ ] 已处理版本兼容性
- [ ] 已处理插件兼容问题

### 风险

可能导致或已知的问题: 
- 配置非wav音频会报错，但是release版本似乎不会(?)
- 未测试命令行传入参数等各种原有功能
- 无 ios 设备无法测试 bark 推送