### PR TITLE
Add config file support and CLI packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,40 +24,32 @@
 </p>
 <a href="https://trendshift.io/repositories/11145" target="_blank"><img src="https://trendshift.io/api/badge/repositories/11145" alt="mikumifa%2FbiliTickerBuy | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
-这是一个开源免费，简单易用的B站会员购辅助工具
+这是一个开源免费，简单易用的 B 站会员购辅助工具
+
 </div>
-
-
-
-
-
 
 ## 💻 快速安装
 
-从github上[下载](https://github.com/mikumifa/biliTickerBuy/releases)
+方式一: 从 github 上[下载](https://github.com/mikumifa/biliTickerBuy/releases)
 
-如果没有您使用系统的已构建版本，请前往[指南](https://github.com/mikumifa/biliTickerBuy/wiki/Docker%E8%BF%90%E8%A1%8C%E6%96%B9%E6%B3%95)
+方式二: Docker 安装[指南](https://github.com/mikumifa/biliTickerBuy/wiki/Docker%E8%BF%90%E8%A1%8C%E6%96%B9%E6%B3%95)
 
-### 使用 pip 安装命令行工具
-
-仓库支持通过 `pip install .` 安装，安装后可以直接使用 `bilitickerbuy` 命令运行。示例：
+方式三: 仓库支持通过 `pip install .` 安装，安装后可以直接使用 `bilitickerbuy` 命令运行。示例：
 
 ```bash
 pip install .
-bilitickerbuy buy ./your_config.json 300 0 100 --terminal_ui 终端 --filename your_config.json
+bilitickerbuy buy ./your_config.json 300 0 100 --filename your_config.json
 ```
 
-其中 `buy` 子命令的第一个参数可以是 JSON 字符串，也可以是 JSON 配置文件的路径（推荐直接传入文件路径）。
-
 ## 👀 使用说明书
+
 前往飞书： https://n1x87b5cqay.feishu.cn/wiki/Eg4xwt3Dbiah02k1WqOcVk2YnMd
 
 ## ❗ 项目问题
 
-程序使用问题： [点此链接前往discussions](https://github.com/mikumifa/biliTickerBuy/discussions)
+程序使用问题： [点此链接前往 discussions](https://github.com/mikumifa/biliTickerBuy/discussions)
 
-反馈程序BUG或者提新功能建议： [点此链接向项目提出反馈BUG](https://github.com/mikumifa/biliTickerBuy/issues/new/choose)
-
+反馈程序 BUG 或者提新功能建议： [点此链接向项目提出反馈 BUG](https://github.com/mikumifa/biliTickerBuy/issues/new/choose)
 
 ## 📩 免责声明
 
@@ -66,9 +58,10 @@ bilitickerbuy buy ./your_config.json 300 0 100 --terminal_ui 终端 --filename y
 若您 fork 或使用本项目，请务必遵守相关法律法规与目标平台规则。
 
 ## 💡 关于访问频率与并发控制
+
 本项目在设计时严格遵循「非侵入式」原则，避免对目标服务器（如 Bilibili）造成任何干扰。
 
-所有网络请求的时间间隔均由用户自行配置，默认值模拟正常用户的手动操作速度。程序默认单线程运行，无并发任务。遇到请求失败时，程序会进行有限次数的重试，并在重试之间加入适当的延时，避免形成高频打点。项目完全依赖平台公开接口及网页结构，不含风控规避、API劫持等破坏性手段。
+所有网络请求的时间间隔均由用户自行配置，默认值模拟正常用户的手动操作速度。程序默认单线程运行，无并发任务。遇到请求失败时，程序会进行有限次数的重试，并在重试之间加入适当的延时，避免形成高频打点。项目完全依赖平台公开接口及网页结构，不含风控规避、API 劫持等破坏性手段。
 
 ## 🛡️ 平台尊重声明
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@
 
 如果没有您使用系统的已构建版本，请前往[指南](https://github.com/mikumifa/biliTickerBuy/wiki/Docker%E8%BF%90%E8%A1%8C%E6%96%B9%E6%B3%95)
 
+### 使用 pip 安装命令行工具
+
+仓库支持通过 `pip install .` 安装，安装后可以直接使用 `bilitickerbuy` 命令运行。示例：
+
+```bash
+pip install .
+bilitickerbuy buy ./your_config.json 300 0 100 --terminal_ui 终端 --filename your_config.json
+```
+
+其中 `buy` 子命令的第一个参数可以是 JSON 字符串，也可以是 JSON 配置文件的路径（推荐直接传入文件路径）。
+
 ## 👀 使用说明书
 前往飞书： https://n1x87b5cqay.feishu.cn/wiki/Eg4xwt3Dbiah02k1WqOcVk2YnMd
 

--- a/app_cmd/__init__.py
+++ b/app_cmd/__init__.py
@@ -1,0 +1,3 @@
+"""
+Command-line entrypoints for biliTickerBuy.
+"""

--- a/app_cmd/buy.py
+++ b/app_cmd/buy.py
@@ -1,4 +1,5 @@
 from argparse import Namespace
+import os
 
 from util import GlobalStatusInstance
 
@@ -8,9 +9,19 @@ def buy_cmd(args: Namespace):
     import uuid
 
     from util import LOG_DIR
-    import os
     from task.buy import buy
     from loguru import logger
+
+    def load_tickets_info(tickets_info_str: str) -> str:
+        config_path = os.path.expanduser(tickets_info_str)
+        if os.path.isfile(config_path):
+            logger.info(f"使用配置文件：{config_path}")
+            try:
+                with open(config_path, "r", encoding="utf-8") as config_file:
+                    return config_file.read()
+            except OSError as exc:
+                raise SystemExit(f"读取配置文件失败: {exc}") from exc
+        return tickets_info_str
 
     filename_only = os.path.basename(args.filename)
     logger.info(f"模式：{args.terminal_ui}")
@@ -72,8 +83,9 @@ def buy_cmd(args: Namespace):
         log_file = loguru_config(
             LOG_DIR, f"{uuid.uuid1()}.log", enable_console=True, file_colorize=True
         )
+    tickets_info_str = load_tickets_info(args.tickets_info_str)
     buy(
-        args.tickets_info_str,
+        tickets_info_str,
         args.time_start,
         args.interval,
         args.mode,

--- a/main.py
+++ b/main.py
@@ -11,7 +11,9 @@ def main():
     subparsers = parser.add_subparsers(dest="command")
     buy_parser = subparsers.add_parser("buy", help="Start the ticket buying ui")
     buy_parser.add_argument(
-        "tickets_info_str", type=str, help="Ticket information in string format."
+        "tickets_info_str",
+        type=str,
+        help="Ticket information in JSON format or a path to a JSON config file.",
     )
     buy_parser.add_argument("interval", type=int, help="Interval time.")
     buy_parser.add_argument("mode", type=int, help="Mode of operation.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=65", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "bilitickerbuy"
 version = "0.1.0"
@@ -21,6 +25,16 @@ dependencies = [
     "tinydb~=4.8.0",
     "Pillow~=10.3.0",
 ]
+[project.scripts]
+bilitickerbuy = "main:main"
+
+[tool.setuptools]
+py-modules = ["main"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["*"]
+
 [tool.mypy]
 disable_error_code = ["import-untyped"]
 check_untyped_defs = true

--- a/tab/__init__.py
+++ b/tab/__init__.py
@@ -1,0 +1,3 @@
+"""
+UI tabs and helpers for biliTickerBuy.
+"""

--- a/task/__init__.py
+++ b/task/__init__.py
@@ -1,0 +1,3 @@
+"""
+Task handlers for biliTickerBuy.
+"""


### PR DESCRIPTION
## Summary
- allow the buy command to accept JSON config files directly and surface clearer help text
- document pip installation and add a console script entry point for command line use
- configure packaging metadata to ship the CLI and modules

## Testing
- python -m compileall main.py app_cmd task util tab

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948ffaa9ca0833193d4ecbb5905b404)