### PR TITLE
增加 BW 乐园预约功能

### DIFF
--- a/app_cmd/bws.py
+++ b/app_cmd/bws.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import uuid
+
+from app_cmd.config.BwsConfig import BwsConfig
+
+
+def bws_cmd(args: BwsConfig) -> None:
+    from loguru import logger
+
+    from interface.bws import bws_reserve_stream
+    from util import LOG_DIR
+    from util.log.LogConfig import loguru_config
+
+    loguru_config(LOG_DIR, f"bws-{uuid.uuid4()}.log", enable_console=True)
+    try:
+        for message in bws_reserve_stream(args):
+            logger.info(message)
+    except KeyboardInterrupt:
+        logger.warning("收到 Ctrl+C，已停止 BW 乐园预约流程。")
+    except Exception as exc:
+        logger.exception(f"BW 乐园预约流程异常退出: {exc}")
+        raise

--- a/app_cmd/bws.py
+++ b/app_cmd/bws.py
@@ -1,8 +1,102 @@
 from __future__ import annotations
 
+import os
+import re
+import sys
+import threading
+import time
 import uuid
 
 from app_cmd.config.BwsConfig import BwsConfig
+
+TASK_COMPLETED_MARKER = "抢票完成后退出程序。。。。。"
+TASK_STOPPED_MARKER = "BTB_TASK_STOPPED_BY_USER"
+
+
+def _resolve_log_file_name() -> str:
+    configured_name = os.environ.get("BTB_APP_LOG_NAME", "").strip()
+    if configured_name:
+        return re.sub(r"[^\w.\-]", "_", os.path.basename(configured_name))
+    return f"bws-{uuid.uuid4()}.log"
+
+
+def _hold_terminal(message: str) -> None:
+    if os.environ.get("BTB_HOLD_TERMINAL", "") != "1":
+        return
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            print(message, flush=True)
+            msvcrt.getwch()
+            return
+        if sys.stdin and sys.stdin.isatty():
+            input(message)
+    except (EOFError, KeyboardInterrupt):
+        pass
+
+
+def _parent_pid_is_running(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    if os.name == "nt":
+        import ctypes
+
+        process_query_limited_information = 0x1000
+        synchronize = 0x00100000
+        still_active = 259
+
+        handle = ctypes.windll.kernel32.OpenProcess(
+            process_query_limited_information | synchronize,
+            False,
+            pid,
+        )
+        if not handle:
+            return False
+        try:
+            exit_code = ctypes.c_ulong()
+            if not ctypes.windll.kernel32.GetExitCodeProcess(
+                handle,
+                ctypes.byref(exit_code),
+            ):
+                return False
+            return exit_code.value == still_active
+        finally:
+            ctypes.windll.kernel32.CloseHandle(handle)
+    try:
+        os.kill(pid, 0)
+    except (OSError, SystemError):
+        return False
+    return True
+
+
+def _start_parent_watchdog(logger) -> None:
+    raw_parent_pid = os.environ.get("BTB_PARENT_PID", "").strip()
+    if not raw_parent_pid:
+        return
+    try:
+        parent_pid = int(raw_parent_pid)
+    except ValueError:
+        return
+    if parent_pid <= 0 or parent_pid == os.getpid():
+        return
+
+    def _watch_parent() -> None:
+        while True:
+            time.sleep(1.0)
+            if _parent_pid_is_running(parent_pid):
+                continue
+            try:
+                logger.warning("检测到主进程已退出，当前 BW 乐园预约子进程即将结束。")
+            except Exception:
+                pass
+            os._exit(0)
+
+    threading.Thread(
+        target=_watch_parent,
+        name="btb-bws-parent-watchdog",
+        daemon=True,
+    ).start()
 
 
 def bws_cmd(args: BwsConfig) -> None:
@@ -12,12 +106,18 @@ def bws_cmd(args: BwsConfig) -> None:
     from util import LOG_DIR
     from util.log.LogConfig import loguru_config
 
-    loguru_config(LOG_DIR, f"bws-{uuid.uuid4()}.log", enable_console=True)
+    loguru_config(LOG_DIR, _resolve_log_file_name(), enable_console=True)
+    _start_parent_watchdog(logger)
     try:
         for message in bws_reserve_stream(args):
             logger.info(message)
     except KeyboardInterrupt:
+        logger.warning(TASK_STOPPED_MARKER)
         logger.warning("收到 Ctrl+C，已停止 BW 乐园预约流程。")
+        _hold_terminal("已停止当前 BW 乐园预约流程。按任意键关闭此窗口...")
     except Exception as exc:
         logger.exception(f"BW 乐园预约流程异常退出: {exc}")
+        _hold_terminal(f"BW 乐园预约流程异常退出: {exc}\n按任意键关闭此窗口...")
         raise
+    logger.info(TASK_COMPLETED_MARKER)
+    _hold_terminal("BW 乐园预约流程已结束。按任意键关闭此窗口...")

--- a/app_cmd/cli_args.py
+++ b/app_cmd/cli_args.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
+from app_cmd.config.BwsConfig import BwsConfig
 from app_cmd.config.BuyConfig import BuyConfig
 
 
@@ -47,3 +48,4 @@ class TickerCliArgs:
 
 
 BuyCliArgs = BuyConfig
+BwsCliArgs = BwsConfig

--- a/app_cmd/config/BwsConfig.py
+++ b/app_cmd/config/BwsConfig.py
@@ -1,0 +1,111 @@
+from dataclasses import dataclass
+from typing import ClassVar
+
+from app_cmd.config.ConfigBasic import BasicConfig, config_field, str_to_bool
+
+
+@dataclass(slots=True)
+class BwsConfig(BasicConfig):
+    """BW park reservation runtime configuration."""
+
+    reserve_id: int = config_field(
+        0,
+        env="BTB_BWS_RESERVE_ID",
+        runtime="reserve_id",
+        cli="--reserve-id",
+        cast=int,
+    )
+    """BW park reservation activity id."""
+
+    reserve_dates: str = config_field(
+        "",
+        env="BTB_BWS_RESERVE_DATES",
+        runtime="reserve_dates",
+        cli="--reserve-dates",
+    )
+    """Comma-separated dates, for example 20260710,20260711,20260712."""
+
+    reserve_date: str = config_field(
+        "",
+        env="BTB_BWS_RESERVE_DATE",
+        runtime="reserve_date",
+        cli="--reserve-date",
+    )
+    """Target date used to pick the activated ticket number."""
+
+    reserve_type: int = config_field(
+        -1,
+        env="BTB_BWS_RESERVE_TYPE",
+        runtime="reserve_type",
+        cli="--reserve-type",
+        cast=int,
+    )
+    """Reservation type: -1 for all, 0 for activities, 1 for goods."""
+
+    year: str = config_field(
+        "",
+        env="BTB_BWS_YEAR",
+        runtime="year",
+        cli="--year",
+    )
+    """Optional BW API year value, for example 202601."""
+
+    time_start: str = config_field(
+        "",
+        env="BTB_BWS_TIME_START",
+        runtime="time_start",
+        cli="--time-start",
+    )
+    """Optional scheduled start time overriding activity reserve_begin_time."""
+
+    start_delay_ms: int = config_field(
+        0,
+        env="BTB_BWS_START_DELAY_MS",
+        runtime="start_delay_ms",
+        cli="--start-delay-ms",
+        cast=int,
+    )
+    """Delay added to the scheduled start time; negative values start early."""
+
+    interval: int = config_field(
+        300,
+        env="BTB_BWS_INTERVAL",
+        runtime="interval",
+        cli="--interval",
+        cast=int,
+    )
+    """Retry interval in milliseconds."""
+
+    retry_limit: int = config_field(
+        0,
+        env="BTB_BWS_RETRY_LIMIT",
+        runtime="retry_limit",
+        cli="--retry-limit",
+        cast=int,
+    )
+    """Maximum submit attempts; 0 means retry until terminal result."""
+
+    cookies_path: str = config_field(
+        "",
+        env="BTB_BWS_COOKIES_PATH",
+        runtime="cookies_path",
+        cli="--cookies-path",
+    )
+    """Cookie store path. Defaults to the app's existing login cookie store."""
+
+    https_proxys: str = config_field(
+        "none",
+        env="BTB_HTTPS_PROXYS",
+        runtime="https_proxys",
+        cli="--https-proxys",
+    )
+    """Proxy string or comma-separated proxy pool."""
+
+    show_detail: bool = config_field(
+        True,
+        env="BTB_BWS_SHOW_DETAIL",
+        runtime="show_detail",
+        cast=str_to_bool,
+        cli_false="--no-show-detail",
+    )
+    """Print selected activity and ticket details before submitting."""

--- a/app_cmd/config/BwsConfig.py
+++ b/app_cmd/config/BwsConfig.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import ClassVar
 
 from app_cmd.config.ConfigBasic import BasicConfig, config_field, str_to_bool
 

--- a/app_cmd/ticker.py
+++ b/app_cmd/ticker.py
@@ -23,6 +23,7 @@ def shutdown_app_process(delay_seconds: float = 1.0) -> None:
 
 def ticker_cmd(args: TickerCliArgs):
     from tab.go import go_start_tab
+    from tab.bws import bws_tab
     from tab.config import go_settings_tab
     from tab.log import log_tab, refresh_log_panel, refresh_task_panel
     from tab.problems import problems_tab
@@ -185,6 +186,8 @@ def ticker_cmd(args: TickerCliArgs):
                         load_go_start_configs,
                         go_start_load_outputs,
                     ) = go_start_tab()
+                with gr.Tab("BW乐园预约", id="bws", elem_id="btb-tab-bws"):
+                    load_bws_tab, bws_tab_load_outputs = bws_tab()
                 with gr.Tab(
                     "高级设置",
                     id="advanced",
@@ -214,6 +217,12 @@ def ticker_cmd(args: TickerCliArgs):
         demo.load(
             fn=load_login_tab,
             outputs=login_tab_load_outputs,
+            show_progress="hidden",
+            queue=False,
+        )
+        demo.load(
+            fn=load_bws_tab,
+            outputs=bws_tab_load_outputs,
             show_progress="hidden",
             queue=False,
         )

--- a/interface/__init__.py
+++ b/interface/__init__.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
 from .auth import get_login_state, login_with_cookies, poll_qr_login, start_qr_login
+from .bws import (
+    fetch_bws_my_reservations,
+    fetch_bws_reserve_info,
+    get_bws_reserve_context,
+    run_bws_reserve_sync,
+    verify_bws_ticket_activation,
+)
 from .config import (
     RuntimeOptions,
     build_runtime_options,
@@ -39,6 +46,8 @@ __all__ = [
     "build_ticket_config_from_selection",
     "cancel_managed_buy",
     "delete_managed_buy",
+    "fetch_bws_my_reservations",
+    "fetch_bws_reserve_info",
     "fetch_addresses",
     "fetch_buyers",
     "fetch_project_detail",
@@ -47,6 +56,7 @@ __all__ = [
     "format_ticket_search_results_text",
     "generate_ticket_config",
     "get_login_state",
+    "get_bws_reserve_context",
     "load_ticket_config",
     "login_with_cookies",
     "managed_task_status",
@@ -54,6 +64,7 @@ __all__ = [
     "normalize_time_start",
     "poll_qr_login",
     "run_buy_sync",
+    "run_bws_reserve_sync",
     "save_ticket_config",
     "search_tickets",
     "start_qr_login",
@@ -61,4 +72,5 @@ __all__ = [
     "start_managed_buy",
     "task_status",
     "validate_config",
+    "verify_bws_ticket_activation",
 ]

--- a/interface/bws.py
+++ b/interface/bws.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import datetime
+import random
 import re
 import time
 from collections.abc import Generator
@@ -14,7 +15,7 @@ from urllib.parse import urljoin
 import requests
 
 from app_cmd.config.BwsConfig import BwsConfig
-from interface.common import _cookie_store_path, _resolve_cookie_list
+from interface.common import _resolve_cookie_list
 from task.buy_helpers import wait_until_start
 
 BWS_RESERVE_BASE_URL = "https://api.bilibili.com/x/activity/bws/online/park/reserve"
@@ -33,17 +34,45 @@ BWS_RESERVE_DATES_BY_YEAR = {
     "202501": "20250711,20250712,20250713",
     "202601": DEFAULT_BWS_RESERVE_DATES,
 }
-TERMINAL_CODES = {
+OFFICIAL_TERMINAL_CODES = {
     0: "预约成功",
     75574: "预约已被抢空",
-    76674: "预约已达上限",
+    76647: "您的预约数已达上限",
 }
-RETRYABLE_CODES = {
+OFFICIAL_RETRYABLE_CODES = {
     -702: "请求频率太快",
-    75637: "尚未开放",
+    412: "当前预约火爆，请稍后重试",
     76650: "操作频繁",
+    76651: "当前预约火爆，请稍后重试",
     429: "请求被限流",
 }
+HISTORICAL_TERMINAL_CODES = {
+    76674: "预约已达上限",
+}
+HISTORICAL_RETRYABLE_CODES = {
+    75637: "尚未开放",
+}
+TERMINAL_CODES = {**HISTORICAL_TERMINAL_CODES, **OFFICIAL_TERMINAL_CODES}
+RETRYABLE_CODES = {**HISTORICAL_RETRYABLE_CODES, **OFFICIAL_RETRYABLE_CODES}
+UNKNOWN_CODE_MARKER = "!!! 【未知返回码】"
+
+
+def _bws_code_meaning(code: int) -> str:
+    return (
+        OFFICIAL_TERMINAL_CODES.get(code)
+        or OFFICIAL_RETRYABLE_CODES.get(code)
+        or HISTORICAL_TERMINAL_CODES.get(code)
+        or HISTORICAL_RETRYABLE_CODES.get(code)
+        or "未知返回码（按可重试处理）"
+    )
+
+
+def _is_known_bws_code(code: int) -> bool:
+    return code in TERMINAL_CODES or code in RETRYABLE_CODES
+
+
+def _is_terminal_bws_code(code: int) -> bool:
+    return code in TERMINAL_CODES
 
 
 @dataclass(frozen=True)
@@ -345,6 +374,8 @@ class BwsApiClient:
                 "csrf": self.csrf_token,
                 "inter_reserve_id": int(reserve_id),
                 "year": year or DEFAULT_BWS_YEAR,
+                "ts": int(time.time() * 1000),
+                "_": random.randint(10000, 99999),
             },
             cookies=self.cookie_dict,
             timeout=self.timeout,
@@ -454,6 +485,43 @@ def _activity_date(activity: dict[str, Any], fallback: str) -> str:
     return datetime.datetime.fromtimestamp(start_time).strftime("%Y%m%d")
 
 
+def _is_vip_ticket(activity: dict[str, Any]) -> bool:
+    return int(activity.get("is_vip_ticket") or 0) == 1
+
+
+def _is_user_vip_for_date(info: dict[str, Any], date: str) -> bool:
+    ticket_info_map = info.get("user_ticket_info")
+    if not isinstance(ticket_info_map, dict):
+        return False
+    ticket_info = ticket_info_map.get(_normalize_date(date))
+    if not isinstance(ticket_info, dict):
+        return False
+    return bool(ticket_info.get("is_vip"))
+
+
+def effective_bws_reserve_begin_time(
+    activity: dict[str, Any],
+    ticket_info: dict[str, Any] | None = None,
+) -> int:
+    try:
+        reserve_time = int(activity.get("reserve_begin_time") or 0)
+    except (TypeError, ValueError):
+        reserve_time = 0
+    if not _is_vip_ticket(activity):
+        return reserve_time
+    if isinstance(ticket_info, dict) and ticket_info.get("is_vip"):
+        return reserve_time
+    next_reserve = activity.get("next_reserve")
+    if isinstance(next_reserve, dict):
+        try:
+            next_reserve_time = int(next_reserve.get("reserve_begin_time") or 0)
+        except (TypeError, ValueError):
+            next_reserve_time = 0
+        if next_reserve_time > 0:
+            return next_reserve_time
+    return reserve_time
+
+
 def _reserved_activity_ids(my_reservations: dict[str, Any] | None) -> set[int]:
     reserve_list = (
         my_reservations.get("reserve_list")
@@ -533,7 +601,9 @@ def _format_timestamp(value: Any) -> str:
 def _configured_start_time(config: BwsConfig, activity: dict[str, Any]) -> str:
     if config.time_start.strip():
         return config.time_start.strip()
-    reserve_begin_time = activity.get("reserve_begin_time")
+    reserve_begin_time = activity.get("effective_reserve_begin_time")
+    if reserve_begin_time is None:
+        reserve_begin_time = activity.get("reserve_begin_time")
     try:
         timestamp = int(reserve_begin_time) + (int(config.start_delay_ms) / 1000.0)
     except (TypeError, ValueError):
@@ -573,14 +643,25 @@ def bws_reserve_stream(config: BwsConfig) -> Generator[str, None, None]:
     ticket_info = verified["ticket_info"]
     ticket_no = verified["ticket_no"]
     target_date = verified["date"]
+    activity["effective_reserve_begin_time"] = effective_bws_reserve_begin_time(
+        activity,
+        ticket_info,
+    )
     title = _activity_title(activity)
     yield "验权通过: 日期 {0} 已激活门票 {1}".format(target_date, ticket_no)
     if config.show_detail:
         yield "目标项目: {0} | ID={1} | 预约开始={2}".format(
             title,
             config.reserve_id,
-            _format_timestamp(activity.get("reserve_begin_time")),
+            _format_timestamp(activity.get("effective_reserve_begin_time")),
         )
+        if _is_vip_ticket(activity):
+            vip_message = (
+                "VIP 优先购项目，当前票种为 VIP，使用 VIP 预约时间"
+                if ticket_info.get("is_vip")
+                else "VIP 优先购项目，当前票种非 VIP，使用普通预约时间"
+            )
+            yield vip_message
         yield "门票信息: {0} - {1}".format(
             ticket_info.get("screen_name", ""),
             ticket_info.get("sku_name", ""),
@@ -608,13 +689,19 @@ def bws_reserve_stream(config: BwsConfig) -> Generator[str, None, None]:
         )
         code = int(result.get("code", result.get("errno", -1)) or 0)
         message = str(result.get("message", result.get("msg", "")) or "")
+        if not _is_known_bws_code(code):
+            yield "{0} 检测到未标记 BW 返回码: [{1}]，已自动按可重试处理。完整返回: {2}".format(
+                UNKNOWN_CODE_MARKER,
+                code,
+                result,
+            )
         yield "第 {0} 次预约结果: [{1}] {2} | {3}".format(
             attempt,
             code,
-            TERMINAL_CODES.get(code) or RETRYABLE_CODES.get(code) or "未知状态",
+            _bws_code_meaning(code),
             message or result,
         )
-        if code in TERMINAL_CODES:
+        if _is_terminal_bws_code(code):
             return
         if code == 412:
             time.sleep(max(interval_seconds, 180.0))

--- a/interface/bws.py
+++ b/interface/bws.py
@@ -1,0 +1,670 @@
+from __future__ import annotations
+
+import copy
+import datetime
+import re
+import time
+from collections.abc import Generator
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin
+
+import requests
+
+from app_cmd.config.BwsConfig import BwsConfig
+from interface.common import _cookie_store_path, _resolve_cookie_list
+from task.buy_helpers import wait_until_start
+
+BWS_RESERVE_BASE_URL = "https://api.bilibili.com/x/activity/bws/online/park/reserve"
+BWS_MY_RESERVE_URL = "https://api.bilibili.com/x/activity/bws/online/park/myreserve"
+BWS_NAV_URL = "https://api.bilibili.com/x/web-interface/nav"
+BWS_OFFICIAL_URL = "https://bw.bilibili.com/"
+BWS_EVENT_PAGE_TEMPLATE = "https://www.bilibili.com/blackboard/era/bws{event_year}-event.html"
+BWS_REFERER = "https://www.bilibili.com/blackboard/era/bws2025-event.html?native.theme=1&night=0"
+BWS_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/540.36 (KHTML, like Gecko)"
+)
+DEFAULT_BWS_YEAR = "202601"
+DEFAULT_BWS_RESERVE_DATES = "20260710,20260711,20260712"
+BWS_RESERVE_DATES_BY_YEAR = {
+    "202501": "20250711,20250712,20250713",
+    "202601": DEFAULT_BWS_RESERVE_DATES,
+}
+TERMINAL_CODES = {
+    0: "预约成功",
+    75574: "预约已被抢空",
+    76674: "预约已达上限",
+}
+RETRYABLE_CODES = {
+    -702: "请求频率太快",
+    75637: "尚未开放",
+    76650: "操作频繁",
+    429: "请求被限流",
+}
+
+
+@dataclass(frozen=True)
+class BwsOfficialSchedule:
+    year: str
+    reserve_dates: str
+    event_year: int
+    source_url: str
+
+
+def _http_get_text(url: str, *, timeout: float = 10.0) -> str:
+    response = requests.get(
+        url,
+        headers={"User-Agent": BWS_USER_AGENT},
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    return response.text
+
+
+def _extract_js_urls(html: str, base_url: str) -> list[str]:
+    urls: list[str] = []
+    for src in re.findall(r"<script[^>]+src=[\"']([^\"']+\.js)[\"']", html):
+        url = urljoin(base_url, src)
+        if url not in urls:
+            urls.append(url)
+    return urls
+
+
+def _extract_event_year(text: str) -> int | None:
+    candidates = [int(item) for item in re.findall(r"\bBW\s*(20\d{2})\b", text, re.I)]
+    if not candidates:
+        candidates = [
+            int(item) for item in re.findall(r"bws?(20\d{2})(?:[-_/]|event)", text, re.I)
+        ]
+    return max(candidates) if candidates else None
+
+
+def _extract_act_days(text: str) -> list[str]:
+    days: list[str] = []
+    for match in re.finditer(r"ACT_DAYS\s*=\s*\[([^\]]+)\]", text):
+        days.extend(re.findall(r"[\"'](20\d{6})[\"']", match.group(1)))
+    if not days:
+        days.extend(re.findall(r"[\"'](20\d{6})[\"']", text))
+    unique: list[str] = []
+    for day in days:
+        if day not in unique:
+            unique.append(day)
+    return unique
+
+
+def _extract_bws_year_param(text: str, event_year: int) -> str:
+    candidates = re.findall(r"isPre\?\d{6}:(20\d{4})", text)
+    candidates.extend(re.findall(r"\byear\s*[:=]\s*[\"']?(20\d{4})", text))
+    prefix = str(event_year)
+    for candidate in candidates:
+        if candidate.startswith(prefix):
+            return candidate
+    return f"{event_year}01"
+
+
+def _schedule_from_event_page(event_year: int) -> BwsOfficialSchedule:
+    page_url = BWS_EVENT_PAGE_TEMPLATE.format(event_year=event_year)
+    html = _http_get_text(page_url)
+    combined = [html]
+    for js_url in _extract_js_urls(html, page_url):
+        try:
+            combined.append(_http_get_text(js_url, timeout=20.0))
+        except Exception:
+            continue
+    text = "\n".join(combined)
+    days = _extract_act_days(text)
+    if not days:
+        raise RuntimeError("official BW event page did not expose ACT_DAYS")
+    year = _extract_bws_year_param(text, event_year)
+    return BwsOfficialSchedule(
+        year=year,
+        reserve_dates=",".join(days),
+        event_year=event_year,
+        source_url=page_url,
+    )
+
+
+def _schedule_from_homepage_dates(event_year: int, html: str) -> BwsOfficialSchedule:
+    combined = [html]
+    for js_url in _extract_js_urls(html, BWS_OFFICIAL_URL):
+        try:
+            combined.append(_http_get_text(js_url, timeout=20.0))
+        except Exception:
+            continue
+    text = "\n".join(combined)
+    raw_days = re.findall(r"date\s*:\s*[\"'](\d{1,2})\.(\d{1,2})[\"']", text)
+    days: list[str] = []
+    for month, day in raw_days:
+        try:
+            date_value = datetime.date(event_year, int(month), int(day))
+        except ValueError:
+            continue
+        normalized = date_value.strftime("%Y%m%d")
+        if normalized not in days:
+            days.append(normalized)
+    if not days:
+        raise RuntimeError("official BW homepage did not expose display dates")
+    return BwsOfficialSchedule(
+        year=f"{event_year}01",
+        reserve_dates=",".join(days),
+        event_year=event_year,
+        source_url=BWS_OFFICIAL_URL,
+    )
+
+
+@lru_cache(maxsize=8)
+def discover_bws_official_schedule(
+    year_hint: str = "",
+) -> BwsOfficialSchedule:
+    year_hint = str(year_hint or "").strip()
+    event_year = None
+    if len(year_hint) >= 4 and year_hint[:4].isdigit():
+        event_year = int(year_hint[:4])
+    if event_year is None:
+        html = _http_get_text(BWS_OFFICIAL_URL)
+        event_year = _extract_event_year(html)
+        if event_year is None:
+            raise RuntimeError("could not detect latest BW year from official site")
+        try:
+            return _schedule_from_event_page(event_year)
+        except Exception:
+            return _schedule_from_homepage_dates(event_year, html)
+    return _schedule_from_event_page(event_year)
+
+
+def default_bws_year(now: datetime.datetime | None = None) -> str:
+    try:
+        return discover_bws_official_schedule().year
+    except Exception:
+        return DEFAULT_BWS_YEAR
+
+
+def infer_bws_reserve_dates(year: str = "") -> str:
+    year_text = str(year or "").strip()
+    if year_text:
+        if year_text in BWS_RESERVE_DATES_BY_YEAR:
+            return BWS_RESERVE_DATES_BY_YEAR[year_text]
+        try:
+            return discover_bws_official_schedule(year_text).reserve_dates
+        except Exception:
+            return DEFAULT_BWS_RESERVE_DATES
+    try:
+        return discover_bws_official_schedule().reserve_dates
+    except Exception:
+        return DEFAULT_BWS_RESERVE_DATES
+
+
+def resolve_bws_reserve_dates(reserve_dates: str = "", year: str = "") -> str:
+    dates = str(reserve_dates or "").replace("，", ",").strip()
+    return dates or infer_bws_reserve_dates(year)
+
+
+def _cookie_value(cookies: list[dict[str, Any]] | None, name: str) -> str | None:
+    for cookie in cookies or []:
+        if cookie.get("name") == name:
+            value = cookie.get("value")
+            return str(value) if value is not None else None
+    return None
+
+
+def _cookies_to_dict(cookies: list[dict[str, Any]] | None) -> dict[str, str]:
+    cookie_dict: dict[str, str] = {}
+    for cookie in cookies or []:
+        name = cookie.get("name")
+        value = cookie.get("value")
+        if name and value is not None:
+            cookie_dict[str(name)] = str(value)
+    return cookie_dict
+
+
+def _resolve_bws_cookies(
+    *,
+    cookies: list[dict[str, Any]] | dict[str, Any] | None = None,
+    cookies_path: str | Path | None = None,
+) -> list[dict[str, Any]]:
+    cookie_list = _resolve_cookie_list(cookies, cookies_path=cookies_path)
+    if not cookie_list:
+        raise RuntimeError("当前未登录，请先在本体完成登录")
+    return cookie_list
+
+
+def _response_json(response: requests.Response) -> dict[str, Any]:
+    try:
+        payload = response.json()
+    except Exception as exc:
+        raise RuntimeError(
+            f"BW 乐园接口返回非 JSON 响应，HTTP 状态：{response.status_code}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError("BW 乐园接口返回格式异常")
+    return payload
+
+
+def _raise_api_error(payload: dict[str, Any], *, action: str) -> None:
+    code = int(payload.get("code", payload.get("errno", -1)) or 0)
+    if code == 0:
+        return
+    message = payload.get("message", payload.get("msg", "未知错误"))
+    raise RuntimeError(f"{action}失败: [{code}] {message}")
+
+
+class BwsApiClient:
+    """Starsbon_bws_ticket style BW park API client."""
+
+    def __init__(self, cookies: list[dict[str, Any]], *, timeout: float = 10.0):
+        self.cookies = cookies
+        self.cookie_dict = _cookies_to_dict(cookies)
+        self.csrf_token = self.cookie_dict.get("bili_jct", "")
+        if not self.csrf_token:
+            raise RuntimeError("Cookie 中缺少 bili_jct，无法调用 BW 乐园预约接口")
+        self.timeout = timeout
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "User-Agent": BWS_USER_AGENT,
+                "accept": "*/*",
+                "accept-language": "zh-CN,zh;q=0.9",
+                "referer": BWS_REFERER,
+            }
+        )
+
+    def get_username(self) -> str:
+        try:
+            response = self.session.get(
+                BWS_NAV_URL,
+                cookies=self.cookie_dict,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            payload = _response_json(response)
+            data = payload.get("data")
+            if payload.get("code") == 0 and isinstance(data, dict):
+                username = str(data.get("uname") or "").strip()
+                if username and data.get("isLogin"):
+                    return username
+        except Exception:
+            pass
+        return "未登录"
+
+    def get_reservation_info(
+        self,
+        *,
+        reserve_dates: str = DEFAULT_BWS_RESERVE_DATES,
+        reserve_type: int = -1,
+        year: str = DEFAULT_BWS_YEAR,
+    ) -> dict[str, Any]:
+        response = self.session.get(
+            f"{BWS_RESERVE_BASE_URL}/info",
+            params={
+                "csrf": self.csrf_token,
+                "reserve_date": reserve_dates,
+                "reserve_type": int(reserve_type),
+                "year": year or DEFAULT_BWS_YEAR,
+            },
+            cookies=self.cookie_dict,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        payload = _response_json(response)
+        _raise_api_error(payload, action="获取 BW 乐园预约信息")
+        data = payload.get("data")
+        if not isinstance(data, dict):
+            raise RuntimeError("BW 乐园预约信息为空")
+        return data
+
+    def get_my_reservations(self, *, year: str = DEFAULT_BWS_YEAR) -> dict[str, Any]:
+        response = self.session.get(
+            BWS_MY_RESERVE_URL,
+            params={
+                "csrf": self.csrf_token,
+                "year": year or DEFAULT_BWS_YEAR,
+            },
+            cookies=self.cookie_dict,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        payload = _response_json(response)
+        _raise_api_error(payload, action="获取我的 BW 乐园预约")
+        data = payload.get("data")
+        return data if isinstance(data, dict) else {}
+
+    def make_reservation(
+        self,
+        *,
+        ticket_no: str,
+        reserve_id: int,
+        year: str = DEFAULT_BWS_YEAR,
+    ) -> dict[str, Any]:
+        response = self.session.post(
+            f"{BWS_RESERVE_BASE_URL}/do",
+            data={
+                "ticket_no": ticket_no,
+                "csrf": self.csrf_token,
+                "inter_reserve_id": int(reserve_id),
+                "year": year or DEFAULT_BWS_YEAR,
+            },
+            cookies=self.cookie_dict,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        return _response_json(response)
+
+
+def _make_bws_client(
+    *,
+    cookies: list[dict[str, Any]] | dict[str, Any] | None = None,
+    cookies_path: str | Path | None = None,
+) -> BwsApiClient:
+    cookie_list = _resolve_bws_cookies(cookies=cookies, cookies_path=cookies_path)
+    return BwsApiClient(cookie_list)
+
+
+def fetch_bws_reserve_info(
+    *,
+    reserve_dates: str = "",
+    reserve_type: int = -1,
+    year: str = "",
+    cookies: list[dict[str, Any]] | dict[str, Any] | None = None,
+    cookies_path: str | Path | None = None,
+    request: BwsApiClient | None = None,
+) -> dict[str, Any]:
+    year = year or default_bws_year()
+    reserve_dates = resolve_bws_reserve_dates(reserve_dates, year)
+    client = request or _make_bws_client(cookies=cookies, cookies_path=cookies_path)
+    return client.get_reservation_info(
+        reserve_dates=reserve_dates,
+        reserve_type=reserve_type,
+        year=year,
+    )
+
+
+def fetch_bws_my_reservations(
+    *,
+    year: str = "",
+    cookies: list[dict[str, Any]] | dict[str, Any] | None = None,
+    cookies_path: str | Path | None = None,
+    request: BwsApiClient | None = None,
+) -> dict[str, Any]:
+    client = request or _make_bws_client(cookies=cookies, cookies_path=cookies_path)
+    return client.get_my_reservations(year=year or default_bws_year())
+
+
+def _normalize_date(value: str) -> str:
+    return str(value or "").replace("-", "").strip()
+
+
+def _iter_dates_from_info(info: dict[str, Any]) -> list[str]:
+    dates: list[str] = []
+    for key in ("user_reserve_info", "user_ticket_info", "reserve_list"):
+        value = info.get(key)
+        if isinstance(value, dict):
+            for date in value.keys():
+                normalized = _normalize_date(date)
+                if normalized and normalized not in dates:
+                    dates.append(normalized)
+    return dates
+
+
+def _ticket_days(info: dict[str, Any]) -> list[str]:
+    user_reserve_info = info.get("user_reserve_info")
+    if isinstance(user_reserve_info, dict) and user_reserve_info:
+        return [_normalize_date(date) for date in user_reserve_info.keys()]
+    user_ticket_info = info.get("user_ticket_info")
+    if isinstance(user_ticket_info, dict) and user_ticket_info:
+        return [_normalize_date(date) for date in user_ticket_info.keys()]
+    return _iter_dates_from_info(info)
+
+
+def _find_activity(info: dict[str, Any], reserve_id: int) -> tuple[str, dict[str, Any]]:
+    reserve_list = info.get("reserve_list")
+    if not isinstance(reserve_list, dict):
+        raise RuntimeError("BW 乐园预约信息缺少 reserve_list")
+    ticket_dates = _ticket_days(info)
+    searched_dates: set[str] = set()
+    for date in ticket_dates:
+        searched_dates.add(date)
+        activities = reserve_list.get(date, [])
+        if not isinstance(activities, list):
+            continue
+        for activity in activities:
+            if not isinstance(activity, dict):
+                continue
+            if int(activity.get("reserve_id", 0) or 0) == int(reserve_id):
+                return date, copy.deepcopy(activity)
+    for date, activities in reserve_list.items():
+        normalized_date = _normalize_date(date)
+        if normalized_date in searched_dates or not isinstance(activities, list):
+            continue
+        for activity in activities:
+            if not isinstance(activity, dict):
+                continue
+            if int(activity.get("reserve_id", 0) or 0) == int(reserve_id):
+                return normalized_date, copy.deepcopy(activity)
+    raise RuntimeError(f"未找到预约项目 reserve_id={reserve_id}")
+
+
+def _activity_date(activity: dict[str, Any], fallback: str) -> str:
+    try:
+        start_time = int(activity.get("act_begin_time"))
+    except (TypeError, ValueError):
+        return fallback
+    return datetime.datetime.fromtimestamp(start_time).strftime("%Y%m%d")
+
+
+def _reserved_activity_ids(my_reservations: dict[str, Any] | None) -> set[int]:
+    reserve_list = (
+        my_reservations.get("reserve_list")
+        if isinstance(my_reservations, dict)
+        else None
+    )
+    if not isinstance(reserve_list, dict):
+        return set()
+    ids: set[int] = set()
+    for activities in reserve_list.values():
+        if not isinstance(activities, list):
+            continue
+        for activity in activities:
+            if not isinstance(activity, dict):
+                continue
+            try:
+                ids.add(int(activity.get("reserve_id")))
+            except (TypeError, ValueError):
+                continue
+    return ids
+
+
+def verify_bws_ticket_activation(
+    info: dict[str, Any],
+    *,
+    reserve_id: int,
+    reserve_date: str = "",
+) -> dict[str, Any]:
+    activity_day, activity = _find_activity(info, reserve_id)
+    target_date = _normalize_date(reserve_date) or _activity_date(activity, activity_day)
+    ticket_info_map = info.get("user_ticket_info")
+    if not isinstance(ticket_info_map, dict):
+        raise RuntimeError("账号未返回 BW 门票信息，请确认已登录并已激活预约日期门票")
+    ticket_info = ticket_info_map.get(target_date)
+    if not isinstance(ticket_info, dict):
+        available = ", ".join(_ticket_days(info)) or "无"
+        raise RuntimeError(
+            "当前账号没有激活目标预约日期的 BW 门票: {0}。可用日期: {1}".format(
+                target_date,
+                available,
+            )
+        )
+    ticket_no = str(ticket_info.get("ticket") or "").strip()
+    if not ticket_no:
+        raise RuntimeError(f"目标日期 {target_date} 的 BW 门票未返回有效电子票号")
+    return {
+        "date": target_date,
+        "ticket_no": ticket_no,
+        "ticket_info": copy.deepcopy(ticket_info),
+        "activity": activity,
+    }
+
+
+def submit_bws_reservation(
+    *,
+    reserve_id: int,
+    ticket_no: str,
+    request: BwsApiClient,
+    year: str = DEFAULT_BWS_YEAR,
+) -> dict[str, Any]:
+    return request.make_reservation(ticket_no=ticket_no, reserve_id=reserve_id, year=year)
+
+
+def _activity_title(activity: dict[str, Any]) -> str:
+    title = activity.get("act_title") or activity.get("title") or ""
+    return str(title).replace("\n", "").strip() or "未知项目"
+
+
+def _format_timestamp(value: Any) -> str:
+    try:
+        timestamp = int(value)
+    except (TypeError, ValueError):
+        return "-"
+    return datetime.datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _configured_start_time(config: BwsConfig, activity: dict[str, Any]) -> str:
+    if config.time_start.strip():
+        return config.time_start.strip()
+    reserve_begin_time = activity.get("reserve_begin_time")
+    try:
+        timestamp = int(reserve_begin_time) + (int(config.start_delay_ms) / 1000.0)
+    except (TypeError, ValueError):
+        return ""
+    return datetime.datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def bws_reserve_stream(config: BwsConfig) -> Generator[str, None, None]:
+    if int(config.reserve_id or 0) <= 0:
+        raise ValueError("reserve_id is required")
+    year = config.year or default_bws_year()
+    reserve_dates = resolve_bws_reserve_dates(
+        config.reserve_dates or config.reserve_date,
+        year,
+    )
+    client = _make_bws_client(cookies_path=config.cookies_path or None)
+    yield f"当前账号: {client.get_username()}"
+
+    info = client.get_reservation_info(
+        reserve_dates=reserve_dates,
+        reserve_type=config.reserve_type,
+        year=year,
+    )
+    try:
+        reserved_ids = _reserved_activity_ids(client.get_my_reservations(year=year))
+    except Exception:
+        reserved_ids = set()
+    if int(config.reserve_id) in reserved_ids:
+        yield f"该项目 ID={config.reserve_id} 已在当前账号的预约列表中，停止重复预约"
+        return
+    verified = verify_bws_ticket_activation(
+        info,
+        reserve_id=config.reserve_id,
+        reserve_date=config.reserve_date,
+    )
+    activity = verified["activity"]
+    ticket_info = verified["ticket_info"]
+    ticket_no = verified["ticket_no"]
+    target_date = verified["date"]
+    title = _activity_title(activity)
+    yield "验权通过: 日期 {0} 已激活门票 {1}".format(target_date, ticket_no)
+    if config.show_detail:
+        yield "目标项目: {0} | ID={1} | 预约开始={2}".format(
+            title,
+            config.reserve_id,
+            _format_timestamp(activity.get("reserve_begin_time")),
+        )
+        yield "门票信息: {0} - {1}".format(
+            ticket_info.get("screen_name", ""),
+            ticket_info.get("sku_name", ""),
+        )
+
+    start_time = _configured_start_time(config, activity)
+    if start_time:
+        for wait_state in wait_until_start(start_time):
+            message = wait_state.get("message")
+            countdown = wait_state.get("countdown")
+            if message:
+                yield str(message)
+            elif countdown:
+                yield f"距离开始还有 {countdown}"
+
+    retry_limit = max(0, int(config.retry_limit or 0))
+    interval_seconds = max(0, int(config.interval or 0)) / 1000.0
+    attempt = 0
+    while retry_limit <= 0 or attempt < retry_limit:
+        attempt += 1
+        result = client.make_reservation(
+            reserve_id=config.reserve_id,
+            ticket_no=ticket_no,
+            year=year,
+        )
+        code = int(result.get("code", result.get("errno", -1)) or 0)
+        message = str(result.get("message", result.get("msg", "")) or "")
+        yield "第 {0} 次预约结果: [{1}] {2} | {3}".format(
+            attempt,
+            code,
+            TERMINAL_CODES.get(code) or RETRYABLE_CODES.get(code) or "未知状态",
+            message or result,
+        )
+        if code in TERMINAL_CODES:
+            return
+        if code == 412:
+            time.sleep(max(interval_seconds, 180.0))
+            continue
+        if interval_seconds > 0:
+            time.sleep(interval_seconds)
+    yield f"已达到最大重试次数 {retry_limit}，预约未成功"
+
+
+def run_bws_reserve_sync(config: BwsConfig | dict[str, Any]) -> dict[str, Any]:
+    if isinstance(config, dict):
+        config = BwsConfig.from_mapping(config, source_name="runtime")
+    logs: list[str] = []
+    status = "completed"
+    try:
+        for message in bws_reserve_stream(config):
+            logs.append(message)
+            if "预约成功" in message:
+                status = "succeeded"
+        return {"ok": status == "succeeded", "status": status, "logs": logs}
+    except Exception as exc:
+        logs.append(str(exc))
+        return {"ok": False, "status": "failed", "error": str(exc), "logs": logs}
+
+
+def get_bws_reserve_context(
+    *,
+    reserve_dates: str = "",
+    reserve_type: int = -1,
+    year: str = "",
+    cookies: list[dict[str, Any]] | dict[str, Any] | None = None,
+    cookies_path: str | Path | None = None,
+) -> dict[str, Any]:
+    year = year or default_bws_year()
+    reserve_dates = resolve_bws_reserve_dates(reserve_dates, year)
+    client = _make_bws_client(cookies=cookies, cookies_path=cookies_path)
+    info = client.get_reservation_info(
+        reserve_dates=reserve_dates,
+        reserve_type=reserve_type,
+        year=year,
+    )
+    try:
+        my_reservations = client.get_my_reservations(year=year)
+    except Exception:
+        my_reservations = {}
+    return {
+        "username": client.get_username(),
+        "reserve_dates": reserve_dates,
+        "year": year,
+        "reserve_info": info,
+        "my_reservations": my_reservations,
+        "csrf_present": bool(_cookie_value(client.cookies, "bili_jct")),
+    }

--- a/main.py
+++ b/main.py
@@ -6,9 +6,7 @@ from typing import Annotated
 
 import tyro
 from starlette.exceptions import StarletteDeprecationWarning
-from app_cmd.buy import buy_cmd
-from app_cmd.cli_args import BuyCliArgs, TickerCliArgs
-from app_cmd.ticker import ticker_cmd
+from app_cmd.cli_args import BuyCliArgs, BwsCliArgs, TickerCliArgs
 
 warnings.filterwarnings(
     "ignore",
@@ -24,7 +22,11 @@ UiCommand = Annotated[
     TickerCliArgs,
     tyro.conf.subcommand(name="ui", prefix_name=False),
 ]
-CliCommand = BuyCommand | UiCommand
+BwsCommand = Annotated[
+    BwsCliArgs,
+    tyro.conf.subcommand(name="bws", prefix_name=False),
+]
+CliCommand = BuyCommand | UiCommand | BwsCommand
 
 
 def _normalize_argv(argv: list[str]) -> list[str]:
@@ -37,7 +39,7 @@ def _normalize_argv(argv: list[str]) -> list[str]:
         return ["ui"]
 
     first = argv[0]
-    if first in {"buy", "ui", "-h", "--help"}:
+    if first in {"buy", "ui", "bws", "-h", "--help"}:
         return argv
 
     return ["ui", *argv]
@@ -46,8 +48,17 @@ def _normalize_argv(argv: list[str]) -> list[str]:
 def main() -> None:
     command = tyro.cli(CliCommand, args=_normalize_argv(sys.argv[1:]))  # type: ignore
     if isinstance(command, BuyCliArgs):
+        from app_cmd.buy import buy_cmd
+
         buy_cmd(command)
         return
+    if isinstance(command, BwsCliArgs):
+        from app_cmd.bws import bws_cmd
+
+        bws_cmd(command)
+        return
+    from app_cmd.ticker import ticker_cmd
+
     ticker_cmd(command)
 
 

--- a/tab/bws.py
+++ b/tab/bws.py
@@ -1,0 +1,558 @@
+from __future__ import annotations
+
+import html
+import datetime
+
+import gradio as gr
+import requests
+
+import util
+from app_cmd.config.BwsConfig import BwsConfig
+from interface.bws import (
+    default_bws_year,
+    get_bws_reserve_context,
+    resolve_bws_reserve_dates,
+    run_bws_reserve_sync,
+)
+from util import GLOBAL_COOKIE_PATH, set_main_request
+from util.request.BiliRequest import BiliRequest
+from util.request.CookieManager import CookieManager
+
+
+CURRENT_COOKIE_UID = "__current_cookie__"
+
+
+def _format_account_choice(uid: str, name: str, level: int) -> str:
+    return f"{uid} - {name} (Lv{level})"
+
+
+def _find_uid_from_choice(choice: str | None) -> str:
+    if not choice:
+        return ""
+    return choice.split(" - ")[0] if " - " in choice else str(choice)
+
+
+def _local_cookie_manager() -> CookieManager:
+    return CookieManager(GLOBAL_COOKIE_PATH)
+
+
+def _cookies_to_header(cookies: list[dict] | None) -> str:
+    parts: list[str] = []
+    for cookie in cookies or []:
+        name = cookie.get("name")
+        value = cookie.get("value")
+        if name and value is not None:
+            parts.append(f"{name}={value}")
+    return "; ".join(parts)
+
+
+def _cookie_value(cookies: list[dict] | None, name: str) -> str | None:
+    for cookie in cookies or []:
+        if cookie.get("name") == name:
+            value = cookie.get("value")
+            return str(value) if value is not None else None
+    return None
+
+
+def _validate_cookies_with_nav(cookies: list[dict] | None) -> tuple[bool, str, str | None]:
+    if not cookies:
+        return False, "本地 Cookie 为空，请先在“账号登录”页登录。", None
+    if not _cookie_value(cookies, "SESSDATA"):
+        return False, "Cookie 缺少 SESSDATA，请重新登录。", None
+    if not _cookie_value(cookies, "bili_jct"):
+        return False, "Cookie 缺少 bili_jct，无法进行 BW 乐园预约。", None
+
+    headers = {
+        "accept": "*/*",
+        "accept-language": "zh-CN,zh;q=0.9",
+        "referer": "https://show.bilibili.com/",
+        "user-agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/126.0.0.0 Safari/537.36"
+        ),
+        "cookie": _cookies_to_header(cookies),
+    }
+    try:
+        response = requests.get(
+            "https://api.bilibili.com/x/web-interface/nav",
+            headers=headers,
+            timeout=10,
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as exc:
+        return False, f"验证 Cookie 请求失败：{exc}", None
+
+    if payload.get("code") != 0:
+        return False, f"验证 Cookie 失败：[{payload.get('code')}] {payload.get('message', '')}", None
+    data = payload.get("data") if isinstance(payload, dict) else {}
+    if not isinstance(data, dict) or not data.get("isLogin"):
+        return False, "Cookie 无效或已过期，请重新登录。", None
+    username = str(data.get("uname") or "").strip()
+    uid = str(data.get("mid") or _cookie_value(cookies, "DedeUserID") or "").strip()
+    if not username:
+        return False, "Cookie 验证通过但未返回用户名，请重新登录。", uid or None
+    return True, f"当前账号：{username}", uid or None
+
+
+def _get_account_choices() -> list[str]:
+    manager = _local_cookie_manager()
+    choices = [
+        _format_account_choice(account.uid, account.name, account.level)
+        for account in manager.get_accounts()
+    ]
+    try:
+        current_cookies = manager.get_cookies(force=True)
+    except Exception:
+        current_cookies = None
+    current_uid = _cookie_value(current_cookies, "DedeUserID")
+    if current_cookies and current_uid:
+        exists = any(_find_uid_from_choice(choice) == current_uid for choice in choices)
+        if not exists:
+            choices.insert(0, f"{current_uid} - 当前Cookie (本地当前)")
+    elif current_cookies:
+        choices.insert(0, f"{CURRENT_COOKIE_UID} - 当前Cookie (本地当前)")
+    return choices
+
+
+def _active_uid() -> str | None:
+    try:
+        manager = _local_cookie_manager()
+        if not manager.have_cookies():
+            return None
+        uid = manager.get_cookies_value("DedeUserID")
+        return str(uid) if uid else None
+    except Exception:
+        return None
+
+
+def _default_account_choice(choices: list[str]) -> str | None:
+    active_uid = _active_uid()
+    if active_uid:
+        for choice in choices:
+            if _find_uid_from_choice(choice) == active_uid:
+                return choice
+    return choices[0] if choices else None
+
+
+def _activate_local_account(choice: str | None) -> tuple[bool, str]:
+    uid = _find_uid_from_choice(choice)
+    if not uid:
+        return False, "请选择一个本地账号。"
+    manager = _local_cookie_manager()
+    account = manager.find_by_uid(uid)
+    if account is not None:
+        cookies = account.cookies
+    else:
+        cookies = manager.get_cookies(force=True)
+        current_uid = _cookie_value(cookies, "DedeUserID")
+        if uid != CURRENT_COOKIE_UID and current_uid and uid != current_uid:
+            return False, f"未找到本地账号 {uid}。"
+    ok, message, _verified_uid = _validate_cookies_with_nav(cookies)
+    if not ok:
+        return False, message
+
+    set_main_request(BiliRequest(cookies_config_path=GLOBAL_COOKIE_PATH))
+    util.main_request.cookieManager.db.insert("cookie", cookies)
+    return True, message
+
+
+def _current_login_message() -> str:
+    try:
+        choices = _get_account_choices()
+        if not choices:
+            return "本地没有保存账号，请先在“账号登录”页完成登录。"
+        manager = _local_cookie_manager()
+        if not manager.have_cookies():
+            return "本地已有账号，请在下方选择账号并验证 Cookie。"
+        ok, message, _uid = _validate_cookies_with_nav(manager.get_cookies(force=True))
+        return message if ok else f"{message} 请在下方选择账号重新验证，或在“账号登录”页重新登录。"
+    except Exception:
+        return "本地账号状态读取失败，请在“账号登录”页重新登录。"
+
+
+def _require_login() -> None:
+    message = _current_login_message()
+    if "当前账号：" not in message:
+        raise gr.Error(message)
+
+
+def _format_ts(value) -> str:
+    try:
+        timestamp = int(value)
+    except (TypeError, ValueError):
+        return "-"
+    try:
+        return datetime.datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S")
+    except (OverflowError, OSError, ValueError):
+        return str(value)
+
+
+def _reserved_activity_ids(my_reservations: dict | None) -> set[int]:
+    reserved_ids: set[int] = set()
+    reserve_list = my_reservations.get("reserve_list") if isinstance(my_reservations, dict) else None
+    if not isinstance(reserve_list, dict):
+        return reserved_ids
+    for activities in reserve_list.values():
+        if not isinstance(activities, list):
+            continue
+        for activity in activities:
+            if not isinstance(activity, dict):
+                continue
+            try:
+                reserved_ids.add(int(activity.get("reserve_id")))
+            except (TypeError, ValueError):
+                continue
+    return reserved_ids
+
+
+def _activity_status(activity: dict, reserved_ids: set[int]) -> str:
+    try:
+        reserve_id = int(activity.get("reserve_id"))
+    except (TypeError, ValueError):
+        reserve_id = -1
+    if reserve_id in reserved_ids:
+        return "已预约"
+    state = activity.get("state")
+    if state == 3:
+        return "已结束"
+    if state in (1, 2):
+        return "可预约"
+    if state is None:
+        return "-"
+    return f"状态{state}"
+
+
+def _activity_kind(activity: dict) -> str:
+    desc = str(activity.get("describe_info") or "")
+    labels: list[str] = []
+    if "预约只是签售资格，现场签售需购买up主周边。" in desc:
+        labels.append("需付费")
+    reserve_type = activity.get("reserve_type")
+    if reserve_type == 1:
+        labels.append("商品")
+    elif reserve_type == 0:
+        labels.append("活动")
+    return " / ".join(labels) if labels else "活动"
+
+
+def _format_activity_rows(reserve_info: dict, my_reservations: dict | None = None) -> str:
+    reserve_list = reserve_info.get("reserve_list")
+    user_ticket_info = reserve_info.get("user_ticket_info")
+    if not isinstance(reserve_list, dict):
+        return "<div class=\"btb-card-note\">未获取到预约项目列表。</div>"
+
+    reserved_ids = _reserved_activity_ids(my_reservations)
+    ticket_cards = ""
+    if isinstance(user_ticket_info, dict) and user_ticket_info:
+        cards: list[str] = []
+        for date, ticket_info in user_ticket_info.items():
+            if not isinstance(ticket_info, dict):
+                continue
+            ticket_line = " / ".join(
+                item
+                for item in [
+                    str(ticket_info.get("screen_name") or ""),
+                    str(ticket_info.get("sku_name") or ""),
+                    str(ticket_info.get("ticket") or ""),
+                ]
+                if item
+            )
+            cards.append(
+                '<div class="btb-mini-card">'
+                f"<strong>{html.escape(str(date))}</strong>"
+                f"<span>{html.escape(ticket_line or '已激活门票')}</span>"
+                "</div>"
+            )
+        if cards:
+            ticket_cards = (
+                "<div class=\"btb-ticket-panel\"><h4>我的 BW 票种</h4>"
+                f"<div class=\"btb-mini-grid\">{''.join(cards)}</div></div>"
+            )
+
+    rows: list[str] = []
+    for date, activities in reserve_list.items():
+        ticket = ""
+        if isinstance(user_ticket_info, dict) and isinstance(
+            user_ticket_info.get(date), dict
+        ):
+            ticket = str(user_ticket_info[date].get("ticket") or "")
+        for activity in activities if isinstance(activities, list) else []:
+            if not isinstance(activity, dict):
+                continue
+            title = str(activity.get("act_title") or "").replace("\n", "")
+            reserve_id = activity.get("reserve_id", "")
+            status = _activity_status(activity, reserved_ids)
+            kind = _activity_kind(activity)
+            reserve_begin_time = _format_ts(activity.get("reserve_begin_time"))
+            act_time = "{0} - {1}".format(
+                _format_ts(activity.get("act_begin_time")),
+                _format_ts(activity.get("act_end_time")),
+            )
+            rows.append(
+                "<tr>"
+                f"<td>{html.escape(str(date))}</td>"
+                f"<td>{html.escape(str(reserve_id))}</td>"
+                f"<td>{html.escape(status)}</td>"
+                f"<td>{html.escape(kind)}</td>"
+                f"<td>{html.escape(title)}</td>"
+                f"<td>{html.escape(str(reserve_begin_time))}</td>"
+                f"<td>{html.escape(act_time)}</td>"
+                f"<td>{html.escape(ticket or '-')}</td>"
+                "</tr>"
+            )
+
+    if not rows:
+        return (
+            ticket_cards
+            + "<div class=\"btb-card-note\">暂无可显示的 BW 乐园预约项目。</div>"
+        )
+
+    return (
+        ticket_cards
+        +
+        "<div class=\"btb-ticket-panel\">"
+        "<h4>可预约项目</h4>"
+        "<table class=\"btb-log-table\">"
+        "<thead><tr><th>日期</th><th>预约ID</th><th>状态</th><th>类型</th><th>项目</th><th>预约开始</th><th>活动时间</th><th>门票号</th></tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody>"
+        "</table>"
+        "</div>"
+    )
+
+
+def _date_dropdown_update(reserve_dates_value: str, year_value: str):
+    resolved_dates = resolve_bws_reserve_dates(
+        str(reserve_dates_value or "").strip(),
+        str(year_value or "").strip() or default_bws_year(),
+    )
+    choices = [date for date in resolved_dates.split(",") if date]
+    return gr.update(
+        choices=choices,
+        value=choices[0] if choices else None,
+    )
+
+
+def bws_tab():
+    initial_account_choices = _get_account_choices()
+    initial_year = default_bws_year()
+    initial_reserve_dates = resolve_bws_reserve_dates("", initial_year).split(",")
+    with gr.Column(elem_classes="btb-page-section"):
+        with gr.Column(elem_classes="btb-card btb-card-sky btb-layout-card"):
+            gr.HTML(
+                """
+                <div class="btb-card-head">
+                    <div>
+                        <h3>BW 乐园预约</h3>
+                        <p>选择本地账号后可直接获取已激活票种和可预约项目。日期留空时会从 BW 官网自动获取最近一届日期。</p>
+                    </div>
+                </div>
+                """
+            )
+            login_status = gr.HTML(
+                value=lambda: f'<div class="btb-card-note">{html.escape(_current_login_message())}</div>'
+            )
+            with gr.Row(elem_classes="btb-action-band !items-end"):
+                local_account = gr.Dropdown(
+                    label="本地账号",
+                    choices=initial_account_choices,
+                    value=_default_account_choice(initial_account_choices),
+                    interactive=True,
+                    allow_custom_value=False,
+                    filterable=False,
+                    scale=4,
+                )
+                with gr.Column(scale=1, min_width=180):
+                    refresh_btn = gr.Button(
+                        "刷新账号状态",
+                        elem_classes="btb-soft-button",
+                    )
+                    validate_account_btn = gr.Button(
+                        "验证并使用账号",
+                        elem_classes="btb-soft-button",
+                    )
+            with gr.Row(elem_classes="btb-action-band !items-end"):
+                year = gr.Textbox(
+                    label="年份参数",
+                    value=initial_year,
+                    placeholder="202601",
+                    scale=1,
+                )
+                reserve_dates = gr.Textbox(
+                    label="预约日期列表（可选）",
+                    placeholder="留空自动从 BW 官网获取最近一届日期",
+                    scale=3,
+                )
+                reserve_date = gr.Dropdown(
+                    label="目标日期",
+                    choices=initial_reserve_dates,
+                    value=initial_reserve_dates[0] if initial_reserve_dates else None,
+                    interactive=True,
+                    allow_custom_value=False,
+                    filterable=False,
+                    scale=2,
+                )
+                reserve_type = gr.Radio(
+                    label="预约类型",
+                    choices=[("全部", -1), ("活动", 0), ("商品", 1)],
+                    value=-1,
+                    scale=2,
+                )
+            with gr.Row(elem_classes="!justify-end"):
+                info_btn = gr.Button("获取预约信息", elem_classes="btb-soft-button")
+
+            with gr.Row(elem_classes="btb-action-band !items-end"):
+                reserve_id = gr.Number(
+                    label="预约项目 ID",
+                    value=None,
+                    placeholder="必填",
+                    precision=0,
+                    minimum=1,
+                    scale=2,
+                )
+                interval = gr.Number(
+                    label="重试间隔（毫秒）",
+                    value=300,
+                    minimum=0,
+                    precision=0,
+                    scale=2,
+                )
+                retry_limit = gr.Number(
+                    label="最大重试次数（0为持续重试）",
+                    value=0,
+                    minimum=0,
+                    precision=0,
+                    scale=2,
+                )
+            with gr.Row(elem_classes="!justify-end"):
+                start_btn = gr.Button("开始预约", elem_classes="btb-strong-button")
+
+            activity_panel = gr.HTML(
+                value='<div class="btb-card-note">选择账号后点击“获取预约信息”，系统会拉取你的 BW 票种和可预约项目。</div>'
+            )
+            result_log = gr.Textbox(
+                label="运行日志",
+                lines=12,
+                interactive=False,
+            )
+
+    def refresh_login_status():
+        choices = _get_account_choices()
+        return (
+            f'<div class="btb-card-note">{html.escape(_current_login_message())}</div>',
+            gr.update(
+                choices=choices,
+                value=_default_account_choice(choices),
+            ),
+        )
+
+    def validate_local_account(choice):
+        ok, message = _activate_local_account(choice)
+        if ok:
+            gr.Info("账号 Cookie 验证通过。", duration=4)
+        else:
+            gr.Warning(message, duration=6)
+        return f'<div class="btb-card-note">{html.escape(message)}</div>'
+
+    def load_context(_reserve_dates, _reserve_type, _year):
+        _require_login()
+        year_value = str(_year or "").strip() or default_bws_year()
+        reserve_dates_value = resolve_bws_reserve_dates(
+            str(_reserve_dates or "").strip(),
+            year_value,
+        )
+        context = get_bws_reserve_context(
+            reserve_dates=reserve_dates_value,
+            reserve_type=int(_reserve_type if _reserve_type is not None else -1),
+            year=year_value,
+            cookies_path=GLOBAL_COOKIE_PATH,
+        )
+        username = context.get("username", "未知账号")
+        used_dates = context.get("reserve_dates", reserve_dates_value)
+        return (
+            f'<div class="btb-card-note">当前账号：{html.escape(str(username))}；已拉取日期：{html.escape(str(used_dates))}</div>',
+            _format_activity_rows(
+                context.get("reserve_info", {}),
+                context.get("my_reservations", {}),
+            ),
+            _date_dropdown_update(str(used_dates), year_value),
+        )
+
+    def start_reserve(
+        _reserve_id,
+        _reserve_dates,
+        _reserve_date,
+        _reserve_type,
+        _year,
+        _interval,
+        _retry_limit,
+    ):
+        _require_login()
+        if not _reserve_id:
+            raise gr.Error("请填写预约项目 ID。")
+        year_value = str(_year or "").strip() or default_bws_year()
+        dates_value = resolve_bws_reserve_dates(
+            str(_reserve_dates or _reserve_date or "").strip(),
+            year_value,
+        )
+
+        result = run_bws_reserve_sync(
+            BwsConfig(
+                reserve_id=int(_reserve_id),
+                reserve_dates=dates_value,
+                reserve_date=str(_reserve_date or "").strip(),
+                reserve_type=int(_reserve_type if _reserve_type is not None else -1),
+                year=year_value,
+                interval=int(_interval or 0),
+                retry_limit=int(_retry_limit or 0),
+                cookies_path=GLOBAL_COOKIE_PATH,
+                show_detail=True,
+            )
+        )
+        logs = "\n".join(str(item) for item in result.get("logs", []))
+        if not result.get("ok") and result.get("error"):
+            logs = f"{logs}\n{result['error']}".strip()
+        return logs
+
+    refresh_btn.click(refresh_login_status, outputs=[login_status, local_account])
+    validate_account_btn.click(
+        validate_local_account,
+        inputs=local_account,
+        outputs=login_status,
+    )
+    local_account.change(
+        validate_local_account,
+        inputs=local_account,
+        outputs=login_status,
+    )
+    reserve_dates.change(
+        _date_dropdown_update,
+        inputs=[reserve_dates, year],
+        outputs=reserve_date,
+    )
+    year.change(
+        _date_dropdown_update,
+        inputs=[reserve_dates, year],
+        outputs=reserve_date,
+    )
+    info_btn.click(
+        load_context,
+        inputs=[reserve_dates, reserve_type, year],
+        outputs=[login_status, activity_panel, reserve_date],
+    )
+    start_btn.click(
+        start_reserve,
+        inputs=[
+            reserve_id,
+            reserve_dates,
+            reserve_date,
+            reserve_type,
+            year,
+            interval,
+            retry_limit,
+        ],
+        outputs=result_log,
+    )
+
+    return refresh_login_status, [login_status, local_account]

--- a/tab/bws.py
+++ b/tab/bws.py
@@ -12,6 +12,7 @@ import util
 from app_cmd.config.BwsConfig import BwsConfig
 from interface.bws import (
     default_bws_year,
+    effective_bws_reserve_begin_time,
     get_bws_reserve_context,
     resolve_bws_reserve_dates,
 )
@@ -228,10 +229,37 @@ def _activity_status(activity: dict, reserved_ids: set[int]) -> str:
 
 
 def _activity_kind(activity: dict) -> str:
-    desc = str(activity.get("describe_info") or "")
+    type_names = {
+        1: "手渡会",
+        2: "见面会",
+        3: "签售会",
+        4: "放映厅",
+        5: "专访",
+        6: "沉浸剧场",
+        7: "占卜",
+        8: "说书",
+        9: "鉴宝",
+        10: "演讲",
+        11: "签名会",
+        12: "见面会+签名会",
+        13: "舞台观赏席位",
+        14: "展台限定",
+        15: "展台签售",
+    }
     labels: list[str] = []
-    if "预约只是签售资格，现场签售需购买up主周边。" in desc:
-        labels.append("需付费")
+    for item in str(activity.get("act_type") or "").split(","):
+        try:
+            type_id = int(item)
+        except ValueError:
+            continue
+        if type_id in type_names:
+            labels.append(type_names[type_id])
+    if activity.get("is_vip_ticket") is not None and activity.get("state") != 3:
+        labels.append(
+            "VIP预约时段"
+            if int(activity.get("is_vip_ticket") or 0) == 1
+            else "所有门票预约时段"
+        )
     reserve_type = activity.get("reserve_type")
     if reserve_type == 1:
         labels.append("商品")
@@ -288,7 +316,15 @@ def _format_activity_rows(reserve_info: dict, my_reservations: dict | None = Non
             reserve_id = activity.get("reserve_id", "")
             status = _activity_status(activity, reserved_ids)
             kind = _activity_kind(activity)
-            reserve_begin_time = _format_ts(activity.get("reserve_begin_time"))
+            ticket_info = (
+                user_ticket_info.get(date)
+                if isinstance(user_ticket_info, dict)
+                and isinstance(user_ticket_info.get(date), dict)
+                else None
+            )
+            reserve_begin_time = _format_ts(
+                effective_bws_reserve_begin_time(activity, ticket_info)
+            )
             act_time = "{0} - {1}".format(
                 _format_ts(activity.get("act_begin_time")),
                 _format_ts(activity.get("act_end_time")),

--- a/tab/bws.py
+++ b/tab/bws.py
@@ -408,7 +408,6 @@ def bws_tab():
                     value=None,
                     placeholder="必填",
                     precision=0,
-                    minimum=1,
                     scale=2,
                 )
                 interval = gr.Number(
@@ -491,6 +490,9 @@ def bws_tab():
         _require_login()
         if not _reserve_id:
             raise gr.Error("请填写预约项目 ID。")
+        reserve_id_value = int(_reserve_id)
+        if reserve_id_value <= 0:
+            raise gr.Error("预约项目 ID 必须大于 0。")
         year_value = str(_year or "").strip() or default_bws_year()
         dates_value = resolve_bws_reserve_dates(
             str(_reserve_dates or _reserve_date or "").strip(),
@@ -499,7 +501,7 @@ def bws_tab():
 
         result = run_bws_reserve_sync(
             BwsConfig(
-                reserve_id=int(_reserve_id),
+                reserve_id=reserve_id_value,
                 reserve_dates=dates_value,
                 reserve_date=str(_reserve_date or "").strip(),
                 reserve_type=int(_reserve_type if _reserve_type is not None else -1),

--- a/tab/bws.py
+++ b/tab/bws.py
@@ -420,11 +420,10 @@ def bws_tab():
                 info_btn = gr.Button("获取预约信息", elem_classes="btb-soft-button")
 
             with gr.Row(elem_classes="btb-action-band !items-end"):
-                reserve_id = gr.Number(
+                reserve_id = gr.Textbox(
                     label="预约项目 ID",
-                    value=None,
+                    value="",
                     placeholder="必填",
-                    precision=0,
                     scale=2,
                 )
                 interval = gr.Number(
@@ -505,9 +504,13 @@ def bws_tab():
         _retry_limit,
     ):
         _require_login()
-        if not _reserve_id:
+        reserve_id_text = str(_reserve_id or "").strip()
+        if not reserve_id_text:
             raise gr.Error("请填写预约项目 ID。")
-        reserve_id_value = int(_reserve_id)
+        try:
+            reserve_id_value = int(reserve_id_text)
+        except ValueError:
+            raise gr.Error("预约项目 ID 必须是正整数。") from None
         if reserve_id_value <= 0:
             raise gr.Error("预约项目 ID 必须大于 0。")
         year_value = str(_year or "").strip() or default_bws_year()

--- a/tab/bws.py
+++ b/tab/bws.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
-import html
 import datetime
+import html
+import os
+import uuid
 
 import gradio as gr
 import requests
@@ -12,9 +14,10 @@ from interface.bws import (
     default_bws_year,
     get_bws_reserve_context,
     resolve_bws_reserve_dates,
-    run_bws_reserve_sync,
 )
-from util import GLOBAL_COOKIE_PATH, set_main_request
+from tab.log import refresh_task_panel, render_task_manager_panel, visible_task_entries
+from task.bws import bws_new_terminal
+from util import GLOBAL_COOKIE_PATH, GlobalStatusInstance, LOG_DIR, set_main_request
 from util.request.BiliRequest import BiliRequest
 from util.request.CookieManager import CookieManager
 
@@ -334,6 +337,20 @@ def _date_dropdown_update(reserve_dates_value: str, year_value: str):
     )
 
 
+def _build_bws_task_log_path(reserve_id: int, reserve_date: str, year: str) -> str:
+    suffix = reserve_date or year or "auto"
+    filename = f"bws_{reserve_id}_{suffix}_{uuid.uuid4().hex[:8]}.log"
+    safe_name = "".join(
+        ch if ch.isalnum() or ch in "-_." else "_" for ch in filename
+    )
+    return os.path.join(LOG_DIR, safe_name)
+
+
+def _bws_task_title(reserve_id: int, reserve_date: str, year: str) -> str:
+    suffix = reserve_date or year or "自动日期"
+    return f"BW预约 {reserve_id} / {suffix}"
+
+
 def bws_tab():
     initial_account_choices = _get_account_choices()
     initial_year = default_bws_year()
@@ -430,11 +447,11 @@ def bws_tab():
             activity_panel = gr.HTML(
                 value='<div class="btb-card-note">选择账号后点击“获取预约信息”，系统会拉取你的 BW 票种和可预约项目。</div>'
             )
-            result_log = gr.Textbox(
-                label="运行日志",
-                lines=12,
-                interactive=False,
-            )
+            with gr.Column(
+                visible=bool(visible_task_entries()),
+                elem_classes="btb-card btb-card-sky btb-layout-card",
+            ) as task_panel:
+                task_refresh_token = render_task_manager_panel(task_panel)
 
     def refresh_login_status():
         choices = _get_account_choices()
@@ -498,24 +515,32 @@ def bws_tab():
             str(_reserve_dates or _reserve_date or "").strip(),
             year_value,
         )
-
-        result = run_bws_reserve_sync(
-            BwsConfig(
-                reserve_id=reserve_id_value,
-                reserve_dates=dates_value,
-                reserve_date=str(_reserve_date or "").strip(),
-                reserve_type=int(_reserve_type if _reserve_type is not None else -1),
-                year=year_value,
-                interval=int(_interval or 0),
-                retry_limit=int(_retry_limit or 0),
-                cookies_path=GLOBAL_COOKIE_PATH,
-                show_detail=True,
-            )
+        reserve_date_value = str(_reserve_date or "").strip()
+        config = BwsConfig(
+            reserve_id=reserve_id_value,
+            reserve_dates=dates_value,
+            reserve_date=reserve_date_value,
+            reserve_type=int(_reserve_type if _reserve_type is not None else -1),
+            year=year_value,
+            interval=int(_interval or 0),
+            retry_limit=int(_retry_limit or 0),
+            cookies_path=GLOBAL_COOKIE_PATH,
+            show_detail=True,
         )
-        logs = "\n".join(str(item) for item in result.get("logs", []))
-        if not result.get("ok") and result.get("error"):
-            logs = f"{logs}\n{result['error']}".strip()
-        return logs
+        log_file_path = _build_bws_task_log_path(
+            reserve_id_value,
+            reserve_date_value,
+            year_value,
+        )
+        proc = bws_new_terminal(config=config, log_file_path=log_file_path)
+        GlobalStatusInstance.register_task_log(
+            title=_bws_task_title(reserve_id_value, reserve_date_value, year_value),
+            mode="终端",
+            log_file=log_file_path,
+            pid=proc.pid,
+        )
+        gr.Info("BW 乐园预约任务已启动，可在下方任务卡查看日志或终止进程。")
+        return gr.update(visible=True)
 
     refresh_btn.click(refresh_login_status, outputs=[login_status, local_account])
     validate_account_btn.click(
@@ -554,7 +579,11 @@ def bws_tab():
             interval,
             retry_limit,
         ],
-        outputs=result_log,
+        outputs=task_panel,
+    ).then(
+        fn=refresh_task_panel,
+        inputs=None,
+        outputs=[task_refresh_token, task_panel],
     )
 
     return refresh_login_status, [login_status, local_account]

--- a/task/bws.py
+++ b/task/bws.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import uuid
+from dataclasses import dataclass
+
+from app_cmd.config.BwsConfig import BwsConfig
+
+
+@dataclass(slots=True)
+class Bws:
+    config: BwsConfig
+
+    def to_cli_args(self) -> list[str]:
+        return ["bws", *self.config.to_cli_args()]
+
+    def start_new_terminal(
+        self,
+        *,
+        log_file_path: str | None = None,
+    ) -> subprocess.Popen:
+        if getattr(sys, "frozen", False):
+            command = [sys.executable]
+        else:
+            script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            main_py = os.path.join(script_dir, "main.py")
+
+            if os.path.exists(main_py):
+                command = [sys.executable, main_py]
+            else:
+                btb_path = shutil.which("btb")
+                if not btb_path:
+                    raise RuntimeError("Cannot find main.py or btb command")
+                command = [btb_path]
+
+        command.extend(self.to_cli_args())
+
+        env = os.environ.copy()
+        env["BTB_PARENT_PID"] = str(os.getpid())
+        if log_file_path:
+            env["BTB_APP_LOG_NAME"] = os.path.basename(log_file_path)
+        else:
+            env.setdefault("BTB_APP_LOG_NAME", f"bws-{uuid.uuid4().hex}.log")
+
+        kwargs: dict[str, object] = {}
+        if os.name == "nt":
+            kwargs["creationflags"] = (
+                subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NEW_CONSOLE
+            )
+            env["BTB_HOLD_TERMINAL"] = "1"
+            return subprocess.Popen(command, env=env, **kwargs)
+
+        env["BTB_CHILD_PROCESS"] = "1"
+        kwargs["start_new_session"] = True
+        with open(os.devnull, "r") as devnull_in, open(os.devnull, "a") as devnull_out:
+            return subprocess.Popen(
+                command,
+                env=env,
+                stdin=devnull_in,
+                stdout=devnull_out,
+                stderr=devnull_out,
+                **kwargs,
+            )
+
+
+def bws_new_terminal(
+    config: BwsConfig,
+    log_file_path: str | None = None,
+) -> subprocess.Popen:
+    return Bws(config=config).start_new_terminal(log_file_path=log_file_path)

--- a/tests/test_bws_reservation.py
+++ b/tests/test_bws_reservation.py
@@ -1,0 +1,138 @@
+import pytest
+
+from app_cmd.config.BwsConfig import BwsConfig
+import interface.bws as bws
+from interface.bws import (
+    DEFAULT_BWS_RESERVE_DATES,
+    _extract_act_days,
+    _extract_bws_year_param,
+    _extract_event_year,
+    infer_bws_reserve_dates,
+    resolve_bws_reserve_dates,
+    verify_bws_ticket_activation,
+)
+
+
+def _reservation_info():
+    return {
+        "user_ticket_info": {
+            "20260710": {
+                "ticket": "TICKET-0710",
+                "screen_name": "BW2026",
+                "sku_name": "单日票",
+            }
+        },
+        "user_reserve_info": {"20260710": []},
+        "reserve_list": {
+            "20260710": [
+                {
+                    "reserve_id": 1001,
+                    "act_title": "签售项目",
+                    "act_begin_time": 1783652400,
+                    "reserve_begin_time": 1783648800,
+                }
+            ],
+            "20260711": [
+                {
+                    "reserve_id": 1002,
+                    "act_title": "舞台项目",
+                    "act_begin_time": 1783738800,
+                    "reserve_begin_time": 1783735200,
+                }
+            ],
+        },
+    }
+
+
+def test_verify_bws_ticket_activation_uses_matching_activity_date():
+    result = verify_bws_ticket_activation(_reservation_info(), reserve_id=1001)
+
+    assert result["date"] == "20260710"
+    assert result["ticket_no"] == "TICKET-0710"
+    assert result["activity"]["reserve_id"] == 1001
+
+
+def test_verify_bws_ticket_activation_fails_when_date_not_activated():
+    with pytest.raises(RuntimeError, match="没有激活目标预约日期"):
+        verify_bws_ticket_activation(_reservation_info(), reserve_id=1002)
+
+
+def test_verify_bws_ticket_activation_fails_when_activity_missing():
+    with pytest.raises(RuntimeError, match="未找到预约项目"):
+        verify_bws_ticket_activation(_reservation_info(), reserve_id=9999)
+
+
+def test_verify_bws_ticket_activation_allows_explicit_date_override():
+    result = verify_bws_ticket_activation(
+        _reservation_info(),
+        reserve_id=1002,
+        reserve_date="2026-07-10",
+    )
+
+    assert result["date"] == "20260710"
+    assert result["ticket_no"] == "TICKET-0710"
+
+
+def test_infer_bws_reserve_dates_uses_year_prefix():
+    dates = infer_bws_reserve_dates("202601").split(",")
+
+    assert dates[0] == "20260710"
+    assert dates[-1] == "20260712"
+    assert len(dates) == 3
+
+
+def test_infer_bws_reserve_dates_supports_2025_demo_dates():
+    assert infer_bws_reserve_dates("202501") == "20250711,20250712,20250713"
+
+
+def test_resolve_bws_reserve_dates_defaults_to_starsbon_dates():
+    assert resolve_bws_reserve_dates("", "202601") == DEFAULT_BWS_RESERVE_DATES
+
+
+def test_resolve_bws_reserve_dates_keeps_manual_value():
+    assert resolve_bws_reserve_dates("20260710,20260711", "202601") == (
+        "20260710,20260711"
+    )
+
+
+def test_extract_official_bws_schedule_parts_from_minified_js():
+    sample = (
+        '<title>BW2026，次元新航线！</title>'
+        'var c=e.isPre?202602:202601,l=e.isPre?202602:202601;'
+        'e.ACT_DAYS=["20260710","20260711","20260712"];'
+    )
+
+    assert _extract_event_year(sample) == 2026
+    assert _extract_bws_year_param(sample, 2026) == "202601"
+    assert _extract_act_days(sample) == ["20260710", "20260711", "20260712"]
+
+
+def test_bws_reserve_stream_stops_when_already_reserved(monkeypatch):
+    class FakeClient:
+        cookies = [{"name": "bili_jct", "value": "csrf"}]
+
+        def get_username(self):
+            return "tester"
+
+        def get_reservation_info(self, **kwargs):
+            return _reservation_info()
+
+        def get_my_reservations(self, **kwargs):
+            return {"reserve_list": {"20260710": [{"reserve_id": 1001}]}}
+
+        def make_reservation(self, **kwargs):
+            raise AssertionError("should not submit duplicate reservation")
+
+    monkeypatch.setattr(bws, "_make_bws_client", lambda **kwargs: FakeClient())
+
+    logs = list(
+        bws.bws_reserve_stream(
+            BwsConfig(
+                reserve_id=1001,
+                reserve_dates="20260710",
+                retry_limit=1,
+            )
+        )
+    )
+
+    assert any("已在当前账号的预约列表中" in message for message in logs)

--- a/tests/test_bws_reservation.py
+++ b/tests/test_bws_reservation.py
@@ -4,9 +4,11 @@ from app_cmd.config.BwsConfig import BwsConfig
 import interface.bws as bws
 from interface.bws import (
     DEFAULT_BWS_RESERVE_DATES,
+    BwsApiClient,
     _extract_act_days,
     _extract_bws_year_param,
     _extract_event_year,
+    effective_bws_reserve_begin_time,
     infer_bws_reserve_dates,
     resolve_bws_reserve_dates,
     verify_bws_ticket_activation,
@@ -158,3 +160,125 @@ def test_bws_terminal_task_uses_bws_subcommand():
     assert args[args.index("--reserve-date") + 1] == "20260710"
     assert args[args.index("--year") + 1] == "202601"
     assert args[args.index("--cookies-path") + 1] == "cookies.json"
+
+
+def test_make_reservation_adds_timestamp_and_random_nonce(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"code": 0, "message": "ok"}
+
+    class FakeSession:
+        headers = {}
+
+        def post(self, url, data, cookies, timeout):
+            captured["url"] = url
+            captured["data"] = data
+            captured["cookies"] = cookies
+            captured["timeout"] = timeout
+            return FakeResponse()
+
+    monkeypatch.setattr(bws.requests, "Session", lambda: FakeSession())
+    monkeypatch.setattr(bws.time, "time", lambda: 1783648800.123)
+    monkeypatch.setattr(bws.random, "randint", lambda start, end: 54321)
+
+    client = BwsApiClient(
+        [
+            {"name": "bili_jct", "value": "csrf-token"},
+            {"name": "SESSDATA", "value": "sess"},
+        ]
+    )
+
+    result = client.make_reservation(
+        ticket_no="TICKET-0710",
+        reserve_id=1001,
+        year="202601",
+    )
+
+    assert result["code"] == 0
+    assert captured["data"]["year"] == "202601"
+    assert captured["data"]["ts"] == 1783648800123
+    assert captured["data"]["_"] == 54321
+
+
+def test_effective_bws_reserve_begin_time_uses_common_time_for_non_vip_ticket():
+    activity = {
+        "reserve_begin_time": 100,
+        "is_vip_ticket": 1,
+        "next_reserve": {"reserve_begin_time": 200},
+    }
+
+    assert effective_bws_reserve_begin_time(activity, {"is_vip": False}) == 200
+    assert effective_bws_reserve_begin_time(activity, {"is_vip": True}) == 100
+
+
+def test_bws_reserve_stream_retries_official_hot_status(monkeypatch):
+    class FakeClient:
+        cookies = [{"name": "bili_jct", "value": "csrf"}]
+
+        def get_username(self):
+            return "tester"
+
+        def get_reservation_info(self, **kwargs):
+            return _reservation_info()
+
+        def get_my_reservations(self, **kwargs):
+            return {"reserve_list": {}}
+
+        def make_reservation(self, **kwargs):
+            return {"code": 76651, "message": "female only"}
+
+    monkeypatch.setattr(bws, "_make_bws_client", lambda **kwargs: FakeClient())
+
+    logs = list(
+        bws.bws_reserve_stream(
+            BwsConfig(
+                reserve_id=1001,
+                reserve_dates="20260710",
+                time_start="2020-01-01 00:00:00",
+                retry_limit=3,
+            )
+        )
+    )
+
+    assert sum("预约结果" in message for message in logs) == 3
+    assert any("当前预约火爆，请稍后重试" in message for message in logs)
+    assert not any("仅限女性" in message for message in logs)
+
+
+def test_bws_reserve_stream_marks_unknown_codes_retryable(monkeypatch):
+    class FakeClient:
+        cookies = [{"name": "bili_jct", "value": "csrf"}]
+
+        def get_username(self):
+            return "tester"
+
+        def get_reservation_info(self, **kwargs):
+            return _reservation_info()
+
+        def get_my_reservations(self, **kwargs):
+            return {"reserve_list": {}}
+
+        def make_reservation(self, **kwargs):
+            return {"code": 88001, "message": "new status"}
+
+    monkeypatch.setattr(bws, "_make_bws_client", lambda **kwargs: FakeClient())
+
+    logs = list(
+        bws.bws_reserve_stream(
+            BwsConfig(
+                reserve_id=1001,
+                reserve_dates="20260710",
+                time_start="2020-01-01 00:00:00",
+                retry_limit=2,
+            )
+        )
+    )
+
+    assert sum("预约结果" in message for message in logs) == 2
+    assert any("【未知返回码】" in message for message in logs)
+    assert any("按可重试处理" in message for message in logs)

--- a/tests/test_bws_reservation.py
+++ b/tests/test_bws_reservation.py
@@ -11,6 +11,7 @@ from interface.bws import (
     resolve_bws_reserve_dates,
     verify_bws_ticket_activation,
 )
+from task.bws import Bws
 
 
 def _reservation_info():
@@ -136,3 +137,24 @@ def test_bws_reserve_stream_stops_when_already_reserved(monkeypatch):
     )
 
     assert any("已在当前账号的预约列表中" in message for message in logs)
+
+
+def test_bws_terminal_task_uses_bws_subcommand():
+    args = Bws(
+        BwsConfig(
+            reserve_id=1001,
+            reserve_dates="20260710",
+            reserve_date="20260710",
+            reserve_type=-1,
+            year="202601",
+            interval=300,
+            retry_limit=2,
+            cookies_path="cookies.json",
+        )
+    ).to_cli_args()
+
+    assert args[0] == "bws"
+    assert args[args.index("--reserve-id") + 1] == "1001"
+    assert args[args.index("--reserve-date") + 1] == "20260710"
+    assert args[args.index("--year") + 1] == "202601"
+    assert args[args.index("--cookies-path") + 1] == "cookies.json"


### PR DESCRIPTION
首先感谢mikumifa大佬开源
我想对那些在网上挂这些开源脚本的说：没有开源的脚本的存在黄牛只会更加猖狂，请问黄牛对你们来说公平吗？请问你们能肘过黄牛吗？如果你不会用，请你RTFM！

## 概述

新增 BW 乐园预约功能，支持在现有登录体系下使用本地账号 Cookie 拉取 BW 乐园可预约信息，并以独立进程方式启动预约任务。

本次变更包含：

- 新增 `bws` CLI 子命令和 `BwsConfig` 配置，支持预约项目 ID、目标日期、预约类型、重试间隔、预约年份等参数。
- 在 Web UI 中新增 `BW乐园预约` Tab：
  - 支持读取本地账号 Cookie 并以下拉菜单选择账号。
  - 支持验证账号 Cookie 是否有效。
  - 支持从 B 站接口拉取当前账号的票种、已预约记录和可预约项目。
  - 目标日期改为下拉选择，预约项目 ID 默认空并提示必填。
- BW 预约任务改为复用原“操作抢票”的任务管理结构：
  - 每次点击开始预约都会启动一个独立子进程，支持多个预约项目多开。
  - Windows 下会打开独立命令行窗口，同时写入独立日志文件。
  - 页面内复用原任务卡结构，支持查看日志、终止任务、移除任务卡。
  - 主 UI 进程退出时，BW 子进程会跟随退出，避免遗留无人管理的预约进程。
- 参考 BW 官方页面信息，自动从 `bw.bilibili.com` 发现最近一届 BW 的年份参数和预约日期，减少每届活动手动更新固定日期的成本。
- 预约前会校验当前账号在目标日期是否存在已激活门票，并在提交前检查是否已经预约过同一项目，避免重复提交。
- 新增 BW 预约相关单元测试，覆盖官网日期解析、票券校验、重复预约保护、提交参数和子进程 CLI 参数。


测试结果：

```powershell
.\.venv\Scripts\python.exe -m py_compile main.py app_cmd\bws.py task\bws.py tab\bws.py tests\test_bws_reservation.py
.\.venv\Scripts\python.exe -m pytest tests\test_bws_reservation.py -q
.\.venv\Scripts\python.exe main.py bws --help
```

结果：

```text
11 passed
```

另外执行过全量测试：

```powershell
.\.venv\Scripts\python.exe -m pytest -q
```

结果为 `42 passed, 3 failed`。失败点不在本次改动文件中：一个是既有 `BuyConfig.rate_limit_delay_ms` 默认值与测试期望不一致，两个是 Windows 环境下 `os.getpgid` 不存在导致的既有平台兼容问题。

### 事务

- [ ] 已与维护者在 issues 或其他平台沟通此 PR 大致内容

## 以下内容可在起草 PR 后、合并 PR 前逐步完成

### 功能

- [x] 已编写完善的配置文件字段说明（若有新增）
- [x] 已编写面向用户的新功能说明（界面文案与本 PR 说明）
- [x] 已测试新功能或更改

### 兼容性

- [x] 已处理版本兼容性
- [x] 已处理插件兼容问题

### 风险

可能导致或已知的问题:

- BW 乐园预约接口和官网页面结构可能随每届活动调整；当前实现会优先从官网动态解析日期，并保留已知年份兜底。
- 该功能依赖本地已登录账号 Cookie，且账号必须已激活目标日期门票；未登录、Cookie 失效或未激活门票时会返回提示。
- BW 预约多开会启动多个独立进程，请按账号、项目和频率合理配置，避免过高并发触发风控。
- 本地完整测试在 Windows 环境存在 3 个既有失败项，已在测试结果中说明。