### PR TITLE
优化抢票时间同步与请求时间戳一致性

### DIFF
--- a/tab/go.py
+++ b/tab/go.py
@@ -234,7 +234,7 @@ def go_start_tab():
 
         sale_start_items: list[tuple[str, datetime.datetime]] = []
         adjusted_now = datetime.datetime.fromtimestamp(
-            time.time() + time_service.get_timeoffset(),
+            time_service.now(),
             tz=BEIJING_TZ,
         )
 

--- a/task/buy.py
+++ b/task/buy.py
@@ -27,7 +27,7 @@ from util.proxy.ProxyBackoff import ProxyBackoff
 from util.proxy.ProxyApiProvider import fetch_proxy_api
 from util.proxy.ProxyManager import ProxyManager
 from util.notifer.RandomMessages import get_random_fail_message
-from util.TimeUtil import current_time_ms
+from util import time_service
 from util.ErrorCodes import ErrorCodes
 from task.buy_helpers import (
     BASE_URL as base_url,
@@ -490,7 +490,7 @@ def buy_stream(config: BuyConfig):
     while isRunning:
         try:
             request_result: dict | None = None
-            ticket_collection_t = current_time_ms()
+            ticket_collection_t = time_service.current_time_ms()
             ticket_state = init_ctoken_state(
                 browser_window_state=browser_window_state,
                 href_length=len(

--- a/task/buy_helpers.py
+++ b/task/buy_helpers.py
@@ -17,7 +17,6 @@ from util.Constant import (
 )
 from util.notifer.Notifier import NotifierManager
 from util.proxy.ProxyBackoff import ProxyBackoff
-from util.TimeUtil import current_time_ms
 from util.request.BiliRequest import BiliRequest
 from util.request.TokenUtil import generate_token
 from util.ErrorCodes import ErrorCodes
@@ -79,7 +78,22 @@ def wait_until_start(time_start: str, warmup=None):
 
     timeoffset = time_service.get_timeoffset()
     yield {"message": "0) 等待开始时间"}
-    yield {"message": f"时间偏差已被设置为: {timeoffset}秒"}
+    yield {
+        "message": (
+            f"时间偏差已被设置为: {timeoffset}秒"
+            f"（时间源: {getattr(time_service, 'time_source', 'unknown')}）"
+        )
+    }
+    bili_check = time_service.compute_bili_time_check(attempts=2, timeout=1.5)
+    if bili_check is not None:
+        yield {
+            "message": (
+                "会员购Date校验: "
+                f"与当前时间源差异约{bili_check.offset_center - timeoffset:+.3f}秒，"
+                f"不确定度约±{bili_check.uncertainty_seconds:.3f}秒，"
+                f"RTT {bili_check.delay * 1000:.1f}ms"
+            )
+        }
 
     for fmt in (
         "%Y-%m-%dT%H:%M:%S",
@@ -99,7 +113,7 @@ def wait_until_start(time_start: str, warmup=None):
 
     yield {"message": f"计划抢票开始时间: {target_time.strftime('%Y-%m-%d %H:%M:%S')}"}
 
-    time_difference = target_time.timestamp() - time.time() + timeoffset
+    time_difference = target_time.timestamp() - time_service.now()
     end_time = time.perf_counter() + time_difference
     next_report_at = float("inf")
     warmed = False
@@ -337,7 +351,7 @@ def prepare_create_request(
     payload = dict(tickets_info)
     payload["again"] = 1
     payload["token"] = order_token
-    now_ms = current_time_ms()
+    now_ms = time_service.current_time_ms()
     payload["timestamp"] = now_ms
     payload["newRisk"] = True
     payload["requestSource"] = "neul-next"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import os
 from pathlib import Path
 
 
@@ -8,3 +9,5 @@ ROOT = Path(__file__).resolve().parents[1]
 root_text = str(ROOT)
 if root_text not in sys.path:
     sys.path.insert(0, root_text)
+
+os.environ.setdefault("BTB_SKIP_INITIAL_TIME_SYNC", "1")

--- a/tests/test_buy_time_sync.py
+++ b/tests/test_buy_time_sync.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+try:
+    import qrcode  # noqa: F401
+except ModuleNotFoundError:
+    sys.modules["qrcode"] = types.ModuleType("qrcode")
+
+buy_helpers = importlib.import_module("task.buy_helpers")
+
+
+class _FakeTicketState:
+    pass
+
+
+class _FakeCreateState:
+    def generate_create_ctoken(self):
+        return "fake-ctoken"
+
+
+class _FakeTimeService:
+    def current_time_ms(self):
+        return 1234567890
+
+
+def test_prepare_create_request_uses_calibrated_timestamp(monkeypatch):
+    monkeypatch.setattr(buy_helpers, "time_service", _FakeTimeService())
+    monkeypatch.setattr(
+        buy_helpers,
+        "sim_ctoken_state",
+        lambda before_state, now_ms: _FakeCreateState(),
+    )
+
+    url, payload = buy_helpers.prepare_create_request(
+        {
+            "project_id": 1,
+            "screen_id": 2,
+            "sku_id": 3,
+            "count": 1,
+            "order_type": 1,
+            "buyer_info": [],
+            "sale_start": "2026-01-01 12:00:00",
+            "username": "user",
+            "detail": "detail",
+        },
+        order_token="order-token",
+        is_hot_project=True,
+        request_result={"data": {}},
+        ticket_state=_FakeTicketState(),
+    )
+
+    assert "/api/ticket/order/createV2?project_id=1" in url
+    assert payload["timestamp"] == 1234567890
+    assert payload["ctoken"] == "fake-ctoken"
+    assert "sale_start" not in payload
+    assert "username" not in payload
+    assert "detail" not in payload

--- a/tests/test_time_util.py
+++ b/tests/test_time_util.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import datetime
+import importlib
+
+import pytest
+
+from util.TimeUtil import TimeUtil, current_time_ms
+
+
+time_util_module = importlib.import_module("util.TimeUtil")
+
+
+def test_current_time_ms_applies_local_minus_reference_offset():
+    assert current_time_ms(timeoffset=0.25, base_ms=1_000) == 750
+    assert current_time_ms(timeoffset=-0.25, base_ms=1_000) == 1_250
+
+
+def test_time_service_now_uses_calibrated_reference_time(monkeypatch):
+    monkeypatch.setattr(time_util_module.time, "time", lambda: 100.5)
+    service = TimeUtil()
+    service.set_timeoffset("0.25000")
+
+    assert service.now() == pytest.approx(100.25)
+    assert service.current_time_ms() == 100_250
+
+
+def test_compute_ntp_sample_uses_low_delay_median():
+    class Response:
+        def __init__(self, offset, delay):
+            self.offset = offset
+            self.delay = delay
+
+    class Client:
+        def __init__(self):
+            self.responses = {
+                "slow.example": Response(offset=-0.8, delay=0.5),
+                "fast-a.example": Response(offset=-0.2, delay=0.02),
+                "fast-b.example": Response(offset=-0.24, delay=0.03),
+            }
+
+        def request(self, server, version, timeout):
+            return self.responses[server]
+
+    service = TimeUtil(
+        ntp_servers=("slow.example", "fast-a.example", "fast-b.example")
+    )
+    service.client = Client()
+
+    sample = service.compute_ntp_sample(attempts_per_server=1)
+
+    assert sample is not None
+    assert sample.source == "fast-a.example"
+    assert sample.offset == pytest.approx(0.24)
+
+
+def test_compute_ntp_sample_returns_fast_primary_without_backup_calls():
+    class Response:
+        offset = -0.2
+        delay = 0.02
+
+    class Client:
+        def __init__(self):
+            self.calls = []
+
+        def request(self, server, version, timeout):
+            self.calls.append(server)
+            return Response()
+
+    service = TimeUtil(ntp_servers=("primary.example", "backup.example"))
+    client = Client()
+    service.client = client
+
+    sample = service.compute_ntp_sample()
+
+    assert sample is not None
+    assert sample.source == "primary.example"
+    assert sample.offset == pytest.approx(0.2)
+    assert client.calls == ["primary.example"]
+
+
+def test_compute_bili_time_check_parses_http_date(monkeypatch):
+    class Response:
+        status_code = 412
+        headers = {
+            "Date": "Sun, 28 Jun 2026 09:43:08 GMT",
+        }
+
+    ticks = iter([1782639788.0, 1782639788.1])
+    monkeypatch.setattr(time_util_module.time, "time", lambda: next(ticks))
+    monkeypatch.setattr(time_util_module.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        time_util_module.requests,
+        "get",
+        lambda *args, **kwargs: Response(),
+    )
+    service = TimeUtil()
+
+    check = service.compute_bili_time_check(attempts=1)
+
+    assert check is not None
+    server_second = datetime.datetime(
+        2026, 6, 28, 9, 43, 8, tzinfo=datetime.timezone.utc
+    ).timestamp()
+    assert check.offset_center == pytest.approx(
+        ((1782639788.0 + 1782639788.1) / 2) - (server_second + 0.5)
+    )
+    assert check.uncertainty_seconds == pytest.approx(0.55)

--- a/util/TimeUtil.py
+++ b/util/TimeUtil.py
@@ -1,58 +1,247 @@
+from __future__ import annotations
+
+import email.utils
+import statistics
 import time
+from dataclasses import dataclass
 
 import ntplib
 from loguru import logger
+import requests
+
+DEFAULT_NTP_SERVERS = (
+    "ntp.aliyun.com",
+    "ntp.tencent.com",
+    "cn.ntp.org.cn",
+)
 
 
 def current_time_ms(*, timeoffset: float = 0, base_ms: int | None = None) -> int:
     """
-    Return a timeoffset-aware millisecond timestamp.
+    Return a reference-time millisecond timestamp.
+
+    timeoffset uses this project's historical sign convention:
+    local wall time - reference/server wall time.
     """
     if base_ms is None:
         base_ms = int(time.time() * 1000)
-    return int(base_ms + timeoffset * 1000)
+    return int(base_ms - timeoffset * 1000)
+
+
+@dataclass(frozen=True, slots=True)
+class TimeSyncSample:
+    source: str
+    offset: float
+    delay: float
+
+
+@dataclass(frozen=True, slots=True)
+class BiliTimeCheck:
+    offset_center: float
+    delay: float
+    date_header: str
+    status_code: int
+    source_url: str
+
+    @property
+    def uncertainty_seconds(self) -> float:
+        # RFC 7231 Date has second precision, plus half the measured RTT.
+        return 0.5 + self.delay / 2
 
 
 class TimeUtil:
     # NTP服务器默认为ntp.aliyun.com, 可根据实际情况修改
-    def __init__(self, _ntp_server="ntp.aliyun.com") -> None:
-        self.ntp_server = _ntp_server
+    def __init__(
+        self,
+        _ntp_server="ntp.aliyun.com",
+        *,
+        ntp_servers: list[str] | tuple[str, ...] | None = None,
+        bili_time_url: str = "https://show.bilibili.com/api/ticket/project/listV2",
+    ) -> None:
+        self.ntp_servers = list(
+            ntp_servers
+            if ntp_servers is not None
+            else (
+                DEFAULT_NTP_SERVERS
+                if _ntp_server == "ntp.aliyun.com"
+                else (_ntp_server,)
+            )
+        )
+        self.ntp_server = self.ntp_servers[0]
+        self.bili_time_url = bili_time_url
         self.client = ntplib.NTPClient()
         self.timeoffset: float = 0
+        self.time_source = "local"
+        self.last_bili_check: BiliTimeCheck | None = None
 
     def compute_timeoffset(self) -> str:
         """
-        返回的timeoffset单位为秒
+        返回的timeoffset单位为秒，语义为：本机时间 - 参考时间。
         """
-        # NTP时间请求有可能会超时失败, 设定三次重试机会
-        response = None
-        for i in range(0, 3):
-            try:
-                response = self.client.request(self.ntp_server, version=4)
-                break
-            except Exception:
-                logger.warning("第" + str(i + 1) + "次获取NTP时间失败, 尝试重新获取")
-                if i == 2:
-                    return "error"
-                time.sleep(0.5)
-        if response is None:
+        sample = self.compute_ntp_sample()
+        if sample is None:
             logger.error("无法获取NTP时间")
             return "error"
-        # response.offset 为[NTP时钟源 - 设备时钟]的偏差, 使用时需要取反
-        return format(-(response.offset), ".5f")
+        return format(sample.offset, ".5f")
+
+    def compute_ntp_sample(
+        self,
+        *,
+        attempts_per_server: int = 1,
+        timeout: float = 1.2,
+        primary_delay_threshold: float = 0.2,
+    ) -> TimeSyncSample | None:
+        """
+        Compute local-reference offset from one or more NTP servers.
+        """
+        samples: list[TimeSyncSample] = []
+        for server_index, server in enumerate(self.ntp_servers):
+            for attempt in range(attempts_per_server):
+                try:
+                    response = self.client.request(server, version=4, timeout=timeout)
+                except Exception:
+                    logger.warning(
+                        f"{server} 第{attempt + 1}次获取NTP时间失败, 尝试重新获取"
+                    )
+                    if attempt + 1 < attempts_per_server:
+                        time.sleep(0.2)
+                    continue
+                # ntplib offset is reference - local. Keep the existing project
+                # convention: local - reference.
+                samples.append(
+                    TimeSyncSample(
+                        source=server,
+                        offset=-(response.offset),
+                        delay=float(response.delay),
+                    )
+                )
+                if (
+                    server_index == 0
+                    and response.delay <= primary_delay_threshold
+                    and len(self.ntp_servers) > 1
+                ):
+                    return samples[0]
+                break
+        if not samples:
+            return None
+        low_delay_samples = sorted(samples, key=lambda item: item.delay)[
+            : max(1, min(3, len(samples)))
+        ]
+        offset = statistics.median(item.offset for item in low_delay_samples)
+        best = min(low_delay_samples, key=lambda item: item.delay)
+        return TimeSyncSample(source=best.source, offset=offset, delay=best.delay)
+
+    def compute_bili_time_check(
+        self,
+        *,
+        url: str | None = None,
+        attempts: int = 3,
+        timeout: float = 3.0,
+    ) -> BiliTimeCheck | None:
+        """
+        Estimate Bilibili Mall gateway time from the HTTP Date header.
+
+        HTTP Date has second precision, so this is a coarse consistency check,
+        not a replacement for NTP millisecond-level synchronization.
+        """
+        source_url = url or self.bili_time_url
+        checks: list[BiliTimeCheck] = []
+        for attempt in range(attempts):
+            try:
+                t0 = time.time()
+                response = requests.get(
+                    source_url,
+                    headers={
+                        "Cache-Control": "no-cache",
+                        "Pragma": "no-cache",
+                    },
+                    timeout=timeout,
+                    allow_redirects=False,
+                )
+                t1 = time.time()
+            except Exception as exc:
+                logger.warning(f"第{attempt + 1}次获取会员购时间失败: {exc}")
+                continue
+            date_header = response.headers.get("Date")
+            if not date_header:
+                logger.warning("会员购响应缺少 Date 头，无法校验时间")
+                continue
+            try:
+                server_second = email.utils.parsedate_to_datetime(
+                    date_header
+                ).timestamp()
+            except Exception as exc:
+                logger.warning(f"无法解析会员购 Date 头: {date_header!r}, {exc}")
+                continue
+            local_midpoint = (t0 + t1) / 2
+            offset_center = local_midpoint - (server_second + 0.5)
+            checks.append(
+                BiliTimeCheck(
+                    offset_center=offset_center,
+                    delay=t1 - t0,
+                    date_header=date_header,
+                    status_code=response.status_code,
+                    source_url=source_url,
+                )
+            )
+            time.sleep(0.1)
+        if not checks:
+            return None
+        self.last_bili_check = min(checks, key=lambda item: item.delay)
+        return self.last_bili_check
 
     def set_timeoffset(self, _timeoffset: str) -> None:
         """
-        传入的timeoffset单位为秒
+        传入的timeoffset单位为秒，语义为：本机时间 - 参考时间。
         """
         if _timeoffset == "error":
             self.timeoffset = 0
+            self.time_source = "local"
             logger.warning("NTP时间同步失败, 使用本地时间")
         else:
             self.timeoffset = float(_timeoffset)
+            self.time_source = "ntp"
 
     def get_timeoffset(self) -> float:
         """
-        获取到的timeoffset单位为秒
+        获取到的timeoffset单位为秒，语义为：本机时间 - 参考时间。
         """
         return self.timeoffset
+
+    def sync_time(self, *, check_bili: bool = True) -> None:
+        sample = self.compute_ntp_sample()
+        if sample is None:
+            self.set_timeoffset("error")
+        else:
+            self.timeoffset = sample.offset
+            self.time_source = f"ntp:{sample.source}"
+            logger.info(
+                "NTP时间同步成功: source={}, offset(local-reference)={:.5f}s, "
+                "delay={:.1f}ms",
+                sample.source,
+                sample.offset,
+                sample.delay * 1000,
+            )
+        if check_bili:
+            check = self.compute_bili_time_check()
+            if check is None:
+                return
+            diff = check.offset_center - self.timeoffset
+            logger.info(
+                "会员购Date校验: offset(local-bili-center)={:.3f}s, "
+                "与当前时间源差异约{:+.3f}s, 不确定度约±{:.3f}s, "
+                "rtt={:.1f}ms, status={}",
+                check.offset_center,
+                diff,
+                check.uncertainty_seconds,
+                check.delay * 1000,
+                check.status_code,
+            )
+
+    def now(self) -> float:
+        """Return calibrated reference wall time in seconds."""
+        return time.time() - self.timeoffset
+
+    def current_time_ms(self) -> int:
+        """Return calibrated reference wall time in milliseconds."""
+        return current_time_ms(timeoffset=self.timeoffset)

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -86,7 +86,10 @@ def set_main_request(request):
 
 
 time_service = TimeUtil()
-time_service.set_timeoffset(time_service.compute_timeoffset())
+if os.environ.get("BTB_SKIP_INITIAL_TIME_SYNC") == "1":
+    time_service.set_timeoffset("0")
+else:
+    time_service.sync_time(check_bili=False)
 
 
 @dataclass


### PR DESCRIPTION
## 概述

本 PR 优化抢票前时间同步与抢票请求时间戳一致性。

原实现中，倒计时等待阶段会读取 `time_service.get_timeoffset()`，用 NTP 偏差修正抢票开始时间；但后续真正发起订单准备和创建订单时，`ticket_collection_t`、订单 payload 里的 `timestamp`、ctoken 相关时间仍然直接使用本机 `time.time()` 派生的毫秒时间。这会导致一个不一致：倒计时触发时间已经校准，但请求里携带的行为时间戳没有同步校准。

具体问题位置：

- `task/buy_helpers.py`
  - `wait_until_start()` 使用 `time_service.get_timeoffset()` 修正倒计时。
  - `prepare_create_request()` 原先调用 `current_time_ms()`，没有传入校准偏差，实际仍是本机时间。
- `task/buy.py`
  - `ticket_collection_t = current_time_ms()` 原先也是本机时间，后续会影响 ctoken 的时间模拟。
- `tab/go.py`
  - 自动填写抢票时间时，用 `time.time() + time_service.get_timeoffset()` 判断是否已过起售时间，和项目当前 offset 语义不够统一，容易继续产生符号/语义混淆。
- `util/TimeUtil.py`
  - 原先只提供 `compute_timeoffset()` / `get_timeoffset()` / `current_time_ms()` 等分散函数，缺少统一的“校准后当前时间”接口。
  - `current_time_ms()` 的 offset 方向与 `wait_until_start()` 的实际 offset 语义不一致，容易导致调用方误用。
  - NTP 校准只有单源 `ntp.aliyun.com`，且没有会员购服务器时间的交叉校验。

本 PR 的改进：

- 在 `util/TimeUtil.py` 中新增统一时间服务能力：
  - `time_service.now()`：返回校准后的参考时间秒数。
  - `time_service.current_time_ms()`：返回校准后的参考时间毫秒数。
  - 明确 `timeoffset` 的语义为“本机时间 - 参考时间”。
  - 默认优先使用 `ntp.aliyun.com` 做高精度校准。
  - 当主 NTP 源低延迟成功时直接使用，避免额外等待备用源。
  - 备用 NTP 源仅在主源失败或延迟异常时兜底。
- 新增会员购 HTTP Date 校验：
  - 抢票等待开始时低频请求会员购接口，读取响应头 `Date`。
  - 会员购 Date 只有秒级精度，因此只作为一致性校验，不作为毫秒级主时钟。
  - 日志中输出会员购 Date 与当前 NTP 时间源的大致差异和不确定度。
- 统一抢票相关时间源：
  - `wait_until_start()` 改用 `time_service.now()` 计算剩余时间。
  - `prepare_create_request()` 改用 `time_service.current_time_ms()` 填充订单 `timestamp`。
  - `buy_stream()` 中 `ticket_collection_t` 改用 `time_service.current_time_ms()`。
  - 自动填写抢票时间时的当前时间判断改用 `time_service.now()`。
- 增加测试：
  - 覆盖 offset 符号和校准后毫秒时间。
  - 覆盖主 NTP 源低延迟时不调用备用源。
  - 覆盖多 NTP 样本选择逻辑。
  - 覆盖会员购 HTTP Date 解析和不确定度计算。
  - 覆盖创建订单 payload 使用校准后的 timestamp。

测试结果：

```bash
.venv/bin/python -m pytest tests/test_time_util.py tests/test_buy_time_sync.py
```

结果：

```text
6 passed
```

### 事务

- [ ] 已与维护者在 issues 或其他平台沟通此 PR 大致内容

## 以下内容可在起草 PR 后、合并 PR 前逐步完成

### 功能

- [x] 已编写完善的配置文件字段说明（若有新增）
- [x] 已编写面向用户的新功能说明（若有必要）
- [x] 已测试新功能或更改

### 兼容性

- [x] 已处理版本兼容性
- [x] 已处理插件兼容问题

### 风险

可能导致或已知的问题:

- 会员购 HTTP Date 只有秒级精度，因此仅用于校验，不作为毫秒级主时间源。
- 抢票等待开始时会额外低频请求会员购接口进行时间校验；已限制为少量请求和短超时，避免明显增加启动延迟。
- 本地完整测试受当前 `.venv` 缺少 `qrcode`、`gradio` 影响，仅验证了本次新增/相关测试：`tests/test_time_util.py`、`tests/test_buy_time_sync.py`。
