### PR TITLE
修复代理 API 自动获取代理时丢失账号密码的问题，增强代理返回格式兼容性

### DIFF
--- a/tests/test_proxy_api_provider.py
+++ b/tests/test_proxy_api_provider.py
@@ -104,6 +104,24 @@ def test_parse_proxy_api_keeps_auth_from_object_fields():
     ]
 
 
+def test_parse_proxy_api_merges_auth_fields_with_proxy_field():
+    payload = {
+        "code": 0,
+        "data": [
+            {
+                "proxy": "192.0.2.40:15115",
+                "Username": "proxy_user",
+                "Password": "proxy_pass",
+                "protocol": "http",
+            }
+        ],
+    }
+
+    assert parse_proxy_api_response(payload, protocol="http") == [
+        _proxy_url("http", "proxy_user", "proxy_pass", "192.0.2.40", 15115)
+    ]
+
+
 def test_parse_proxy_api_keeps_auth_for_socks5_url():
     proxy = _proxy_url("socks5", "user", "pass", "127.0.0.1", 1080)
     payload = {

--- a/tests/test_proxy_api_provider.py
+++ b/tests/test_proxy_api_provider.py
@@ -7,6 +7,10 @@ from util.proxy.ProxyApiProvider import (
 )
 
 
+def _proxy_url(scheme: str, username: str, password: str, host: str, port: int) -> str:
+    return f"{scheme}://" + f"{username}:{password}@" + f"{host}:{port}"
+
+
 def test_build_proxy_api_url_overrides_required_params():
     url = build_proxy_api_url(
         "http://api.example.com/get?app_key=abc&count=&format=text&protocol=http",
@@ -54,8 +58,60 @@ def test_parse_youdaili_success_response_as_socks_proxy():
     }
 
     assert parse_proxy_api_response(payload, protocol="socks5") == [
-        "socks://8.8.8.8:12234"
+        "socks5://8.8.8.8:12234"
     ]
+
+
+def test_parse_proxy_api_keeps_auth_from_standard_url():
+    proxy = _proxy_url("http", "proxy_user", "proxy_pass", "192.0.2.10", 15674)
+    payload = {
+        "code": 0,
+        "data": [proxy],
+    }
+
+    assert parse_proxy_api_response(payload, protocol="http") == [proxy]
+
+
+def test_parse_proxy_api_keeps_auth_from_host_port_user_pass():
+    payload = {
+        "code": 0,
+        "proxies": [
+            "192.0.2.20:15115:proxy_user:proxy_pass",
+        ],
+    }
+
+    assert parse_proxy_api_response(payload, protocol="http") == [
+        _proxy_url("http", "proxy_user", "proxy_pass", "192.0.2.20", 15115)
+    ]
+
+
+def test_parse_proxy_api_keeps_auth_from_object_fields():
+    payload = {
+        "code": 0,
+        "data": [
+            {
+                "host": "192.0.2.30",
+                "port": 15115,
+                "Authkey": "proxy_user",
+                "Authpwd": "proxy_pass",
+                "protocol": "http",
+            }
+        ],
+    }
+
+    assert parse_proxy_api_response(payload, protocol="http") == [
+        _proxy_url("http", "proxy_user", "proxy_pass", "192.0.2.30", 15115)
+    ]
+
+
+def test_parse_proxy_api_keeps_auth_for_socks5_url():
+    proxy = _proxy_url("socks5", "user", "pass", "127.0.0.1", 1080)
+    payload = {
+        "code": 0,
+        "data": [proxy],
+    }
+
+    assert parse_proxy_api_response(payload, protocol="socks5") == [proxy]
 
 
 def test_parse_youdaili_failure_response_raises():

--- a/util/proxy/ProxyApiProvider.py
+++ b/util/proxy/ProxyApiProvider.py
@@ -121,7 +121,31 @@ def _extract_proxy_parts(
     if isinstance(item, dict):
         proxy_value = _get_any_key(item, "proxy", "addr", "address")
         if proxy_value:
-            return _extract_proxy_parts(str(proxy_value), protocol=protocol)
+            proxy_parts = _extract_proxy_parts(str(proxy_value), protocol=protocol)
+            if proxy_parts is None:
+                return None
+            scheme, host, port, username, password = proxy_parts
+            if username:
+                return proxy_parts
+            username = (
+                _get_any_key(item, "username", "user", "account", "authkey")
+                or ""
+            )
+            password = (
+                _get_any_key(item, "password", "pass", "pwd", "authpwd")
+                or ""
+            )
+            scheme = _normalize_proxy_scheme(
+                _get_any_key(item, "protocol", "scheme", "type") or scheme,
+                protocol,
+            )
+            return (
+                scheme,
+                host,
+                port,
+                str(username).strip(),
+                str(password),
+            )
 
         host = _get_any_key(item, "ip", "host")
         port = _get_any_key(item, "port")

--- a/util/proxy/ProxyApiProvider.py
+++ b/util/proxy/ProxyApiProvider.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from typing import Any
-from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit, urlunsplit
 
 import requests
 
@@ -68,28 +68,131 @@ def _iter_proxy_items(payload: Any) -> list[Any]:
     return []
 
 
-def _extract_host_port(item: Any) -> tuple[str, str] | None:
-    if isinstance(item, dict):
-        proxy_value = item.get("proxy") or item.get("addr") or item.get("address")
-        if proxy_value:
-            return _extract_host_port(str(proxy_value))
+def _normalize_proxy_scheme(scheme: str | None, fallback_protocol: str) -> str:
+    text = str(scheme or "").strip().lower()
+    if text in {"socks", "socks5"}:
+        return "socks5"
+    if text == "socks4":
+        return "socks4"
+    if text in {"http", "https"}:
+        return text
+    return normalize_proxy_api_protocol(fallback_protocol)
 
-        host = item.get("ip") or item.get("host")
-        port = item.get("port")
+
+def _format_proxy_url(
+    *,
+    scheme: str,
+    host: str,
+    port: str,
+    username: str = "",
+    password: str = "",
+) -> str:
+    host = str(host or "").strip()
+    port = str(port or "").strip()
+    username = str(username or "").strip()
+    password = str(password or "")
+    if ":" in host and not (host.startswith("[") and host.endswith("]")):
+        host = f"[{host}]"
+    if username:
+        auth = quote(username, safe="")
+        if password:
+            auth = f"{auth}:{quote(password, safe='')}"
+        return f"{scheme}://{auth}@{host}:{port}"
+    return f"{scheme}://{host}:{port}"
+
+
+def _get_any_key(item: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in item:
+            return item[key]
+    lower_item = {str(key).lower(): value for key, value in item.items()}
+    for key in keys:
+        value = lower_item.get(key.lower())
+        if value is not None:
+            return value
+    return None
+
+
+def _extract_proxy_parts(
+    item: Any,
+    *,
+    protocol: str,
+) -> tuple[str, str, str, str, str] | None:
+    if isinstance(item, dict):
+        proxy_value = _get_any_key(item, "proxy", "addr", "address")
+        if proxy_value:
+            return _extract_proxy_parts(str(proxy_value), protocol=protocol)
+
+        host = _get_any_key(item, "ip", "host")
+        port = _get_any_key(item, "port")
         if host and port:
-            return str(host).strip(), str(port).strip()
+            username = (
+                _get_any_key(item, "username", "user", "account", "authkey")
+                or ""
+            )
+            password = (
+                _get_any_key(item, "password", "pass", "pwd", "authpwd")
+                or ""
+            )
+            scheme = _normalize_proxy_scheme(
+                _get_any_key(item, "protocol", "scheme", "type"),
+                protocol,
+            )
+            return (
+                scheme,
+                str(host).strip(),
+                str(port).strip(),
+                str(username).strip(),
+                str(password),
+            )
         return None
 
     text = str(item or "").strip()
     if not text:
         return None
-    text = re.sub(r"^[a-zA-Z][a-zA-Z0-9+.-]*://", "", text)
+
+    parsed = urlsplit(text)
+    if parsed.scheme and parsed.netloc:
+        try:
+            port = parsed.port
+        except ValueError:
+            port = None
+        if parsed.hostname and port:
+            return (
+                _normalize_proxy_scheme(parsed.scheme, protocol),
+                parsed.hostname.strip(),
+                str(port),
+                unquote(parsed.username or "").strip(),
+                unquote(parsed.password or ""),
+            )
+
+    scheme = normalize_proxy_api_protocol(protocol)
+    schema_match = re.match(r"^([a-zA-Z][a-zA-Z0-9+.-]*)://(.+)$", text)
+    if schema_match:
+        scheme = _normalize_proxy_scheme(schema_match.group(1), protocol)
+        text = schema_match.group(2)
+
+    text = text.split("/", 1)[0].split("?", 1)[0].split("#", 1)[0]
+    username = ""
+    password = ""
     if "@" in text:
-        text = text.rsplit("@", 1)[1]
+        auth, text = text.rsplit("@", 1)
+        username, _, password = auth.partition(":")
+
+    parts = text.split(":")
+    if len(parts) >= 4:
+        return (
+            scheme,
+            parts[0].strip(),
+            parts[1].strip(),
+            username or parts[2].strip(),
+            password or ":".join(parts[3:]),
+        )
+
     if ":" not in text:
         return None
     host, port = text.rsplit(":", 1)
-    return host.strip(), port.strip()
+    return scheme, host.strip(), port.strip(), username.strip(), password
 
 
 def parse_proxy_api_response(payload: dict[str, Any], *, protocol: str) -> list[str]:
@@ -99,17 +202,22 @@ def parse_proxy_api_response(payload: dict[str, Any], *, protocol: str) -> list[
         message = payload.get("msg") or payload.get("message") or payload
         raise ProxyApiError(f"代理 API 返回失败: {message}")
 
-    scheme = "socks" if normalize_proxy_api_protocol(protocol) == "socks5" else "http"
     proxies: list[str] = []
     seen: set[str] = set()
     for item in _iter_proxy_items(payload):
-        host_port = _extract_host_port(item)
-        if not host_port:
+        proxy_parts = _extract_proxy_parts(item, protocol=protocol)
+        if not proxy_parts:
             continue
-        host, port = host_port
+        scheme, host, port, username, password = proxy_parts
         if not host or not port.isdigit():
             continue
-        proxy = f"{scheme}://{host}:{port}"
+        proxy = _format_proxy_url(
+            scheme=scheme,
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+        )
         key = proxy.lower()
         if key in seen:
             continue


### PR DESCRIPTION
## 概述

修复代理 API 自动获取代理时丢失账号密码的问题，并增强代理返回格式兼容性。

此前代理 API 如果返回 `http://user:pass@host:port`，解析逻辑会丢弃 `user:pass@`，最终只保留 `http://host:port`，导致需要账号密码认证的代理请求失败，出现 `407 Proxy Authentication Required`。

本次变更支持并保留以下格式中的认证信息：

- `http://user:pass@host:port`
- `socks5://user:pass@host:port`
- `host:port:user:pass`
- JSON 对象字段：`username/password`、`user/pass`、`authkey/authpwd`
- JSON 对象中 `proxy/addr/address` 与认证字段分开返回的格式，例如 `{"proxy": "host:port", "username": "user", "password": "pass"}`
- 字段名大小写不敏感，例如 `Authkey/Authpwd`、`Username/Password`

同时将 SOCKS5 代理 API 输出统一为 `socks5://...`。

具体问题位置：

- `util/proxy/ProxyApiProvider.py`
  - 原先 `_extract_host_port()` 会先去掉 URL scheme，再在存在 `@` 时只保留 `@` 后面的 `host:port`，因此账号密码被丢弃。
  - 原逻辑只返回 host/port，没有统一表达 scheme、username、password，后续格式化代理 URL 时也无法保留认证信息。
  - 对 JSON 返回对象中 `proxy + username/password` 分开给出的格式兼容不足。

本次解决方式：

- 将代理解析拆成 `_extract_proxy_parts()`，统一返回 `scheme, host, port, username, password`。
- 使用 `urllib.parse.urlsplit()` 解析标准代理 URL，保留并解码 username/password。
- 对 `host:port:user:pass` 做兼容解析。
- 对 JSON 字段使用大小写不敏感读取，支持 `username/password`、`user/pass`、`authkey/authpwd` 等常见字段名。
- 当 `proxy/addr/address` 字段只提供 `host:port` 时，会从同一个对象里合并认证字段。
- 使用 `_format_proxy_url()` 统一输出代理 URL，并对用户名密码做 URL encode。

测试结果：

```bash
.venv/bin/python -m pytest tests/test_proxy_api_provider.py
```

结果：

```text
9 passed
```

### 事务

- [x] 已与维护者在 issues 或其他平台沟通此 PR 大致内容

## 以下内容可在起草 PR 后、合并 PR 前逐步完成

### 功能

- [x] 已编写完善的配置文件字段说明（若有新增）
- [x] 已编写面向用户的新功能说明（若有必要）
- [x] 已测试新功能或更改

### 兼容性

- [x] 已处理版本兼容性
- [x] 已处理插件兼容问题

### 风险

可能导致或已知的问题:

- 本次改动仅影响代理 API 返回值解析，不改变手动填写代理、抢票请求流程或代理切换策略。
- SOCKS5 代理 API 输出从 `socks://` 统一为 `socks5://`，与界面提示和 `requests/httpx` 常用格式保持一致。
- 已保留原有无账号密码代理格式兼容性，例如 `host:port`、`http://host:port`、JSON 中的 `ip/host + port`。
