### PR TITLE
Fix stale buyer selections after account changes

### DIFF
--- a/tab/settings.py
+++ b/tab/settings.py
@@ -212,6 +212,13 @@ def _empty_ticket_info_updates():
     ]
 
 
+def _has_invalid_index(indices: list[int], values: list[Any]) -> bool:
+    return any(
+        not isinstance(item, int) or item < 0 or item >= len(values)
+        for item in indices
+    )
+
+
 def _format_ticket_option(screen_name: str, ticket: dict, ticket_price: int) -> str:
     ticket_desc = ticket.get("desc", "")
     sale_start = str(ticket.get("sale_start", "未知"))
@@ -372,9 +379,9 @@ def on_submit_ticket_id(num):
         ]
 
         yield [
-            gr.update(choices=ticket_str_list),
-            gr.update(choices=buyer_str_list),
-            gr.update(choices=addr_str_list),
+            gr.update(choices=ticket_str_list, value=None),
+            gr.update(choices=buyer_str_list, value=[]),
+            gr.update(choices=addr_str_list, value=None),
             gr.update(visible=True),
             gr.update(
                 value=_render_ticket_info_html(
@@ -429,7 +436,7 @@ def on_submit_all(
     try:
         if ticket_id is None:
             raise gr.Error("请输入正确的活动链接。")
-        if len(people_indices) == 0:
+        if not isinstance(people_indices, list) or len(people_indices) == 0:
             raise gr.Error("请至少选择一位实名购票人。")
         if addr_value is None:
             raise gr.Error("没有可用的收货地址。")
@@ -441,6 +448,20 @@ def on_submit_all(
             raise gr.Error("请填写联系人电话。")
         if address_index is None:
             raise gr.Error("请先选择收货地址。")
+        if _has_invalid_index(people_indices, buyer_value):
+            raise gr.Error("实名购票人选择已失效，请重新获取票务信息后选择。")
+        if (
+            not isinstance(ticket_info, int)
+            or ticket_info < 0
+            or ticket_info >= len(ticket_value)
+        ):
+            raise gr.Error("票档选择已失效，请重新获取票务信息后选择。")
+        if (
+            not isinstance(address_index, int)
+            or address_index < 0
+            or address_index >= len(addr_value)
+        ):
+            raise gr.Error("收货地址选择已失效，请重新获取票务信息后选择。")
 
         ticket_cur: dict[str, Any] = ticket_value[ticket_info]
         people_cur = [buyer_value[item] for item in people_indices]
@@ -971,7 +992,7 @@ def setting_tab():
                         gr.Warning("该日期暂无票务信息。")
                         return [
                             gr.update(choices=sales_dates, value=_date, visible=True),
-                            gr.update(choices=[]),
+                            gr.update(choices=[], value=None),
                             gr.update(value="", visible=False),
                         ]
 
@@ -1001,7 +1022,7 @@ def setting_tab():
 
                     return [
                         gr.update(choices=sales_dates, value=_date, visible=True),
-                        gr.update(choices=ticket_str_list),
+                        gr.update(choices=ticket_str_list, value=None),
                         gr.update(
                             value=_render_ticket_info_html(
                                 title="票务信息",

--- a/tests/test_settings_ticket_selection.py
+++ b/tests/test_settings_ticket_selection.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from tab import settings
+
+
+class _JsonResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _FakeRequest:
+    def get(self, url: str):
+        if "linkgoods/list" in url:
+            return _JsonResponse({"data": {"list": []}})
+        if "buyer/list" in url:
+            return _JsonResponse(
+                {
+                    "data": {
+                        "list": [
+                            {"name": "alice", "personal_id": "id-a"},
+                        ]
+                    }
+                }
+            )
+        if "addr/list" in url:
+            return _JsonResponse(
+                {
+                    "data": {
+                        "addr_list": [
+                            {
+                                "addr": "road 1",
+                                "area": "area",
+                                "city": "city",
+                                "id": 1,
+                                "name": "receiver",
+                                "phone": "13800138000",
+                                "prov": "prov",
+                            }
+                        ]
+                    }
+                }
+            )
+        raise AssertionError(f"unexpected url: {url}")
+
+
+def _project_payload():
+    return {
+        "id": 123,
+        "name": "demo project",
+        "hotProject": False,
+        "has_eticket": True,
+        "sales_dates": [],
+        "start_time": 1735689600,
+        "end_time": 1735689600,
+        "screen_list": [
+            {
+                "id": 10,
+                "name": "day 1",
+                "project_id": 123,
+                "ticket_list": [
+                    {
+                        "desc": "vip",
+                        "id": 20,
+                        "price": 100,
+                        "sale_start": "2026-01-01 12:00:00",
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_submit_ticket_id_resets_stale_selection_values(monkeypatch):
+    monkeypatch.setattr(settings.util, "main_request", _FakeRequest())
+    monkeypatch.setattr(
+        settings,
+        "fetch_project_payload",
+        lambda request, project_id: _project_payload(),
+    )
+    monkeypatch.setattr(
+        settings,
+        "_fetch_screens_by_date_with_fallback",
+        lambda request, project_id, date_str: [],
+    )
+
+    updates = next(settings.on_submit_ticket_id("123"))
+
+    assert updates[0]["value"] is None
+    assert updates[1]["choices"] == ["alice-id-a"]
+    assert updates[1]["value"] == []
+    assert updates[2]["value"] is None
+
+
+def test_has_invalid_index_detects_stale_buyer_selection():
+    assert not settings._has_invalid_index([0], [{"name": "alice"}])
+    assert settings._has_invalid_index([0, 1], [{"name": "alice"}])


### PR DESCRIPTION
## Summary

- Clear stale ticket, buyer, and address selections when ticket data is refreshed.
- Validate selected indices before generating config files so stale UI state reports a clear error.
- Add tests for resetting stale buyer selections.

## Root Cause

The Gradio components refresh their `choices` when ticket/account data changes, but the previous `value` can remain selected. Since buyer selections use index values, an old account's buyer index may still be submitted against the new account's buyer list.

## Tests

- `.venv\Scripts\pytest.exe tests/test_settings_ticket_selection.py tests/test_login_account_defaults.py`

Fixes #964
