### PR TITLE
Fix macOS installer asset selection

### DIFF
--- a/assets/updater/update.sh
+++ b/assets/updater/update.sh
@@ -187,13 +187,13 @@ if ! RELEASE_JSON="$(request_release_json)"; then
   exit 1
 fi
 
-# 将每个 asset 对象拆到单独一行，再匹配当前平台。
+# 将每个 asset 对象拆到单独一行，再匹配当前平台的 CLI zip。
 ASSET_URL="$(
   printf '%s' "$RELEASE_JSON" |
     tr -d '\n' |
     sed 's/},{/},\
 {/g' |
-    grep "\"name\":\"[^\"]*_${PLATFORM_KEY}_[^\"]*\"" |
+    grep "\"name\":\"[^\"]*_${PLATFORM_KEY}_[^\"]*\.zip\"" |
     sed -n 's/.*"browser_download_url":"\([^"]*\)".*/\1/p' |
     head -n 1
 )"

--- a/install.sh
+++ b/install.sh
@@ -184,14 +184,18 @@ parse_version_info() {
   platform_block="$(
     printf '%s\n' "$version_info_json" |
       awk -v target="\"${platform_key}\"" '
-        index($0, target) {
+        !in_block && index($0, target) {
           in_block = 1
         }
 
         in_block {
           print
 
-          if ($0 ~ /^[[:space:]]*}[,]?[[:space:]]*$/) {
+          opens = gsub(/\{/, "{")
+          closes = gsub(/\}/, "}")
+          depth += opens - closes
+
+          if (depth <= 0) {
             exit
           }
         }
@@ -218,6 +222,35 @@ parse_version_info() {
         's/^[[:space:]]*"size"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' |
       head -n 1
   )"
+
+  # macOS 发行包同时包含 dmg 和 CLI zip，安装脚本需要 CLI zip。
+  cli_asset_block="$(
+    printf '%s\n' "$platform_block" |
+      sed -n '/_cli\.zip"/,+4p'
+  )"
+
+  if [ -n "$cli_asset_block" ]; then
+    ASSET_NAME="$(
+      printf '%s\n' "$cli_asset_block" |
+        sed -n \
+          's/^[[:space:]]*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' |
+        head -n 1
+    )"
+
+    ASSET_SHA256="$(
+      printf '%s\n' "$cli_asset_block" |
+        sed -n \
+          's/^[[:space:]]*"sha256"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' |
+        head -n 1
+    )"
+
+    ASSET_SIZE="$(
+      printf '%s\n' "$cli_asset_block" |
+        sed -n \
+          's/^[[:space:]]*"size"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' |
+        head -n 1
+    )"
+  fi
 
   if [ -z "$RELEASE_TAG" ]; then
     echo "version-info.json 中缺少 version 字段。" >&2


### PR DESCRIPTION
  ## 概述

  修复 macOS 安装器和 updater 误选 `.dmg` 的问题，改为优先使用 CLI 的 `.zip` 安装包。

  ### 事务

  - [ ] 已与维护者在 issues 或其他平台沟通此 PR 大致内容

  ### 功能

  - [x] ~~已编写面向用户的新功能说明（若有必要）~~ (不相关)
  - [x] 已测试新功能或更改

  ### 兼容性

  - [x] 已处理版本兼容性

已本地执行 `bash install.sh` 验证通过，能正确下载并安装 `*_cli.zip`

  ### 风险

  可能导致或已知的问题:
  - 无明显额外风险；仅调整安装包选择逻辑，避免 macOS 安装阶段误选 `.dmg`