### PR TITLE
feat: add misc setting to hide main header

### DIFF
--- a/app_cmd/ticker.py
+++ b/app_cmd/ticker.py
@@ -28,7 +28,7 @@ def ticker_cmd(args: Namespace):
     from tab.settings import login_tab, setting_tab
     from tab.update import update_tab
     from util.log_web import attach_log_routes
-    from util import LOG_DIR
+    from util import ConfigDB, LOG_DIR
     from util.LogConfig import loguru_config
 
     loguru_config(LOG_DIR, "app.log", enable_console=True, file_colorize=False)
@@ -43,6 +43,9 @@ def ticker_cmd(args: Namespace):
             ).decode("ascii")
 
     app_version = get_app_version()
+    hide_header = ConfigDB.get("hideHeader")
+    if hide_header is None:
+        hide_header = False
 
     header = f"""
     <section class="btb-hero">
@@ -167,7 +170,7 @@ def ticker_cmd(args: Namespace):
         """,
     ) as demo:
         with gr.Column(elem_classes="btb-app-shell"):
-            gr.HTML(header)
+            header_ui = gr.HTML(header, visible=not hide_header)
             with gr.Tabs(elem_id="btb-main-tabs", elem_classes="btb-top-tabs"):
                 with gr.Tab("账号登录", id="login", elem_id="btb-tab-login"):
                     login_tab()
@@ -176,7 +179,7 @@ def ticker_cmd(args: Namespace):
                 with gr.Tab("操作抢票", id="go", elem_id="btb-tab-go"):
                     go_task_refresh_token, go_task_panel = go_start_tab()
                 with gr.Tab("高级设置", id="advanced", elem_id="btb-tab-advanced"):
-                    go_settings_tab()
+                    go_settings_tab(header_ui)
                 with gr.Tab("项目说明", id="guide", elem_id="btb-tab-guide"):
                     problems_tab()
                 with gr.Tab("软件更新", id="update", elem_id="btb-tab-update"):

--- a/tab/go.py
+++ b/tab/go.py
@@ -423,7 +423,7 @@ def go_start_tab():
     return task_refresh_token, task_panel
 
 
-def go_settings_tab():
+def go_settings_tab(header_ui):
     def _split_proxy_lines(proxy_text: str | None) -> list[str]:
         if not proxy_text:
             return []
@@ -548,6 +548,13 @@ def go_settings_tab():
         ConfigDB.insert("hideRandomMessage", value)
         return gr.update(value=ConfigDB.get("hideRandomMessage"))
 
+    def update_hide_header(value):
+        ConfigDB.insert("hideHeader", value)
+        return (
+            gr.update(value=ConfigDB.get("hideHeader")),
+            gr.update(visible=not value),
+        )
+
     def update_auto_fill_time(value):
         ConfigDB.insert("autoFillTime", value)
         return gr.update(value=ConfigDB.get("autoFillTime"))
@@ -559,6 +566,9 @@ def go_settings_tab():
     hide_random_message_default = ConfigDB.get("hideRandomMessage")
     if hide_random_message_default is None:
         hide_random_message_default = True
+    hide_header_default = ConfigDB.get("hideHeader")
+    if hide_header_default is None:
+        hide_header_default = False
     auto_fill_time_default = ConfigDB.get("autoFillTime")
     if auto_fill_time_default is None:
         auto_fill_time_default = True
@@ -747,6 +757,11 @@ def go_settings_tab():
                         value=hide_random_message_default,
                         info="关闭后，抢票失败时将不再显示有趣的语录",
                     )
+                    hide_header_ui = gr.Checkbox(
+                        label="隐藏顶部大 Header",
+                        value=hide_header_default,
+                        info="默认显示。开启后将隐藏顶部包含项目地址和图标的区域。",
+                    )
                     notify_proxy_exhausted_ui = gr.Checkbox(
                         label="无可用代理时发送提醒",
                         value=notify_proxy_exhausted_default,
@@ -796,6 +811,11 @@ def go_settings_tab():
         fn=update_hide_random_message,
         inputs=show_random_message_ui,
         outputs=show_random_message_ui,
+    )
+    hide_header_ui.change(
+        fn=update_hide_header,
+        inputs=hide_header_ui,
+        outputs=[hide_header_ui, header_ui],
     )
     auto_fill_time_ui.change(
         fn=update_auto_fill_time,


### PR DESCRIPTION
### Motivation

- Provide a user-facing option to hide the large top header (address + icon area) from the UI under the Misc settings, while keeping it visible by default.

### Description

- Read and persist the new `hideHeader` preference via `ConfigDB` and treat `None` as `False` so the header is visible by default (`app_cmd/ticker.py`).
- Expose the header element as a Gradio component `header_ui = gr.HTML(...)` and control its visibility with the stored preference (`app_cmd/ticker.py`).
- Extend `go_settings_tab` to accept `header_ui`, add a `hide_header` checkbox labeled "隐藏顶部大 Header", and wire its change to `update_hide_header` which updates `ConfigDB` and toggles `header_ui` visibility (`tab/go.py`).
- Ensure toggling the checkbox updates the UI immediately by returning `gr.update(visible=...)` alongside saving the preference (`tab/go.py`).

### Testing

- Ran `python -m compileall -q app_cmd/ticker.py tab/go.py` successfully.
- Ran `PYTHONPATH=. pytest -q` and all tests passed (`2 passed`).
- Ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dc78f43808331a69a55661297bd6c)