### PR TITLE
新增操作抢票页一键终止任务功能

### DIFF
--- a/tab/go.py
+++ b/tab/go.py
@@ -11,7 +11,12 @@ from gradio import SelectData
 from loguru import logger
 
 from app_cmd.config.BuyConfig import BuyConfig
-from tab.log import refresh_task_panel, render_task_manager_panel, visible_task_entries
+from tab.log import (
+    refresh_task_panel,
+    render_task_manager_panel,
+    stop_all_running_tasks,
+    visible_task_entries,
+)
 from task.buy import buy_new_terminal
 from util import (
     ConfigDB,
@@ -409,10 +414,20 @@ def go_start_tab():
     )
     upload_ui.select(file_select_handler, upload_ui, ticket_ui)
 
-    go_btn = gr.Button(
-        "开始抢票",
-        elem_classes="btb-strong-button",
-    )
+    with gr.Row(elem_classes="btb-inline-actions !justify-end"):
+        stop_all_btn = gr.Button(
+            "一键终止",
+            variant="stop",
+            elem_classes="btb-soft-button btb-task-button btb-task-button--stop",
+            scale=0,
+            min_width=120,
+        )
+        go_btn = gr.Button(
+            "开始抢票",
+            elem_classes="btb-strong-button",
+            scale=0,
+            min_width=140,
+        )
     with gr.Column(
         visible=bool(visible_task_entries()),
         elem_classes="btb-card btb-card-sky btb-layout-card",
@@ -470,6 +485,11 @@ def go_start_tab():
         outputs=task_panel,
     ).then(
         fn=refresh_task_panel,
+        inputs=None,
+        outputs=[task_refresh_token, task_panel],
+    )
+    stop_all_btn.click(
+        fn=stop_all_running_tasks,
         inputs=None,
         outputs=[task_refresh_token, task_panel],
     )

--- a/tab/log.py
+++ b/tab/log.py
@@ -390,6 +390,45 @@ def stop_task(pid: int):
     return refresh_task_panel()
 
 
+def stop_all_running_tasks():
+    entries = [
+        entry
+        for entry in visible_task_entries()
+        if entry.status == TASK_STATUS_RUNNING and entry.pid
+    ]
+    if not entries:
+        gr.Info("当前没有运行中的抢票任务。")
+        return refresh_task_panel()
+
+    stopped_count = 0
+    force_stopped_count = 0
+    failed_messages: list[str] = []
+
+    for entry in entries:
+        message = terminate_task(entry.pid)
+        if entry.log_file:
+            append_stop_log(entry.log_file, entry.title, message)
+        if "失败" in message or "没有权限" in message:
+            failed_messages.append(f"{entry.title}: {message}")
+            continue
+
+        GlobalStatusInstance.update_task_log_status(entry.pid, TASK_STATUS_STOPPED)
+        stopped_count += 1
+        if "强制" in message:
+            force_stopped_count += 1
+
+    if failed_messages:
+        gr.Warning("部分任务终止失败：" + "；".join(failed_messages))
+    elif force_stopped_count:
+        gr.Warning(
+            f"已终止 {stopped_count} 个抢票任务，其中 {force_stopped_count} 个被强制停止。"
+        )
+    else:
+        gr.Info(f"已终止 {stopped_count} 个抢票任务。")
+
+    return refresh_task_panel()
+
+
 def remove_task(pid: int):
     entry = GlobalStatusInstance.get_task_log(pid)
     if entry is None:

--- a/tests/test_task_log_controls.py
+++ b/tests/test_task_log_controls.py
@@ -1,6 +1,7 @@
 import signal
 
 import tab.log as task_log
+from util import GlobalStatusInstance, TaskLogEntry
 
 
 def test_is_task_running_treats_posix_zombie_as_stopped(monkeypatch):
@@ -55,3 +56,71 @@ def test_terminate_task_returns_message_when_signal_permission_denied(monkeypatc
     )
 
     assert task_log.terminate_task(12345) == "停止任务进程失败：没有权限。"
+
+
+def test_stop_all_running_tasks_stops_only_active_pid_entries(monkeypatch, tmp_path):
+    log_file = tmp_path / "running.log"
+    log_file.write_text("", encoding="utf-8")
+    stopped_pids = []
+    info_messages = []
+
+    original_task_logs = GlobalStatusInstance.task_logs
+    GlobalStatusInstance.task_logs = [
+        TaskLogEntry(
+            title="running",
+            mode="终端",
+            log_file=str(log_file),
+            created_at=1,
+            pid=111,
+            status=task_log.TASK_STATUS_RUNNING,
+        ),
+        TaskLogEntry(
+            title="completed",
+            mode="终端",
+            log_file=str(tmp_path / "completed.log"),
+            created_at=1,
+            pid=222,
+            status=task_log.TASK_STATUS_COMPLETED,
+        ),
+        TaskLogEntry(
+            title="missing-pid",
+            mode="终端",
+            log_file=str(tmp_path / "missing.log"),
+            created_at=1,
+            pid=None,
+            status=task_log.TASK_STATUS_RUNNING,
+        ),
+    ]
+
+    try:
+        monkeypatch.setattr(task_log, "is_task_running", lambda pid: pid == 111)
+
+        def fake_terminate_task(pid):
+            stopped_pids.append(pid)
+            return "已停止任务进程。"
+
+        monkeypatch.setattr(task_log, "terminate_task", fake_terminate_task)
+        monkeypatch.setattr(
+            task_log.gr,
+            "Info",
+            lambda message: info_messages.append(message),
+        )
+        monkeypatch.setattr(task_log.gr, "Warning", lambda message: None)
+
+        token, panel_update = task_log.stop_all_running_tasks()
+
+        assert isinstance(token, int)
+        assert panel_update["visible"] is True
+        assert stopped_pids == [111]
+        assert (
+            GlobalStatusInstance.get_task_log(111).status
+            == task_log.TASK_STATUS_STOPPED
+        )
+        assert (
+            GlobalStatusInstance.get_task_log(222).status
+            == task_log.TASK_STATUS_COMPLETED
+        )
+        assert "BTB_TASK_STOPPED_BY_USER" in log_file.read_text(encoding="utf-8")
+        assert info_messages == ["已终止 1 个抢票任务。"]
+    finally:
+        GlobalStatusInstance.task_logs = original_task_logs


### PR DESCRIPTION
## 概述

在“操作抢票”界面新增“一键终止”按钮，用于一次性终止当前已经启动且仍在运行的所有抢票任务。

此前界面中只能在任务管理卡片里逐个点击“终止任务”。当用户一次上传多个配置文件、队列模式启动多个抢票进程，或者需要紧急停止全部任务时，需要逐个操作，处理速度较慢，也容易漏掉仍在运行的任务。

本次变更复用现有单任务终止逻辑，不重新实现杀进程流程：

- `tab/go.py`
  - 在“操作抢票”页的开始按钮旁新增“一键终止”按钮。
  - 点击后刷新任务管理面板，保持状态展示同步。
- `tab/log.py`
  - 新增 `stop_all_running_tasks()`，批量筛选状态为“运行中”且存在 `pid` 的任务。
  - 对每个运行中任务调用现有 `terminate_task()`，继续沿用进程组 `SIGTERM` / `SIGKILL` 和 Windows `taskkill` 的处理方式。
  - 终止后写入现有 `BTB_TASK_STOPPED_BY_USER` 标记，并更新任务状态为“已主动结束”。
  - 若当前没有运行中的抢票任务，会给出“当前没有运行中的抢票任务。”提示。
- `tests/test_task_log_controls.py`
  - 增加批量终止测试，覆盖只终止运行中且有 `pid` 的任务。
  - 验证已完成任务不会被误处理。
  - 验证终止后会写入停止标记日志。

测试结果：

```bash
/Users/qiufeng/Documents/bilibilitickerbuy/.venv/bin/python -m pytest tests/test_task_log_controls.py tests/test_go_ticket_preview.py -q
```

结果：

```text
5 passed
```

同时已执行：

```bash
git diff --check
```

并在本地 UI 验证：打开 `操作抢票` 页面后，“一键终止”和“开始抢票”均可见；无运行任务时点击“一键终止”，会出现“当前没有运行中的抢票任务。”提示，浏览器控制台无相关错误。

### 事务

- [ ] 已与维护者在 issues 或其他平台沟通此 PR 大致内容

## 以下内容可在起草 PR 后、合并 PR 前逐步完成

### 功能

- [x] 已编写完善的配置文件字段说明（若有新增）
- [x] 已编写面向用户的新功能说明（若有必要）
- [x] 已测试新功能或更改

### 兼容性

- [x] 已处理版本兼容性
- [x] 已处理插件兼容问题

### 风险

可能导致或已知的问题:

- 本次改动只复用已有的单任务终止逻辑，不改变抢票启动、配置解析、代理分配或下单请求流程。
- “一键终止”只处理当前记录中仍为“运行中”且存在 `pid` 的任务；已完成、已结束、已主动结束或无 `pid` 的任务不会被强制处理。
- 批量终止时如果某个任务没有权限终止，会保留失败提示，不会把该任务错误标记为已主动结束。
