### PR TITLE
修正来自mall.bilibili.com的cookie泄露问题

### DIFF
--- a/task/buy.py
+++ b/task/buy.py
@@ -351,6 +351,8 @@ def buy_stream(config: BuyConfig):
         if bool(payload["hotProject"]) and not is_hot_project:
             is_hot_project = True
             tickets_info["is_hot_project"] = True
+        _request._invalidate_h2_client()
+        
         _request.prewarm_h2_connection(f"{base_url}/")
         return messages
 


### PR DESCRIPTION
在预热请求前对链接https://mall.bilibili.com/mall-search-items/items_detail/info 的预查会返回一组意义不明的cookie：
a=b; Max-Age=86400; Path=/; Domain=.bilibili.com
a1=b1; Max-Age=86400; Path=/; Domain=.bilibili.com
a2=b2; Max-Age=86400; Path=/; Domain=.bilibili.com
c3=c3; Max-Age=86400; Path=/; Domain=.bilibili.com
由于后面复用了同一个h2_client，会导致该四个cookie泄露到对show.bilibili.com的请求中，怀疑为b站对btb的应对策略。