### PR TITLE
Docker运行修复&优化

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update --allow-unauthenticated && \
 
 ENV BTB_SERVER_NAME="0.0.0.0"
 ENV GRADIO_SERVER_PORT=7860
+ENV GRADIO_NUM_PORTS=100
 ENV BTB_DOCKER=1
 ENV DISPLAY=:99
 RUN mkdir -p /etc/supervisor/conf.d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,12 @@ services:
     image: bilitickerbuy
     container_name: bilitickerbuy_container
     ports:
-      - "7860-7879:7860-7879"
+      - "7860-7879:7860-7879" # 默认暴露20个端口，范围可按需修改
     environment:
+      - GRADIO_SERVER_PORT=7860
+      - GRADIO_NUM_PORTS=100  # 不小于暴露的端口数量
       # 可在此添加环境变量使得高级设置持久化，避免每次启动容器后都需要在前端重新配置
-      # 设置后网页前端仍会显示为空值，但在开始抢票时会使用这些环境变量的值  
-      # For example:
+      # （设置后网页前端仍会显示为空值，但在开始抢票时会使用这些环境变量的值）
       # - BTB_HTTPS_PROXYS=http://127.0.1:8080,socks5://127.0.1:1080
       # - BTB_PUSHPLUSTOKEN=your_pushplus_token
       # - BTB_BARKTOKEN=your_bark_token

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  bilitickerbuy:
+    build: .
+    image: bilitickerbuy
+    container_name: bilitickerbuy_container
+    ports:
+      - "7860-7879:7860-7879"
+    environment:
+      # 可在此添加环境变量使得高级设置持久化，避免每次启动容器后都需要在前端重新配置
+      # 设置后网页前端仍会显示为空值，但在开始抢票时会使用这些环境变量的值  
+      # For example:
+      # - BTB_HTTPS_PROXYS=http://127.0.1:8080,socks5://127.0.1:1080
+      # - BTB_PUSHPLUSTOKEN=your_pushplus_token
+      # - BTB_BARKTOKEN=your_bark_token
+      # - BTB_NTFY_URL=https://ntfy.sh/topic
+    restart: unless-stopped


### PR DESCRIPTION
## 概述

实现/解决/优化的内容: 

- **解决：** 修复 #841，通过Dockerfile 中添加`GRADIO_NUM_PORTS=100`环境变量解决无法另开端口新建Gradio示例
- **优化：** 参考了[说明书](https://my.feishu.cn/wiki/ADCvwXgdxi1fLJk56d1c5DJ6nGg) _docker运行_ 部分添加了 `docker-compose.yml`，可按需添加环境变量

### 事务

- [ ] 已与维护者在 issues 或其他平台沟通此 PR 大致内容

## 以下内容可在起草 PR 后、合并 PR 前逐步完成

### 功能

- [ ] 已编写完善的配置文件字段说明（若有新增）
- [ ] 已编写面向用户的新功能说明（若有必要）
- [X] 已测试新功能或更改

### 兼容性

- [ ] 已处理版本兼容性
- [ ] 已处理插件兼容问题

### 风险

可能导致或已知的问题:

1. [说明书](https://my.feishu.cn/wiki/ADCvwXgdxi1fLJk56d1c5DJ6nGg) _docker运行_ 部分应同步修改为范围（以20个为例，如有特殊需要则可更改）：
```
docker run -d -p 7860-7879:7860-7879 --name bilitickerbuy_container bilitickerbuy
```
PR中 `docker-compose.yml`中已反映。
