### PR TITLE
Fix heartbeat task detail reporting

### DIFF
--- a/app_cmd/buy.py
+++ b/app_cmd/buy.py
@@ -1,6 +1,6 @@
 from argparse import Namespace
 
-from util import GlobalStatus
+from util import GlobalStatusInstance
 
 
 def buy_cmd(args: Namespace):
@@ -62,7 +62,7 @@ def buy_cmd(args: Namespace):
         )
         client = gradio_client.Client(args.endpoint_url)
         assert demo.local_url
-        GlobalStatus.nowTask = filename_only
+        GlobalStatusInstance.nowTask = filename_only
         start_heartbeat_thread(
             client,
             self_url=demo.local_url,


### PR DESCRIPTION
## Summary
- update the buy command to store the current task on the shared GlobalStatus instance
- remove the unused GlobalStatus import

## Testing
- python - <<'PY'
import time
from task.endpoint import start_heartbeat_thread
from util import GlobalStatusInstance

class FakeClient:
    def __init__(self):
        self.calls = []
    def predict(self, self_url, detail, api_name=None):
        self.calls.append((self_url, detail, api_name))
        print(f"heartbeat -> self_url={self_url}, detail={detail}, api_name={api_name}")

client = FakeClient()
GlobalStatusInstance.nowTask = "sample_task.json"
start_heartbeat_thread(client, "http://self", "http://master")

time.sleep(2.5)

print("captured calls:", client.calls)
PY

------
https://chatgpt.com/codex/tasks/task_e_68f71827d2c0833197ca55102f71fecb