### PR TITLE
关于 #696 的解决方法

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ __pycache__/
 *$py.class
 geetest/dataset
 geetest/debug
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@
 
 ## 💻 快速安装
 
-[下载链接](https://github.com/mikumifa/biliTickerBuy/releases) 
+[下载链接](https://github.com/mikumifa/biliTickerBuy/releases)
+
+如果您是MacOS M系列芯片/Linux用户，请前往[指南](https://github.com/mikumifa/biliTickerBuy/wiki/linux%E5%92%8CMacOS%E7%9A%84%E8%BF%90%E8%A1%8C%E6%96%B9%E5%BC%8F-(%E4%BD%BF%E7%94%A8Docker))
 
 ## 👀 使用说明书
 前往飞书： https://n1x87b5cqay.feishu.cn/wiki/Eg4xwt3Dbiah02k1WqOcVk2YnMd
@@ -73,4 +75,3 @@
 ## ⭐️ Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=mikumifa/biliTickerBuy&type=Date)](https://www.star-history.com/#mikumifa/biliTickerBuy&Date)
-

--- a/main.py
+++ b/main.py
@@ -1,21 +1,23 @@
 import argparse
 import os
 
-# 清理系统代理变量以防止 httpx / requests 连接失败
-cleared_vars = []
-for proxy_var in ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"]:
-    if proxy_var in os.environ:
-        del os.environ[proxy_var]
-        cleared_vars.append(proxy_var)
-
-if cleared_vars:
-    print(f"[WARN] 已清除以下代理环境变量，避免连接失败: {', '.join(cleared_vars)}")
-
 def get_env_default(key: str, default, cast_func):
     return cast_func(os.environ.get(f"BTB_{key}", default))
 
+def clear_env_proxy()
+    # 清理系统代理变量以防止 httpx / requests 连接失败
+    cleared_vars = []
+    for proxy_var in ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"]:
+        if proxy_var in os.environ:
+            del os.environ[proxy_var]
+            cleared_vars.append(proxy_var)
+
+    if cleared_vars:
+        print(f"[WARN] 已清除以下代理环境变量，避免连接失败: {', '.join(cleared_vars)}")
+
 
 def main():
+    clear_env_proxy()
     parser = argparse.ArgumentParser(description="Ticket Purchase Tool or Gradio UI")
     subparsers = parser.add_subparsers(dest="command")
     buy_parser = subparsers.add_parser("buy", help="Start the ticket buying ui")

--- a/util/CookieManager.py
+++ b/util/CookieManager.py
@@ -1,6 +1,3 @@
-import os
-import subprocess
-import sys
 from loguru import logger
 from playwright.sync_api import sync_playwright
 from util.KVDatabase import KVDatabase
@@ -11,24 +8,10 @@ class CookieManager:
         if cookies is not None:
             self.db.insert("cookie", cookies)
 
-    # 自动下载浏览器
-    def _ensure_playwright_installed(self):
-        try:
-            # 切换国内源
-            os.environ["PLAYWRIGHT_DOWNLOAD_HOST"] = "https://npmmirror.com/mirrors/playwright/"
-            # 下载浏览器二进制文件
-            subprocess.run([sys.executable, "-m", "playwright", "install", "chromium"], check=True)
-        except subprocess.CalledProcessError as e:
-            logger.error(f"Playwright 浏览器安装失败: {e}")
-            raise RuntimeError("Playwright 浏览器缺失，且自动安装失败")
-
     @logger.catch
     def _login_and_save_cookies(
         self, login_url="https://show.bilibili.com/platform/home.html"
     ):
-        # 确保浏览器已安装
-        self._ensure_playwright_installed()
-
         logger.info("启动浏览器中，第一次启动会比较慢，请使用在浏览器登录")
         with sync_playwright() as p:
             try:


### PR DESCRIPTION
## 概述

* 修复了打包后无法下载浏览器的问题（回滚处理）
* 添加了标识，提示 Linux/MacOS M 系列芯片用户如何启动本项目
* 重写了 [wiki 文档](https://github.com/mikumifa/biliTickerBuy/wiki/linux%E5%92%8CMacOS%E7%9A%84%E8%BF%90%E8%A1%8C%E6%96%B9%E5%BC%8F-(%E4%BD%BF%E7%94%A8Docker))，确保新人能够看懂

我折腾了半天，最终发现：想要在 M 系列芯片的 macOS 上使用 PyInstaller 对内嵌有浏览器的应用进行签名几乎是不可能的。即使强行复制签名文件，在 macOS 上运行时仍会提示“软件已损坏”。要想实现兼容最新 macOS 的打包方案，可能唯一的方式是更换 `playwright`，使用如 `pywebview` 这类调用系统浏览器的库。但这显然不可接受。

因此，我认为目前最合适的解决方案是不对项目结构进行修改，而是直接告知 Linux/macOS 用户通过 Docker 启动项目。基于这个思路，我重写了 [wiki 文档](https://github.com/mikumifa/biliTickerBuy/wiki/linux%E5%92%8CMacOS%E7%9A%84%E8%BF%90%E8%A1%8C%E6%96%B9%E5%BC%8F-(%E4%BD%BF%E7%94%A8Docker))，以确保新手用户能够顺利上手。

另外，我强烈建议补充一篇开发者指南或构建指南。虽然项目的构建流程稍微尝试一下便可理解，但这对新手或想要研究本项目的人并不友好。我们可以在文档中指导新手使用[低版本 Python 直接运行](https://github.com/mikumifa/biliTickerBuy/issues/696#issuecomment-3021725139)，或者使用 `uv`构建。这样的一篇文档可以极大的降低想要从源代码构建的上手难度。

---

### 事务

* [ ] 已与维护者在 Issues 或其他平台沟通过此 PR 的大致内容

### 功能

* [x] 已完善配置文件字段说明（如有新增）
* [x] 已编写用户文档说明（如有必要）
* [x] 已完成功能测试或验证（即使功能几乎未改）

### 兼容性

* 本次为直接回滚操作
* [x] 已确认版本兼容性
* [x] 已排查可能影响插件的变更点

### 风险

* 无