### PR TITLE
Add configurable Gradio root path

### DIFF
--- a/app_cmd/cli_args.py
+++ b/app_cmd/cli_args.py
@@ -21,6 +21,14 @@ def _env_optional_int(*keys: str) -> int | None:
     return None
 
 
+def _env_optional_str(*keys: str) -> str | None:
+    for key in keys:
+        raw = os.environ.get(key)
+        if raw not in (None, ""):
+            return raw
+    return None
+
+
 @dataclass(slots=True)
 class TickerCliArgs:
     """Web UI launch options."""
@@ -33,6 +41,9 @@ class TickerCliArgs:
 
     port: int | None = _env_optional_int("BTB_PORT", "GRADIO_SERVER_PORT")
     """Port for the UI server. Defaults to Gradio or environment configuration."""
+
+    root_path: str | None = _env_optional_str("BTB_ROOT_PATH", "GRADIO_ROOT_PATH")
+    """External URL or root path used when the UI is accessed through a remote IP, domain, or reverse proxy."""
 
 
 BuyCliArgs = BuyConfig

--- a/app_cmd/ticker.py
+++ b/app_cmd/ticker.py
@@ -244,6 +244,7 @@ def ticker_cmd(args: TickerCliArgs):
         inbrowser=not is_docker,
         server_name=args.server_name,
         server_port=args.port,
+        root_path=args.root_path,
         allowed_paths=allowed_paths,
         prevent_thread_lock=True,
         footer_links=[],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
     environment:
       - GRADIO_SERVER_PORT=7860
       - GRADIO_NUM_PORTS=100  # 不小于暴露的端口数量
+      # 如果从远端 IP、域名或反向代理访问，请设置为浏览器访问时使用的外部地址
+      # 例如：http://your-server-ip:7860 或 https://your-domain.example
+      - BTB_ROOT_PATH=${BTB_ROOT_PATH:-}
       # 可在此添加环境变量使得高级设置持久化，避免每次启动容器后都需要在前端重新配置
       # （设置后网页前端仍会显示为空值，但在开始抢票时会使用这些环境变量的值）
       # - BTB_HTTPS_PROXYS=http://127.0.1:8080,socks5://127.0.1:1080


### PR DESCRIPTION
## 概述

实现/解决/优化的内容:
- 支持配置BTB_ROOT_PATH，因为想挂到其他机器上远程访问，避免gradio总是写到127.0.0.1

### 事务

- [ ] 已与维护者在 issues 或其他平台沟通此 PR 大致内容

## 以下内容可在起草 PR 后、合并 PR 前逐步完成

### 功能

- [ ] 已编写完善的配置文件字段说明（若有新增）
- [ ] 已编写面向用户的新功能说明（若有必要）
- [x] 已测试新功能或更改

### 兼容性

- [ ] 已处理版本兼容性
- [ ] 已处理插件兼容问题

### 风险

可能导致或已知的问题:
无