### PR TITLE
feat: add proxy API provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,152 @@
-<div align="center">
-  <a href="https://github.com/mikumifa/biliTickerBuy" target="_blank">
-    <img width="160" src="assets/icon.ico" alt="logo">
-  </a>
-  <h2 id="koishi">biliTickerBuy</h1>
+## 总体改动
 
-<p>
-  <!-- GitHub Downloads -->
-  <a href="https://github.com/mikumifa/biliTickerBuy/releases">
-    <img src="https://img.shields.io/github/downloads/mikumifa/biliTickerBuy/total" alt="GitHub all releases">
-  </a>
-  <!-- GitHub Release Version -->
-  <a href="https://github.com/mikumifa/biliTickerBuy/releases">
-    <img src="https://img.shields.io/github/v/release/mikumifa/biliTickerBuy" alt="GitHub release (with filter)">
-  </a>
-  <!-- GitHub Issues -->
-  <a href="https://github.com/mikumifa/biliTickerBuy/issues">
-    <img src="https://img.shields.io/github/issues/mikumifa/biliTickerBuy" alt="GitHub issues">
-  </a>
-  <!-- GitHub Stars -->
-  <a href="https://github.com/mikumifa/biliTickerBuy/stargazers">
-    <img src="https://img.shields.io/github/stars/mikumifa/biliTickerBuy" alt="GitHub Repo stars">
-  </a>
-</p>
-<a href="https://trendshift.io/repositories/11145" target="_blank"><img src="https://trendshift.io/api/badge/repositories/11145" alt="mikumifa%2FbiliTickerBuy | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+本次改动新增了“代理 API 获取与自动补充代理池”能力。用户可以填写代理 API 地址，选择 HTTP/HTTPS 或 SOCKS5 代理类型；程序会自动拉取代理，也会在抢票过程中代理池耗尽时自动请求新的代理并替换当前代理池。目前指针对“有代理”代理商的API做了适配，如果认为此PR有用，可以提供其他代理服务商的APIdemo进行适配。
 
-这是一个开源免费，简单易用的 B 站会员购辅助工具
+## 改动位置
 
-</div>
+### 代理 API 配置项
 
-## 💻 快速安装
+位置：`app_cmd/config/BuyConfig.py:63`
 
-请查看完整的 [安装指南](./docs/installation.md)。
+新增字段：
 
-## 👀 使用说明书
+- `proxy_api_url`
+- `proxy_api_protocol`
+- `proxy_api_request_count`
 
-前往飞书： https://n1x87b5cqay.feishu.cn/wiki/Eg4xwt3Dbiah02k1WqOcVk2YnMd
+这些字段分别支持环境变量、运行时配置、数据库字段和 CLI 参数：
 
-## ❗ 项目问题
+- `BTB_PROXY_API_URL` / `--proxy-api-url`
+- `BTB_PROXY_API_PROTOCOL` / `--proxy-api-protocol`
+- `BTB_PROXY_API_REQUEST_COUNT` / `--proxy-api-request-count`
 
-程序使用问题： [点此链接前往 discussions](https://github.com/mikumifa/biliTickerBuy/discussions)
+### 运行时配置同步
 
-反馈程序 BUG 或者提新功能建议： [点此链接向项目提出反馈 BUG](https://github.com/mikumifa/biliTickerBuy/issues/new/choose)
+位置：`interface/config.py:37`
 
-## Related Work
+`RuntimeOptions` 新增代理 API 相关字段：
 
-Skill版本：https://github.com/mikumifa/biliTickerSkill
+- `proxy_api_url`
+- `proxy_api_protocol`
+- `proxy_api_request_count`
 
-分布式版本：https://github.com/mikumifa/biliTickerStorm
+位置：`interface/config.py:305`
 
-## 📩 免责声明
-本项目遵循 MIT License 许可协议，仅供个人学习与研究使用。请勿将本项目用于任何商业牟利行为，亦严禁用于任何形式的代抢、违法行为或违反相关平台规则的用途。由此产生的一切后果均由使用者自行承担，与本人无关。
-若您 fork 或使用本项目，请务必遵守相关法律法规与目标平台规则。
-## 🛡️ 平台尊重声明
-本项目在设计时严格遵循「非侵入式」原则，避免对目标服务器（如 Bilibili）造成任何干扰。
-如本项目中存在侵犯 Bilibili 公司合法权益的内容，请通过邮箱 [1055069518@qq.com](mailto:1055069518@qq.com) 与我联系，我将第一时间下架相关内容并删除本仓库。对此造成的不便，我深表歉意，感谢您的理解与包容。
+`build_runtime_options()` 新增这些入参，并对 `proxy_api_request_count` 做非负数归一化。
 
-## 🤩 项目贡献者
+### 代理 API 请求与解析模块
 
-<a href="https://github.com/mikumifa/biliTickerBuy/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=mikumifa/biliTickerBuy&preview=true&max=&columns=" />
-</a>
-<br /><br />
+位置：`util/proxy/ProxyApiProvider.py:1`
 
-## ⭐️ Star History
+新增模块包含：
 
-[![Star History Chart](https://api.star-history.com/svg?repos=mikumifa/biliTickerBuy&type=Date)](https://www.star-history.com/#mikumifa/biliTickerBuy&Date)
+- `ProxyApiError`
+- `ProxyApiResult`
+- `normalize_proxy_api_protocol()`
+- `build_proxy_api_url()`
+- `parse_proxy_api_response()`
+- `fetch_proxy_api()`
+
+主要行为：
+
+- 自动把代理 API URL 中的 `count`、`format`、`protocol` 参数规范为请求需要的值。
+- 支持解析常见 JSON 返回结构，例如 `data.proxy_list`、`list`、`proxies`、`items`。
+- 支持从 `ip + port` 字段或 `host:port` 字符串中提取代理。
+- 自动去重，并输出程序可使用的代理地址格式。
+
+### 设置页 UI
+
+位置：`tab/config.py:49`
+
+新增读取代理 API 配置的辅助函数：
+
+- `get_proxy_api_url()`
+- `get_proxy_api_protocol()`
+
+位置：`tab/config.py:82`
+
+新增 UI 回调：
+
+- `fetch_proxy_from_api()`：从代理 API 获取代理，并写入现有代理列表。
+- `save_proxy_api_config()`：保存代理 API 地址和代理类型。
+
+位置：`tab/config.py:394`
+
+在“代理”设置页新增“通过代理 API 获取”区域，包括：
+
+- 代理 API 地址输入框
+- 代理地址类型下拉框
+- “保存 API 配置”按钮
+- “获取并填入代理”按钮
+- 代理 API 结果显示框
+
+位置：`tab/config.py:722`
+
+绑定“保存 API 配置”和“获取并填入代理”按钮事件。
+
+位置：`tab/config.py:875`
+
+设置页加载配置时同步回填代理 API 地址和代理类型。
+
+### 抢票流程自动补充代理池
+
+位置：`task/buy.py:27`
+
+引入 `fetch_proxy_api()`。
+
+位置：`task/buy.py:230`
+
+在 `handle_proxy_failure()` 内新增 `replenish_proxy_pool()`。当代理 API 已配置，并且当前代理池不可用时，会按配置数量请求新代理。
+
+位置：`task/buy.py:263`
+
+调用 `_handle_proxy_failure()` 时传入 `replenish_proxy_pool` 回调，让代理失败处理流程可以触发自动补池。
+
+### 代理失败处理扩展点
+
+位置：`task/buy_helpers.py:257`
+
+`handle_proxy_failure()` 新增参数：
+
+- `replenish_proxy_pool`
+
+位置：`task/buy_helpers.py:281`
+
+当没有可用代理时，优先调用 `replenish_proxy_pool()`。如果补池成功，会重置代理退避时间并立即返回补池成功消息；如果补池失败，则继续原有的退避等待流程。
+
+### 替换代理池能力
+
+位置：`util/proxy/ProxyManager.py:106`
+
+新增 `replace_proxy_list()`，用于整体替换代理列表并重建代理状态注册表。
+
+位置：`util/request/BiliRequest.py:110`
+
+新增 `replace_proxy_pool()`，用于：
+
+- 调用 `ProxyManager.replace_proxy_list()`
+- 将新代理池应用到当前 session
+- 失效化 HTTP/2 client，避免继续沿用旧连接状态
+
+### 示例文件
+
+位置：`demo/proxy_ip_request_api_demo.py:1`
+
+新增代理 API 请求示例，用于快速验证代理服务商 API 的原始返回。
+
+### 测试
+
+位置：`tests/test_proxy_api_provider.py:1`
+
+新增代理 API provider 单元测试，覆盖：
+
+- URL 参数覆盖和规范化
+- HTTP 代理解析
+- SOCKS5 代理解析
+- API 失败响应抛错
+
+验证命令：
+
+```bash
+uv run pytest tests/test_proxy_api_provider.py
+```

--- a/app_cmd/config/BuyConfig.py
+++ b/app_cmd/config/BuyConfig.py
@@ -60,6 +60,34 @@ class BuyConfig(BasicConfig):
     )
     """Proxy string or comma-separated proxy pool."""
 
+    proxy_api_url: str = config_field(
+        "",
+        env="BTB_PROXY_API_URL",
+        runtime="proxy_api_url",
+        db="proxyApiUrl",
+        cli="--proxy-api-url",
+    )
+    """Proxy provider API URL used to replenish the proxy pool."""
+
+    proxy_api_protocol: str = config_field(
+        "http",
+        env="BTB_PROXY_API_PROTOCOL",
+        runtime="proxy_api_protocol",
+        db="proxyApiProtocol",
+        cli="--proxy-api-protocol",
+    )
+    """Proxy provider protocol parameter: http or socks5."""
+
+    proxy_api_request_count: int = config_field(
+        0,
+        env="BTB_PROXY_API_REQUEST_COUNT",
+        runtime="proxy_api_request_count",
+        db="queueConcurrencyLimit",
+        cli="--proxy-api-request-count",
+        cast=int,
+    )
+    """Number of proxies requested from the API; 0 follows the current pool size."""
+
     # ConfigDB 里原字段是 hideRandomMessage，语义和 show_random_message 相反
     show_random_message: bool = config_field(
         True,

--- a/demo/proxy_ip_request_api_demo.py
+++ b/demo/proxy_ip_request_api_demo.py
@@ -1,0 +1,10 @@
+import requests
+
+url = "http://api.youdaili.com/v1/proxy/get?app_key=&app_secret=&count=&format=&protocol=&sep=&expire=&auth=&isp=&province=&city=&only="
+
+payload = {}
+headers = {}
+
+response = requests.request("GET", url, headers=headers, data=payload)
+
+print(response.text)

--- a/interface/config.py
+++ b/interface/config.py
@@ -34,6 +34,9 @@ class RuntimeOptions:
     barkToken: str = ""
     meowNickname: str = ""
     https_proxys: str = "none"
+    proxy_api_url: str = ""
+    proxy_api_protocol: str = "http"
+    proxy_api_request_count: int = 0
     serverchan3ApiUrl: str = ""
     ntfy_url: str = ""
     ntfy_username: str = ""
@@ -299,6 +302,9 @@ def build_runtime_options(
     barkToken: str = "",
     meowNickname: str = "",
     https_proxys: str = "none",
+    proxy_api_url: str = "",
+    proxy_api_protocol: str = "http",
+    proxy_api_request_count: int = 0,
     serverchan3ApiUrl: str = "",
     ntfy_url: str = "",
     ntfy_username: str = "",
@@ -332,6 +338,12 @@ def build_runtime_options(
         barkToken=barkToken,
         meowNickname=meowNickname,
         https_proxys=https_proxys,
+        proxy_api_url=proxy_api_url,
+        proxy_api_protocol=proxy_api_protocol,
+        proxy_api_request_count=normalize_non_negative_interval(
+            proxy_api_request_count,
+            default=0,
+        ),
         serverchan3ApiUrl=serverchan3ApiUrl,
         ntfy_url=ntfy_url,
         ntfy_username=ntfy_username,

--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ CliCommand = BuyCommand | UiCommand
 
 def _normalize_argv(argv: list[str]) -> list[str]:
     normalized = [
-        "--config-file" if arg in {"-cf", "--config-fileme"} else arg for arg in argv
+        "--config-file" if arg in {"-cf", "--config-file"} else arg for arg in argv
     ]
 
     argv = normalized

--- a/tab/config.py
+++ b/tab/config.py
@@ -46,6 +46,13 @@ def go_settings_tab(header_ui):
     def get_latest_proxy():
         return _format_proxy_text(ConfigDB.get("https_proxy") or "")
 
+    def get_proxy_api_url():
+        return ConfigDB.get("proxyApiUrl") or ""
+
+    def get_proxy_api_protocol():
+        protocol = str(ConfigDB.get("proxyApiProtocol") or "http").lower()
+        return "socks5" if protocol in {"socks", "socks5"} else "http"
+
     def input_https_proxy(_https_proxy):
         normalized_proxy = _serialize_proxy_text(_https_proxy)
         ConfigDB.insert("https_proxy", normalized_proxy)
@@ -71,6 +78,43 @@ def go_settings_tab(header_ui):
 
     def show_proxy_test_loading():
         return gr.update(value="正在测试代理连通性，请稍候...", visible=True)
+
+    def fetch_proxy_from_api(api_url, protocol):
+        try:
+            from util.proxy.ProxyApiProvider import fetch_proxy_api
+
+            protocol = (
+                "socks5"
+                if str(protocol).lower() in {"socks", "socks5"}
+                else "http"
+            )
+            ConfigDB.insert("proxyApiUrl", str(api_url or "").strip())
+            ConfigDB.insert("proxyApiProtocol", protocol)
+            count = ConfigDB.get_as_int("queueConcurrencyLimit", 0)
+            if count <= 0:
+                count = max(1, len(_split_proxy_lines(ConfigDB.get("https_proxy") or "")))
+            result = fetch_proxy_api(api_url, count=count, protocol=protocol)
+            ConfigDB.insert("https_proxy", ",".join(result.proxies))
+            gr.Info(f"已从代理 API 获取 {len(result.proxies)} 个代理。")
+            return gr.update(value="\n".join(result.proxies)), gr.update(
+                value=f"✅ 已获取 {len(result.proxies)} 个代理",
+                visible=True,
+            )
+        except Exception as e:
+            return gr.update(), gr.update(value=f"❌ 获取代理失败: {str(e)}", visible=True)
+
+    def save_proxy_api_config(api_url, protocol):
+        protocol = (
+            "socks5"
+            if str(protocol).lower() in {"socks", "socks5"}
+            else "http"
+        )
+        ConfigDB.insert("proxyApiUrl", str(api_url or "").strip())
+        ConfigDB.insert("proxyApiProtocol", protocol)
+        gr.Info("代理 API 配置已保存。")
+        return gr.update(value=ConfigDB.get("proxyApiUrl") or ""), gr.update(
+            value=protocol
+        )
 
     def inner_input_serverchan(x):
         ConfigDB.insert("serverchanKey", x)
@@ -347,6 +391,37 @@ def go_settings_tab(header_ui):
                         placeholder="点击上方按钮开始测试代理连通性...",
                         visible=False,
                     )
+                    gr.Markdown("### 通过代理 API 获取")
+                    proxy_api_url_ui = gr.Textbox(
+                        label="代理 API 地址",
+                        placeholder="例如：http://api.youdaili.com/v1/proxy/get?app_key=...&app_secret=...&count=&format=&protocol=",
+                        value=get_proxy_api_url(),
+                    )
+                    proxy_api_protocol_ui = gr.Dropdown(
+                        label="代理地址类型",
+                        choices=[
+                            ("HTTP / HTTPS", "http"),
+                            ("SOCKS5", "socks5"),
+                        ],
+                        value=get_proxy_api_protocol(),
+                        interactive=True,
+                        allow_custom_value=False,
+                        filterable=False,
+                    )
+                    with gr.Row(elem_classes="btb-inline-actions !justify-end"):
+                        save_proxy_api_btn = gr.Button(
+                            "保存 API 配置",
+                            elem_classes="btb-soft-button",
+                        )
+                        fetch_proxy_api_btn = gr.Button(
+                            "获取并填入代理",
+                            elem_classes="btb-soft-button",
+                        )
+                    proxy_api_result_ui = gr.Textbox(
+                        label="代理 API 结果",
+                        interactive=False,
+                        visible=False,
+                    )
                     gr.Markdown(
                         """
                         <div class="mt-3 text-sm leading-7 text-slate-700">
@@ -355,6 +430,7 @@ def go_settings_tab(header_ui):
                           <p><strong>带账号密码的 HTTP 代理示例：</strong><code>http://proxyuser:proxypass@xx.xx.xx.xx:8080</code></p>
                           <p><strong>程序什么时候会用代理：</strong>当抢票流程检测到风控时，会按你填写的顺序切换到下一个代理；当前请求不会在请求层立刻自动重试，下一次抢票重试才会使用新代理。</p>
                           <p><strong>代理失效怎么处理：</strong>同一代理在短时间内连续失败会被暂时冷却；如果所有代理都不可用，程序会按递增时间休息后再试。</p>
+                          <p><strong>代理 API：</strong>保存 API 地址后，程序会在代理全部不可用时自动按并发数请求新代理；请求会自动带上 <code>format=json</code>、<code>count</code> 和所选 <code>protocol</code>。</p>
                           <p><strong>建议先测试再开抢：</strong>保存后点击上方“测试代理连通性”，确认代理能正常访问哔哩哔哩接口。</p>
                           <p><strong>自建代理：</strong>如果你没有现成代理，可以自己在 Ubuntu / Debian 服务器上搭建 Squid HTTP 代理。</p>
                           <p><strong>完整搭建说明：</strong><a href="https://github.com/mikumifa/biliTickerBuy/blob/main/docs/proxy-self-hosting.md" target="_blank" rel="noopener noreferrer">GitHub 查看自建代理指南</a></p>
@@ -643,6 +719,16 @@ def go_settings_tab(header_ui):
         inputs=[https_proxy_ui, test_timeout_ui],
         outputs=test_result_ui,
     )
+    save_proxy_api_btn.click(
+        fn=save_proxy_api_config,
+        inputs=[proxy_api_url_ui, proxy_api_protocol_ui],
+        outputs=[proxy_api_url_ui, proxy_api_protocol_ui],
+    )
+    fetch_proxy_api_btn.click(
+        fn=fetch_proxy_from_api,
+        inputs=[proxy_api_url_ui, proxy_api_protocol_ui],
+        outputs=[https_proxy_ui, proxy_api_result_ui],
+    )
 
     serverchan_ui.submit(
         fn=inner_input_serverchan, inputs=serverchan_ui, outputs=serverchan_ui
@@ -786,6 +872,8 @@ def go_settings_tab(header_ui):
         hide_header = ConfigDB.get_as_bool("hideHeader", False)
         return [
             gr.update(value=get_latest_proxy()),
+            gr.update(value=get_proxy_api_url()),
+            gr.update(value=get_proxy_api_protocol()),
             gr.update(value=ConfigDB.get("audioPath") or None),
             gr.update(value=ConfigDB.get("serverchanKey") or ""),
             gr.update(value=ConfigDB.get("serverchan3ApiUrl") or ""),
@@ -827,6 +915,8 @@ def go_settings_tab(header_ui):
 
     return load_go_settings_configs, [
         https_proxy_ui,
+        proxy_api_url_ui,
+        proxy_api_protocol_ui,
         audio_path_ui,
         serverchan_ui,
         serverchan3_ui,

--- a/task/buy.py
+++ b/task/buy.py
@@ -24,6 +24,7 @@ from app_cmd.config.BuyConfig import BuyConfig
 from interface.project import fetch_project_payload
 from util.notifer.Notifier import NotifierManager
 from util.proxy.ProxyBackoff import ProxyBackoff
+from util.proxy.ProxyApiProvider import fetch_proxy_api
 from util.proxy.ProxyManager import ProxyManager
 from util.notifer.RandomMessages import get_random_fail_message
 from util.TimeUtil import current_time_ms
@@ -226,11 +227,45 @@ def buy_stream(config: BuyConfig):
         *,
         attempt: int | None = None,
     ):
+        def replenish_proxy_pool():
+            if not str(config.proxy_api_url or "").strip():
+                return False, None
+            try:
+                request_count = int(config.proxy_api_request_count or 0)
+            except (TypeError, ValueError):
+                request_count = 0
+            if request_count <= 0:
+                request_count = max(
+                    1,
+                    len(
+                        [
+                            proxy
+                            for proxy in _request.proxy_manager.proxy_list
+                            if proxy.lower() != "none"
+                        ]
+                    ),
+                )
+            try:
+                result = fetch_proxy_api(
+                    config.proxy_api_url,
+                    count=request_count,
+                    protocol=config.proxy_api_protocol,
+                )
+                _request.replace_proxy_pool(",".join(result.proxies))
+                return (
+                    True,
+                    f"已从代理 API 自动获取 {len(result.proxies)} 个新代理",
+                )
+            except Exception as exc:
+                logger.warning(f"代理 API 自动获取失败: {exc}")
+                return False, f"代理 API 自动获取失败: {exc}"
+
         immediate_message, delay_seconds = _handle_proxy_failure(
             _request,
             reason,
             proxy_backoff,
             config.notifier_config,
+            replenish_proxy_pool=replenish_proxy_pool,
         )
         attempt_total = (
             effective_retry_limit if attempt is not None else state.attempt_total

--- a/task/buy_helpers.py
+++ b/task/buy_helpers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import math
 import time
+from collections.abc import Callable
 
 from cptoken import CTokenRuntimeState, sim_ctoken_state
 
@@ -258,6 +259,7 @@ def handle_proxy_failure(
     reason: str,
     proxy_backoff: ProxyBackoff,
     notifier_config: NotifierConfig,
+    replenish_proxy_pool: Callable[[], tuple[bool, str | None]] | None = None,
 ) -> tuple[str | None, int | None]:
     previous_proxy = _request.current_proxy_display()
     cooled = _request.mark_current_proxy_failure(reason)
@@ -275,6 +277,20 @@ def handle_proxy_failure(
 
     if _request.has_available_proxy():
         return immediate_message, None
+
+    if replenish_proxy_pool is not None:
+        replenished, replenish_message = replenish_proxy_pool()
+        if replenished:
+            proxy_backoff.reset()
+            if immediate_message and replenish_message:
+                return f"{immediate_message}\n{replenish_message}", None
+            return replenish_message or immediate_message, None
+        if replenish_message:
+            immediate_message = (
+                f"{immediate_message}\n{replenish_message}"
+                if immediate_message
+                else replenish_message
+            )
 
     delay_seconds = proxy_backoff.next_delay_seconds()
     if proxy_backoff.should_notify():

--- a/tests/test_proxy_api_provider.py
+++ b/tests/test_proxy_api_provider.py
@@ -1,0 +1,70 @@
+import pytest
+
+from util.proxy.ProxyApiProvider import (
+    ProxyApiError,
+    build_proxy_api_url,
+    parse_proxy_api_response,
+)
+
+
+def test_build_proxy_api_url_overrides_required_params():
+    url = build_proxy_api_url(
+        "http://api.example.com/get?app_key=abc&count=&format=text&protocol=http",
+        count=3,
+        protocol="socks5",
+    )
+
+    assert url == (
+        "http://api.example.com/get?"
+        "app_key=abc&count=3&format=json&protocol=socks5"
+    )
+
+
+def test_parse_youdaili_success_response_as_http_proxy():
+    payload = {
+        "code": 0,
+        "msg": "OK",
+        "data": {
+            "count": 1,
+            "proxy_list": [
+                {
+                    "ip": "8.8.8.8",
+                    "port": 12234,
+                }
+            ],
+        },
+    }
+
+    assert parse_proxy_api_response(payload, protocol="http") == [
+        "http://8.8.8.8:12234"
+    ]
+
+
+def test_parse_youdaili_success_response_as_socks_proxy():
+    payload = {
+        "code": 0,
+        "msg": "OK",
+        "data": {
+            "proxy_list": [
+                {
+                    "ip": "8.8.8.8",
+                    "port": 12234,
+                }
+            ],
+        },
+    }
+
+    assert parse_proxy_api_response(payload, protocol="socks5") == [
+        "socks://8.8.8.8:12234"
+    ]
+
+
+def test_parse_youdaili_failure_response_raises():
+    payload = {
+        "code": 104,
+        "msg": "未检索到满足要求的代理IP，请调整筛选条件后再试，或联系客服处理！",
+        "data": None,
+    }
+
+    with pytest.raises(ProxyApiError):
+        parse_proxy_api_response(payload, protocol="http")

--- a/util/proxy/ProxyApiProvider.py
+++ b/util/proxy/ProxyApiProvider.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import requests
+
+
+class ProxyApiError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class ProxyApiResult:
+    proxies: list[str]
+    response: dict[str, Any]
+
+
+def normalize_proxy_api_protocol(protocol: str | None) -> str:
+    text = str(protocol or "http").strip().lower()
+    if text in {"socks", "socks5"}:
+        return "socks5"
+    return "http"
+
+
+def build_proxy_api_url(api_url: str, *, count: int, protocol: str) -> str:
+    target = str(api_url or "").strip()
+    if not target:
+        raise ProxyApiError("请先填写代理 API 地址")
+
+    parts = urlsplit(target)
+    query = dict(parse_qsl(parts.query, keep_blank_values=True))
+    query["count"] = str(max(1, int(count)))
+    query["format"] = "json"
+    query["protocol"] = normalize_proxy_api_protocol(protocol)
+    return urlunsplit(
+        (
+            parts.scheme,
+            parts.netloc,
+            parts.path,
+            urlencode(query, doseq=True),
+            parts.fragment,
+        )
+    )
+
+
+def _iter_proxy_items(payload: Any) -> list[Any]:
+    if isinstance(payload, dict):
+        data = payload.get("data")
+        if isinstance(data, dict):
+            for key in ("proxy_list", "list", "proxies", "items"):
+                value = data.get(key)
+                if isinstance(value, list):
+                    return value
+            if any(key in data for key in ("ip", "host", "port", "proxy")):
+                return [data]
+        elif isinstance(data, list):
+            return data
+
+        for key in ("proxy_list", "list", "proxies", "items"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return value
+    if isinstance(payload, list):
+        return payload
+    return []
+
+
+def _extract_host_port(item: Any) -> tuple[str, str] | None:
+    if isinstance(item, dict):
+        proxy_value = item.get("proxy") or item.get("addr") or item.get("address")
+        if proxy_value:
+            return _extract_host_port(str(proxy_value))
+
+        host = item.get("ip") or item.get("host")
+        port = item.get("port")
+        if host and port:
+            return str(host).strip(), str(port).strip()
+        return None
+
+    text = str(item or "").strip()
+    if not text:
+        return None
+    text = re.sub(r"^[a-zA-Z][a-zA-Z0-9+.-]*://", "", text)
+    if "@" in text:
+        text = text.rsplit("@", 1)[1]
+    if ":" not in text:
+        return None
+    host, port = text.rsplit(":", 1)
+    return host.strip(), port.strip()
+
+
+def parse_proxy_api_response(payload: dict[str, Any], *, protocol: str) -> list[str]:
+    code = payload.get("code", payload.get("errno", 0))
+    success = payload.get("success")
+    if success is False or str(code) not in {"0", "200", "None"}:
+        message = payload.get("msg") or payload.get("message") or payload
+        raise ProxyApiError(f"代理 API 返回失败: {message}")
+
+    scheme = "socks" if normalize_proxy_api_protocol(protocol) == "socks5" else "http"
+    proxies: list[str] = []
+    seen: set[str] = set()
+    for item in _iter_proxy_items(payload):
+        host_port = _extract_host_port(item)
+        if not host_port:
+            continue
+        host, port = host_port
+        if not host or not port.isdigit():
+            continue
+        proxy = f"{scheme}://{host}:{port}"
+        key = proxy.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        proxies.append(proxy)
+
+    if not proxies:
+        raise ProxyApiError("代理 API 返回成功，但没有解析到代理 IP 和端口")
+    return proxies
+
+
+def fetch_proxy_api(
+    api_url: str,
+    *,
+    count: int,
+    protocol: str,
+    timeout: int = 15,
+) -> ProxyApiResult:
+    request_url = build_proxy_api_url(api_url, count=count, protocol=protocol)
+    response = requests.request("GET", request_url, headers={}, data={}, timeout=timeout)
+    response.raise_for_status()
+    payload = response.json()
+    if not isinstance(payload, dict):
+        raise ProxyApiError("代理 API 未返回 JSON 对象")
+    return ProxyApiResult(
+        proxies=parse_proxy_api_response(payload, protocol=protocol),
+        response=payload,
+    )

--- a/util/proxy/ProxyManager.py
+++ b/util/proxy/ProxyManager.py
@@ -103,6 +103,18 @@ class ProxyManager:
     def proxy_pool_status(self) -> str:
         return self.state_registry.describe_all_states()
 
+    def replace_proxy_list(self, proxy_string: str) -> None:
+        proxy_list = self.parse_proxy_list(proxy_string)
+        if not proxy_list:
+            raise ValueError("at least have none proxy")
+        self.proxy_list = proxy_list
+        self.state_registry = ProxyStateRegistry(
+            self.proxy_list,
+            mask_proxy=self.mask_proxy_value,
+            failure_threshold=self.state_registry.failure_threshold,
+            cooldown_seconds=self.state_registry.cooldown_seconds,
+        )
+
     def snapshot(self) -> int:
         return self.now_proxy_idx
 

--- a/util/request/BiliRequest.py
+++ b/util/request/BiliRequest.py
@@ -107,6 +107,11 @@ class BiliRequest:
     def proxy_pool_status(self) -> str:
         return self.proxy_manager.proxy_pool_status()
 
+    def replace_proxy_pool(self, proxy_string: str) -> None:
+        self.proxy_manager.replace_proxy_list(proxy_string)
+        self.proxy_manager.apply_to_session(self.session)
+        self._invalidate_h2_client()
+
     def has_available_proxy(self) -> bool:
         return self.proxy_manager.has_available_proxy()
 


### PR DESCRIPTION
## Summary
- add proxy API configuration for CLI/runtime/UI
- support fetching proxies from provider API and filling proxy pool
- auto replenish proxy pool when all configured proxies are unavailable
- add proxy API parser tests and demo script
- fix config-file argv normalization

## Tests
- uv run pytest tests/test_proxy_api_provider.py