### PR TITLE
Add verified update center and release checksum manifest; bump version to 2.14.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,10 +79,10 @@ jobs:
           asset_name: ${{ secrets.ReleaseZipName }}_${{ matrix.config.os.filename }}_${{ github.ref_name }}.zip
           tag: ${{ github.ref_name }}
           overwrite: true
-          prerelease: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
 
       - name: Mark release as prerelease
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref_name, '-')
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -131,23 +131,66 @@ jobs:
             done
           done
 
-      - name: Generate version info
+      - name: Generate checksums and version info
         shell: bash
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_ZIP_NAME: ${{ secrets.ReleaseZipName }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
         run: |
-          cat > release-files/version-info.json << EOF
-          {
-            "version": "${{ steps.version.outputs.version }}",
-            "release_date": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
-            "github_release": "https://github.com/${{ github.repository }}/releases/tag/${{ steps.version.outputs.version }}",
-            "files": {
-              "linux_amd64": "${{ secrets.ReleaseZipName }}_linux_amd64_${{ steps.version.outputs.version }}.zip",
-              "linux_arm64": "${{ secrets.ReleaseZipName }}_linux_arm64_${{ steps.version.outputs.version }}.zip",
-              "macos_arm64": "${{ secrets.ReleaseZipName }}_macos_arm64_${{ steps.version.outputs.version }}.zip",
-              "macos_intel": "${{ secrets.ReleaseZipName }}_macos_intel_${{ steps.version.outputs.version }}.zip",
-              "windows_amd64": "${{ secrets.ReleaseZipName }}_windows_amd64_${{ steps.version.outputs.version }}.zip"
-            }
+          for arch in linux_amd64 linux_arm64 macos_arm64 macos_intel windows_amd64; do
+            test -f "release-files/${RELEASE_ZIP_NAME}_${arch}_${RELEASE_VERSION}.zip"
+          done
+
+          cd release-files
+          sha256sum ./*.zip > SHA256SUMS.txt
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          version = os.environ["RELEASE_VERSION"]
+          prefix = os.environ["RELEASE_ZIP_NAME"]
+          repository = os.environ["RELEASE_REPOSITORY"]
+          platforms = (
+              "linux_amd64",
+              "linux_arm64",
+              "macos_arm64",
+              "macos_intel",
+              "windows_amd64",
+          )
+          files = {}
+          for platform_name in platforms:
+              path = Path(f"{prefix}_{platform_name}_{version}.zip")
+              files[platform_name] = {
+                  "name": path.name,
+                  "size": path.stat().st_size,
+                  "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+              }
+
+          manifest = {
+              "version": version,
+              "release_date": datetime.now(timezone.utc).isoformat(),
+              "github_release": f"https://github.com/{repository}/releases/tag/{version}",
+              "files": files,
           }
-          EOF
+          Path("version-info.json").write_text(
+              json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Upload checksum manifest to GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ steps.version.outputs.version }}" \
+            release-files/version-info.json \
+            release-files/SHA256SUMS.txt \
+            --clobber
 
       - name: Upload to WebDAV
         shell: bash

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ btb
 btb buy ./your_config.json
 ```
 
+## 🔄 软件更新
+
+主界面的“软件更新”页会在打开时检查 GitHub Release，也可以手动点击检查：
+
+- **稳定版**：跳过 GitHub prerelease，只接收正式版本。
+- **测试版**：同时接收正式版本和 prerelease。
+- 程序不会静默覆盖或强制重启。只有用户主动点击后才会下载对应平台的更新包，并使用 Release 中的 SHA-256 清单完成校验；校验通过后仍由用户确认何时替换旧版本。
+
 ## 👀 使用说明书
 
 前往飞书： https://n1x87b5cqay.feishu.cn/wiki/Eg4xwt3Dbiah02k1WqOcVk2YnMd

--- a/app_cmd/ticker.py
+++ b/app_cmd/ticker.py
@@ -6,6 +6,8 @@ from argparse import Namespace
 import gradio as gr
 import loguru
 
+from app_version import get_app_version
+
 
 def exit_app_ui():
     loguru.logger.info("程序退出")
@@ -18,6 +20,7 @@ def ticker_cmd(args: Namespace):
     from tab.log import log_tab
     from tab.problems import problems_tab
     from tab.settings import setting_tab
+    from tab.update import update_tab
     from util import LOG_DIR
     from util.LogConfig import loguru_config
 
@@ -31,9 +34,11 @@ def ticker_cmd(args: Namespace):
                 + base64.b64encode(icon_file.read()).decode("ascii")
             )
 
+    app_version = get_app_version()
+
     header = f"""
     <section class="btb-hero">
-        <div class="btb-hero__eyebrow">BILI TICKER BUY</div>
+        <div class="btb-hero__eyebrow">BILI TICKER BUY · v{app_version}</div>
         <div class="btb-hero__grid">
             <div>
                 <h1>B 站会员购抢票工作台</h1>
@@ -124,6 +129,8 @@ def ticker_cmd(args: Namespace):
                     go_tab(demo)
                 with gr.Tab("项目说明"):
                     problems_tab()
+                with gr.Tab("软件更新"):
+                    update_tab(demo)
                 with gr.Tab("日志查看"):
                     log_tab()
 

--- a/app_update.py
+++ b/app_update.py
@@ -1,0 +1,240 @@
+"""GitHub release discovery and verified update-package downloads."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+import requests
+from packaging.version import InvalidVersion, Version
+
+GITHUB_REPOSITORY = "mikumifa/biliTickerBuy"
+GITHUB_RELEASES_API = f"https://api.github.com/repos/{GITHUB_REPOSITORY}/releases"
+UPDATE_CHANNEL_STABLE = "稳定版"
+UPDATE_CHANNEL_PRERELEASE = "测试版"
+UPDATE_CHANNELS = (UPDATE_CHANNEL_STABLE, UPDATE_CHANNEL_PRERELEASE)
+REQUEST_TIMEOUT = (5, 20)
+
+
+class UpdateError(RuntimeError):
+    """Raised when an update cannot be discovered or downloaded safely."""
+
+
+@dataclass(frozen=True)
+class ReleaseInfo:
+    version: str
+    tag_name: str
+    name: str
+    html_url: str
+    body: str
+    prerelease: bool
+    published_at: str
+    assets: tuple[dict[str, Any], ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["assets"] = list(self.assets)
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ReleaseInfo":
+        return cls(
+            version=str(data["version"]),
+            tag_name=str(data["tag_name"]),
+            name=str(data.get("name") or data["tag_name"]),
+            html_url=str(data["html_url"]),
+            body=str(data.get("body") or ""),
+            prerelease=bool(data.get("prerelease")),
+            published_at=str(data.get("published_at") or ""),
+            assets=tuple(data.get("assets") or ()),
+        )
+
+
+def normalize_version(value: str) -> Version:
+    candidate = value.strip()
+    if candidate.lower().startswith("v"):
+        candidate = candidate[1:]
+    try:
+        return Version(candidate)
+    except InvalidVersion as exc:
+        raise UpdateError(f"无法识别版本号：{value}") from exc
+
+
+def select_update(
+    releases: Iterable[dict[str, Any]], current_version: str, channel: str
+) -> ReleaseInfo | None:
+    if channel not in UPDATE_CHANNELS:
+        raise UpdateError(f"未知更新频道：{channel}")
+
+    current = normalize_version(current_version)
+    candidates: list[tuple[Version, dict[str, Any]]] = []
+    for release in releases:
+        if release.get("draft"):
+            continue
+        try:
+            release_version = normalize_version(str(release.get("tag_name", "")))
+        except UpdateError:
+            continue
+        is_prerelease = bool(release.get("prerelease")) or release_version.is_prerelease
+        if channel == UPDATE_CHANNEL_STABLE and is_prerelease:
+            continue
+        if release_version > current:
+            candidates.append((release_version, release))
+
+    if not candidates:
+        return None
+
+    version, release = max(candidates, key=lambda item: item[0])
+    assets = tuple(
+        {
+            "name": str(asset.get("name") or ""),
+            "browser_download_url": str(asset.get("browser_download_url") or ""),
+            "size": int(asset.get("size") or 0),
+        }
+        for asset in release.get("assets") or ()
+        if asset.get("name") and asset.get("browser_download_url")
+    )
+    return ReleaseInfo(
+        version=str(version),
+        tag_name=str(release.get("tag_name") or version),
+        name=str(release.get("name") or release.get("tag_name") or version),
+        html_url=str(release.get("html_url") or ""),
+        body=str(release.get("body") or ""),
+        prerelease=bool(release.get("prerelease")) or version.is_prerelease,
+        published_at=str(release.get("published_at") or ""),
+        assets=assets,
+    )
+
+
+def fetch_update(
+    current_version: str,
+    channel: str,
+    *,
+    session: requests.Session | None = None,
+) -> ReleaseInfo | None:
+    client = session or requests.Session()
+    response = client.get(
+        GITHUB_RELEASES_API,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": f"biliTickerBuy/{current_version}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        timeout=REQUEST_TIMEOUT,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    if not isinstance(payload, list):
+        raise UpdateError("GitHub 返回了无法识别的版本列表。")
+    return select_update(payload, current_version, channel)
+
+
+def platform_asset_key() -> str:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if system == "windows" and machine in {"amd64", "x86_64"}:
+        return "windows_amd64"
+    if system == "linux" and machine in {"amd64", "x86_64"}:
+        return "linux_amd64"
+    if system == "linux" and machine in {"arm64", "aarch64"}:
+        return "linux_arm64"
+    if system == "darwin" and machine in {"arm64", "aarch64"}:
+        return "macos_arm64"
+    if system == "darwin" and machine in {"amd64", "x86_64"}:
+        return "macos_intel"
+    raise UpdateError(f"当前平台暂不支持自动下载：{system}/{machine}")
+
+
+def _find_asset(release: ReleaseInfo, name: str) -> dict[str, Any]:
+    for asset in release.assets:
+        if asset.get("name") == name:
+            return asset
+    raise UpdateError(f"GitHub Release 中缺少文件：{name}")
+
+
+def _download_json(
+    url: str, *, session: requests.Session, user_agent: str
+) -> dict[str, Any]:
+    response = session.get(
+        url,
+        headers={"Accept": "application/octet-stream", "User-Agent": user_agent},
+        timeout=REQUEST_TIMEOUT,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    if not isinstance(payload, dict):
+        raise UpdateError("版本校验清单格式错误。")
+    return payload
+
+
+def download_update_package(
+    release: ReleaseInfo,
+    destination: str | os.PathLike[str],
+    *,
+    session: requests.Session | None = None,
+) -> Path:
+    client = session or requests.Session()
+    user_agent = f"biliTickerBuy/{release.version}"
+    manifest_asset = _find_asset(release, "version-info.json")
+    manifest = _download_json(
+        str(manifest_asset["browser_download_url"]),
+        session=client,
+        user_agent=user_agent,
+    )
+
+    manifest_version = str(manifest.get("version") or "")
+    if normalize_version(manifest_version) != normalize_version(release.tag_name):
+        raise UpdateError("版本校验清单与 GitHub Release 版本不一致。")
+
+    key = platform_asset_key()
+    file_info = (manifest.get("files") or {}).get(key)
+    if not isinstance(file_info, dict):
+        raise UpdateError(f"版本校验清单中缺少当前平台：{key}")
+
+    filename = str(file_info.get("name") or "")
+    expected_sha256 = str(file_info.get("sha256") or "").lower()
+    if not filename or not re.fullmatch(r"[0-9a-f]{64}", expected_sha256):
+        raise UpdateError("版本校验清单缺少有效的文件名或 SHA-256。")
+
+    package_asset = _find_asset(release, filename)
+    expected_size = int(file_info.get("size") or 0)
+    if expected_size and int(package_asset.get("size") or 0) not in {0, expected_size}:
+        raise UpdateError("版本校验清单中的文件大小与 GitHub Release 不一致。")
+
+    destination_path = Path(destination).expanduser().resolve()
+    destination_path.mkdir(parents=True, exist_ok=True)
+    output_path = destination_path / Path(filename).name
+    partial_path = output_path.with_suffix(output_path.suffix + ".part")
+
+    digest = hashlib.sha256()
+    try:
+        with client.get(
+            str(package_asset["browser_download_url"]),
+            headers={"Accept": "application/octet-stream", "User-Agent": user_agent},
+            timeout=REQUEST_TIMEOUT,
+            stream=True,
+        ) as response:
+            response.raise_for_status()
+            with partial_path.open("wb") as output:
+                for chunk in response.iter_content(chunk_size=1024 * 1024):
+                    if chunk:
+                        output.write(chunk)
+                        digest.update(chunk)
+        if expected_size and partial_path.stat().st_size != expected_size:
+            raise UpdateError("更新包大小校验失败，文件可能不完整，已取消更新。")
+        actual_sha256 = digest.hexdigest()
+        if actual_sha256 != expected_sha256:
+            raise UpdateError(
+                "更新包 SHA-256 校验失败，文件可能不完整，已取消更新。"
+            )
+        partial_path.replace(output_path)
+    except Exception:
+        partial_path.unlink(missing_ok=True)
+        raise
+
+    return output_path

--- a/app_version.py
+++ b/app_version.py
@@ -1,0 +1,13 @@
+"""Application version helpers."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+__version__ = "2.14.16"
+
+
+def get_app_version() -> str:
+    """Return the installed package version, falling back to the source constant."""
+    try:
+        return version("bilitickerbuy")
+    except PackageNotFoundError:
+        return __version__

--- a/assets/style.css
+++ b/assets/style.css
@@ -1195,3 +1195,37 @@ body .gradio-container .dropdown .single-select {
   padding-right: 48px !important;
 }
 
+
+.btb-update-status {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 16px 18px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+}
+
+.btb-update-status strong {
+  color: var(--text-primary);
+  font-size: 16px;
+}
+
+.btb-update-status.is-current {
+  color: var(--semantic-success-text);
+  background: var(--semantic-success-bg);
+  box-shadow: inset 0 0 0 1px var(--semantic-success-ring);
+}
+
+.btb-update-status.is-available {
+  color: var(--semantic-brand-text);
+  background: var(--semantic-brand-bg);
+  box-shadow: inset 0 0 0 1px var(--semantic-brand-ring);
+}
+
+.btb-update-status.is-error {
+  color: var(--semantic-error-text);
+  background: var(--semantic-error-bg);
+  box-shadow: inset 0 0 0 1px var(--semantic-error-ring);
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bilitickerbuy"
-version = "2.14.15"
+version = "2.14.16"
 description = "开源的 B 站会员购辅助工具，提供命令行和 Gradio 界面"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -28,6 +28,7 @@ dependencies = [
     "httpx[socks]>=0.28.1",
     "loguru~=0.7.2",
     "ntplib~=0.4.0",
+    "packaging>=23.2",
     "numpy~=1.26.4",
     "playsound3~=3.2.2",
     "pydantic~=2.8.2",
@@ -52,7 +53,7 @@ Issues = "https://github.com/mikumifa/biliTickerBuy/issues"
 btb = "main:main"
 
 [tool.setuptools]
-py-modules = ["main"]
+py-modules = ["main", "app_version", "app_update"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ loguru~=0.7.2
 retry~=0.9.2
 tinydb~=4.8.0
 ntplib~=0.4.0
+packaging>=23.2
 gradio_calendar~=0.0.6
 playsound3~=3.2.2
 pydantic~=2.8.2

--- a/tab/update.py
+++ b/tab/update.py
@@ -1,0 +1,119 @@
+"""Update center UI."""
+
+from __future__ import annotations
+
+import html
+from pathlib import Path
+
+import gradio as gr
+import requests
+
+from app_update import (
+    UPDATE_CHANNELS,
+    UPDATE_CHANNEL_STABLE,
+    ReleaseInfo,
+    UpdateError,
+    download_update_package,
+    fetch_update,
+)
+from app_version import get_app_version
+from util import ConfigDB, EXE_PATH
+
+UPDATE_CHANNEL_KEY = "update_channel"
+
+
+def _saved_channel() -> str:
+    channel = ConfigDB.get(UPDATE_CHANNEL_KEY)
+    return channel if channel in UPDATE_CHANNELS else UPDATE_CHANNEL_STABLE
+
+
+def _format_update(release: ReleaseInfo | None, channel: str) -> str:
+    current = html.escape(get_app_version())
+    if release is None:
+        return (
+            '<div class="btb-update-status is-current">'
+            "<strong>当前已是所选频道的最新版本</strong>"
+            f"<span>当前版本 v{current} · {html.escape(channel)}</span>"
+            "</div>"
+        )
+
+    release_type = "测试版" if release.prerelease else "稳定版"
+    return (
+        '<div class="btb-update-status is-available">'
+        "<strong>发现可用更新</strong>"
+        f"<span>v{current} → v{html.escape(release.version)}（{release_type}）</span>"
+        f'<a href="{html.escape(release.html_url)}" target="_blank">查看 GitHub 发布说明</a>'
+        "</div>"
+    )
+
+
+def check_updates(channel: str):
+    ConfigDB.insert(UPDATE_CHANNEL_KEY, channel)
+    try:
+        release = fetch_update(get_app_version(), channel)
+    except (UpdateError, requests.RequestException, ValueError) as exc:
+        message = (
+            '<div class="btb-update-status is-error">'
+            "<strong>暂时无法检查更新</strong>"
+            f"<span>{html.escape(str(exc))}</span>"
+            "</div>"
+        )
+        return message, None, gr.update(visible=False)
+
+    return (
+        _format_update(release, channel),
+        release.to_dict() if release else None,
+        gr.update(visible=release is not None),
+    )
+
+
+def download_update(release_data: dict | None):
+    if not release_data:
+        return gr.update(value=None, visible=False), "请先检查更新。"
+
+    try:
+        release = ReleaseInfo.from_dict(release_data)
+        download_dir = Path(EXE_PATH) / "updates" / release.tag_name
+        package_path = download_update_package(release, download_dir)
+    except (UpdateError, requests.RequestException, OSError, ValueError) as exc:
+        return gr.update(value=None, visible=False), f"下载失败：{exc}"
+
+    return (
+        gr.update(value=str(package_path), visible=True),
+        "更新包下载完成且 SHA-256 校验通过。程序不会自动退出或覆盖文件，"
+        "请结束正在执行的任务后，再解压并替换旧版本。",
+    )
+
+
+def update_tab(demo: gr.Blocks):
+    channel = gr.Radio(
+        choices=list(UPDATE_CHANNELS),
+        value=_saved_channel(),
+        label="更新频道",
+        info="稳定版会跳过 GitHub prerelease；测试版会同时接收预发布版本。",
+    )
+    status = gr.HTML(
+        '<div class="btb-update-status"><strong>正在检查更新…</strong></div>'
+    )
+    release_state = gr.State(None)
+
+    with gr.Row():
+        check_button = gr.Button("立即检查", variant="secondary")
+        download_button = gr.Button(
+            "下载并校验更新包", variant="primary", visible=False
+        )
+
+    notice = gr.Markdown(
+        "更新不会静默安装。只有点击下载后才会获取更新包，且校验通过后仍需由你确认并手动替换。"
+    )
+    package_file = gr.File(label="已验证的更新包", visible=False, interactive=False)
+
+    check_outputs = [status, release_state, download_button]
+    demo.load(check_updates, inputs=channel, outputs=check_outputs)
+    check_button.click(check_updates, inputs=channel, outputs=check_outputs)
+    channel.change(check_updates, inputs=channel, outputs=check_outputs)
+    download_button.click(
+        download_update,
+        inputs=release_state,
+        outputs=[package_file, notice],
+    )

--- a/tests/test_app_update.py
+++ b/tests/test_app_update.py
@@ -1,0 +1,144 @@
+import hashlib
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app_update import (
+    UPDATE_CHANNEL_PRERELEASE,
+    UPDATE_CHANNEL_STABLE,
+    ReleaseInfo,
+    UpdateError,
+    download_update_package,
+    select_update,
+)
+
+
+def _release(tag, *, prerelease=False, draft=False, assets=None):
+    return {
+        "tag_name": tag,
+        "name": tag,
+        "html_url": f"https://example.test/{tag}",
+        "body": "notes",
+        "prerelease": prerelease,
+        "draft": draft,
+        "published_at": "2026-06-08T00:00:00Z",
+        "assets": assets or [],
+    }
+
+
+def test_stable_channel_skips_prereleases():
+    releases = [_release("v2.15.0-beta.1", prerelease=True), _release("v2.14.17")]
+    update = select_update(releases, "2.14.16", UPDATE_CHANNEL_STABLE)
+    assert update is not None
+    assert update.version == "2.14.17"
+
+
+def test_prerelease_channel_selects_newest_version():
+    releases = [_release("v2.14.17"), _release("v2.15.0-beta.1", prerelease=True)]
+    update = select_update(releases, "2.14.16", UPDATE_CHANNEL_PRERELEASE)
+    assert update is not None
+    assert update.version == "2.15.0b1"
+
+
+class FakeResponse:
+    def __init__(self, *, payload=None, content=b""):
+        self._payload = payload
+        self._content = content
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        return None
+
+    def iter_content(self, chunk_size):
+        yield self._content
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+
+class FakeSession:
+    def __init__(self, manifest, package):
+        self.manifest = manifest
+        self.package = package
+
+    def get(self, url, **kwargs):
+        if url.endswith("version-info.json"):
+            return FakeResponse(payload=self.manifest)
+        return FakeResponse(content=self.package)
+
+
+def test_download_verifies_sha256(tmp_path: Path):
+    package = b"verified update"
+    filename = "btb_linux_amd64_v2.14.17.zip"
+    manifest = {
+        "version": "v2.14.17",
+        "files": {
+            "linux_amd64": {
+                "name": filename,
+                "sha256": hashlib.sha256(package).hexdigest(),
+                "size": len(package),
+            }
+        }
+    }
+    release = ReleaseInfo(
+        version="2.14.17",
+        tag_name="v2.14.17",
+        name="v2.14.17",
+        html_url="https://example.test/release",
+        body="",
+        prerelease=False,
+        published_at="",
+        assets=(
+            {"name": "version-info.json", "browser_download_url": "https://example.test/version-info.json", "size": 1},
+            {"name": filename, "browser_download_url": "https://example.test/package.zip", "size": len(package)},
+        ),
+    )
+
+    with patch("app_update.platform_asset_key", return_value="linux_amd64"):
+        output = download_update_package(
+            release, tmp_path, session=FakeSession(manifest, package)
+        )
+
+    assert output.read_bytes() == package
+
+
+def test_download_rejects_bad_sha256(tmp_path: Path):
+    filename = "btb_linux_amd64_v2.14.17.zip"
+    manifest = {
+        "version": "v2.14.17",
+        "files": {
+            "linux_amd64": {
+                "name": filename,
+                "sha256": "0" * 64,
+                "size": len(b"tampered"),
+            }
+        },
+    }
+    release = ReleaseInfo(
+        version="2.14.17",
+        tag_name="v2.14.17",
+        name="v2.14.17",
+        html_url="https://example.test/release",
+        body="",
+        prerelease=False,
+        published_at="",
+        assets=(
+            {"name": "version-info.json", "browser_download_url": "https://example.test/version-info.json", "size": 1},
+            {"name": filename, "browser_download_url": "https://example.test/package.zip", "size": len(b"tampered")},
+        ),
+    )
+
+    with patch("app_update.platform_asset_key", return_value="linux_amd64"):
+        with pytest.raises(UpdateError, match="SHA-256"):
+            download_update_package(
+                release, tmp_path, session=FakeSession(manifest, b"tampered")
+            )
+
+    assert not list(tmp_path.iterdir())

--- a/uv.lock
+++ b/uv.lock
@@ -47,7 +47,7 @@ wheels = [
 
 [[package]]
 name = "bilitickerbuy"
-version = "2.14.15"
+version = "2.14.16"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -60,6 +60,7 @@ dependencies = [
     { name = "loguru" },
     { name = "ntplib" },
     { name = "numpy" },
+    { name = "packaging" },
     { name = "pillow" },
     { name = "playsound3" },
     { name = "pydantic" },
@@ -83,6 +84,7 @@ requires-dist = [
     { name = "loguru", specifier = "~=0.7.2" },
     { name = "ntplib", specifier = "~=0.4.0" },
     { name = "numpy", specifier = "~=1.26.4" },
+    { name = "packaging", specifier = ">=23.2" },
     { name = "pillow", specifier = "~=10.3.0" },
     { name = "playsound3", specifier = "~=3.2.2" },
     { name = "pydantic", specifier = "~=2.8.2" },


### PR DESCRIPTION
### Motivation

- Introduce a safe, user-visible update flow that discovers GitHub Releases, downloads platform-specific update packages and verifies SHA-256 before exposing them to users. 
- Embed the running application version into the UI and publish release artifacts with a machine-readable checksum/manifest so clients can verify downloads.
- Ensure CI release workflow sets prerelease correctly and produces/upload checksum manifests for WebDAV and GitHub Release assets.

### Description

- Added a new update subsystem with `app_update.py` implementing release discovery (`fetch_update`/`select_update`) and verified package download (`download_update_package`) with SHA-256 and size checks, plus platform mapping and errors. 
- Added `app_version.py` to expose package version (fallback to source constant) and updated UI to show `v{app_version}` in the header by importing `get_app_version` in `app_cmd/ticker.py`. 
- Added a Gradio update tab UI in `tab/update.py` to let users pick stable/test channels, check for updates, and download verified packages (saved under `EXE_PATH/updates`). 
- Extended CI release workflow (`.github/workflows/release.yml`) to mark prereleases based on tag names, produce `SHA256SUMS.txt` and `version-info.json` manifest, upload those to the GitHub Release, and include them when uploading to WebDAV. 
- Added UI styles for update status (`assets/style.css`), README notes about update channels, and included packaging dependency and module exports (`pyproject.toml`, `requirements.txt`, `uv.lock`, and `tool.setuptools.py-modules`). 
- Bumped project version to `2.14.16` and added unit tests for the update logic in `tests/test_app_update.py`.

### Testing

- Added unit tests in `tests/test_app_update.py` to validate release selection logic and verified-download behavior, and ran them with `pytest`; the tests passed. 
- Exercised the download verification logic via mocked `requests.Session` in tests to confirm SHA-256 and size validation and proper failure on tampering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26eb66c400833188059b7e6c1758fd)