### PR TITLE
Add PyPI publish workflow for tagged releases

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,31 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tools
+        run: pip install build twine
+
+      - name: Build distribution
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ dependencies = [
     "tinydb~=4.8.0",
     "Pillow~=10.3.0",
 ]
+[project.urls]
+Homepage = "https://github.com/mikumifa/biliTickerBuy"
+Source = "https://github.com/mikumifa/biliTickerBuy"
+
 [project.scripts]
 bilitickerbuy = "main:main"
 btb = "main:main"


### PR DESCRIPTION
## 概述

实现/解决/优化的内容:
- 添加按 v*.*.* 标签触发的 PyPI 发布工作流，自动构建并上传分发包。
- 在 pyproject.toml 中补充 project.urls，指向源码仓库。

### 事务

- [ ] 已与维护者在issues或其他平台沟通此PR大致内容

## 以下内容可在起草PR后、合并PR前逐步完成

### 功能

- [ ] 已编写完善的配置文件字段说明（若有新增）
- [ ] 已编写面向用户的新功能说明（若有必要）
- [ ] 已测试新功能或更改

### 兼容性

- [ ] 已处理版本兼容性
- [ ] 已处理插件兼容问题

### 风险

可能导致或已知的问题: 
- 新的发布流程依赖 PYPI_API_TOKEN secret 正确配置。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694911c940248331b77349b11b0c9759)