### PR TITLE
修正等待开始时间时的Busy wait问题

### DIFF
--- a/task/buy.py
+++ b/task/buy.py
@@ -94,6 +94,9 @@ def buy_stream(
         start_time = time.perf_counter()
         end_time = start_time + time_difference
         while time.perf_counter() < end_time:
+            #因为时间精度问题，结果不做缓存处理
+            yield f"未到开始时间，休眠{(end_time-time.perf_counter())/2}秒"
+            time.sleep((end_time-time.perf_counter())/2)
             pass
 
     while isRunning:


### PR DESCRIPTION
## 概述

实现/解决/优化的内容:  修正等待开始时间时的Busy wait问题，避免单核被沾满（

### 事务

- [ ] 已与维护者在issues或其他平台沟通此PR大致内容

## 以下内容可在起草PR后、合并PR前逐步完成

### 功能

- [x] 已编写完善的配置文件字段说明（若有新增）
- [x] 已编写面向用户的新功能说明（若有必要）
- [x] 已测试新功能或更改

### 兼容性

- [x] 已处理版本兼容性
- [x] 已处理插件兼容问题

### 风险

可能导致或已知的问题:  可能会导致开始时间不精确，但是理论上应该是准确的，在Linux机器上做过一次测试，日志输出看时间是准的，不清楚Windows会不会因为底层实现不同有差异（涉及到高精度时间分辨率问题，具体可见 https://zhuanlan.zhihu.com/p/3432845958 ）：
```
[2025-07-05:04:23:42.229]|INFO|task.buy:299|0) 等待开始时间
[2025-07-05:04:23:42.230]|INFO|task.buy:299|时间偏差已被设置为: 0.00032s
[2025-07-05:04:23:42.232]|INFO|task.buy:299|休眠5588.884127641359秒
[2025-07-05:05:56:51.116]|INFO|task.buy:299|休眠2794.4419669878553秒
[2025-07-05:06:43:25.558]|INFO|task.buy:299|休眠1397.2208894953365秒
[2025-07-05:07:06:42.779]|INFO|task.buy:299|休眠698.6103295263601秒
[2025-07-05:07:18:21.390]|INFO|task.buy:299|休眠349.30503775086254秒
[2025-07-05:07:24:10.695]|INFO|task.buy:299|休眠174.65239756385563秒
[2025-07-05:07:27:05.348]|INFO|task.buy:299|休眠87.3260803243611秒
[2025-07-05:07:28:32.674]|INFO|task.buy:299|休眠43.66289851084002秒
[2025-07-05:07:29:16.337]|INFO|task.buy:299|休眠21.831310172361555秒
[2025-07-05:07:29:38.169]|INFO|task.buy:299|休眠10.915552470862167秒
[2025-07-05:07:29:49.085]|INFO|task.buy:299|休眠5.45767553334008秒
[2025-07-05:07:29:54.542]|INFO|task.buy:299|休眠2.7287318578455597秒
[2025-07-05:07:29:57.271]|INFO|task.buy:299|休眠1.3642649693356361秒
[2025-07-05:07:29:58.636]|INFO|task.buy:299|休眠0.6820275913341902秒
[2025-07-05:07:29:59.318]|INFO|task.buy:299|休眠0.34090437783743255秒
[2025-07-05:07:29:59.659]|INFO|task.buy:299|休眠0.17032283285516314秒
[2025-07-05:07:29:59.830]|INFO|task.buy:299|休眠0.08502064784988761秒
[2025-07-05:07:29:59.915]|INFO|task.buy:299|休眠0.042355580342700705秒
[2025-07-05:07:29:59.958]|INFO|task.buy:299|休眠0.021070631337352097秒
[2025-07-05:07:29:59.979]|INFO|task.buy:299|休眠0.010277454333845526秒
[2025-07-05:07:29:59.990]|INFO|task.buy:299|休眠0.005042564356699586秒
[2025-07-05:07:29:59.995]|INFO|task.buy:299|休眠0.0024260973441414535秒
[2025-07-05:07:29:59.998]|INFO|task.buy:299|休眠0.001136597857112065秒
[2025-07-05:07:29:59.999]|INFO|task.buy:299|休眠0.0004854358558077365秒
[2025-07-05:07:29:59.999]|INFO|task.buy:299|休眠0.00018009435734711587秒
[2025-07-05:07:30:00.000]|INFO|task.buy:299|休眠3.637085319496691e-05秒
[2025-07-05:07:30:00.000]|INFO|task.buy:299|1）订单准备
```
