### PR TITLE
Reduce busy waiting before scheduled buy

### DIFF
--- a/task/buy.py
+++ b/task/buy.py
@@ -85,8 +85,12 @@ def buy_stream(
             )
         start_time = time.perf_counter()
         end_time = start_time + time_difference
-        while time.perf_counter() < end_time:
-            pass
+        while True:
+            now = time.perf_counter()
+            if now >= end_time:
+                break
+            remaining = end_time - now
+            time.sleep(min(0.5, remaining))
 
     while isRunning:
         try:


### PR DESCRIPTION
## Summary
- replace the busy-wait loop before the scheduled start with a sleep-based wait to avoid unnecessary CPU usage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f71826ebe8833183114cf6cca0c45a