### PR TITLE
[codex] Fix task removal permission handling

### DIFF
--- a/tab/log.py
+++ b/tab/log.py
@@ -186,11 +186,61 @@ def is_task_running(pid: int | None) -> bool:
                 return False
         except OSError:
             return False
+    if _is_posix_zombie_process(pid):
+        return False
     try:
         os.kill(pid, 0)
-    except (OSError, ProcessLookupError):
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
         return False
     return True
+
+
+def _is_posix_zombie_process(pid: int) -> bool:
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "stat=", "-p", str(pid)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=1,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+    stat = result.stdout.strip().splitlines()
+    if not stat:
+        return False
+    return stat[0].strip().startswith("Z")
+
+
+def _send_posix_signal(pid: int, sig: signal.Signals) -> str:
+    try:
+        pgid = os.getpgid(pid)
+    except ProcessLookupError:
+        return "not_found"
+    except PermissionError:
+        pgid = pid
+    except OSError:
+        pgid = pid
+
+    saw_permission_error = False
+    for sender in (lambda: os.killpg(pgid, sig), lambda: os.kill(pid, sig)):
+        try:
+            sender()
+            return "sent"
+        except ProcessLookupError:
+            return "not_found"
+        except PermissionError:
+            saw_permission_error = True
+        except OSError:
+            continue
+
+    return "permission_denied" if saw_permission_error else "failed"
 
 
 def terminate_task(pid: int) -> str:
@@ -226,10 +276,13 @@ def terminate_task(pid: int) -> str:
 
         return "已发送停止任务请求"
 
-    try:
-        os.killpg(pid, signal.SIGTERM)
-    except ProcessLookupError:
+    terminate_result = _send_posix_signal(pid, signal.SIGTERM)
+    if terminate_result == "not_found":
         return "任务进程已结束。"
+    if terminate_result == "permission_denied":
+        return "停止任务进程失败：没有权限。"
+    if terminate_result == "failed":
+        return "停止任务进程失败。"
 
     deadline = time.time() + 3
     while time.time() < deadline:
@@ -237,10 +290,13 @@ def terminate_task(pid: int) -> str:
             return "已停止任务进程。"
         time.sleep(0.1)
 
-    try:
-        os.killpg(pid, signal.SIGKILL)
-    except ProcessLookupError:
+    kill_result = _send_posix_signal(pid, signal.SIGKILL)
+    if kill_result == "not_found":
         return "已停止任务进程。"
+    if kill_result == "permission_denied":
+        return "强制停止任务进程失败：没有权限。"
+    if kill_result == "failed":
+        return "强制停止任务进程失败。"
 
     return "已强制停止任务进程。"
 

--- a/tests/test_task_log_controls.py
+++ b/tests/test_task_log_controls.py
@@ -1,0 +1,57 @@
+import signal
+
+import tab.log as task_log
+
+
+def test_is_task_running_treats_posix_zombie_as_stopped(monkeypatch):
+    monkeypatch.setattr(task_log.os.path, "exists", lambda _path: False)
+
+    class PsResult:
+        stdout = "Z\n"
+
+    monkeypatch.setattr(task_log.subprocess, "run", lambda *args, **kwargs: PsResult())
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("zombie process should be handled before os.kill")
+
+    monkeypatch.setattr(task_log.os, "kill", fail_if_called)
+
+    assert task_log.is_task_running(12345) is False
+
+
+def test_terminate_task_falls_back_to_process_signal_when_group_denied(monkeypatch):
+    running_states = iter([True, False])
+    signals_sent = []
+
+    monkeypatch.setattr(task_log, "is_task_running", lambda _pid: next(running_states))
+    monkeypatch.setattr(task_log.os, "getpgid", lambda pid: pid)
+    monkeypatch.setattr(
+        task_log.os,
+        "killpg",
+        lambda _pgid, _sig: (_ for _ in ()).throw(PermissionError()),
+    )
+    monkeypatch.setattr(
+        task_log.os,
+        "kill",
+        lambda pid, sig: signals_sent.append((pid, sig)),
+    )
+
+    assert task_log.terminate_task(12345) == "已停止任务进程。"
+    assert signals_sent == [(12345, signal.SIGTERM)]
+
+
+def test_terminate_task_returns_message_when_signal_permission_denied(monkeypatch):
+    monkeypatch.setattr(task_log, "is_task_running", lambda _pid: True)
+    monkeypatch.setattr(task_log.os, "getpgid", lambda pid: pid)
+    monkeypatch.setattr(
+        task_log.os,
+        "killpg",
+        lambda _pgid, _sig: (_ for _ in ()).throw(PermissionError()),
+    )
+    monkeypatch.setattr(
+        task_log.os,
+        "kill",
+        lambda _pid, _sig: (_ for _ in ()).throw(PermissionError()),
+    )
+
+    assert task_log.terminate_task(12345) == "停止任务进程失败：没有权限。"


### PR DESCRIPTION
## Summary
- Handle POSIX task termination permission errors without crashing the Gradio callback.
- Fall back from process-group signaling to direct process signaling when needed.
- Treat `ps`-reported zombie processes as stopped so task cards can leave the running state.

## Root Cause
The task card remove/stop actions called `os.killpg(...)` directly on POSIX systems. If the process group signal raised `PermissionError`, the exception propagated through Gradio and the task card action appeared to do nothing. macOS can also report finished child tasks as zombie processes, while `os.kill(pid, 0)` still succeeds for them.

## Validation
- `.venv/bin/python -m pytest`