### PR TITLE
[codex] Understand Anything 代码结构图

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ build
 *.log
 *.json
 !assets/fail_messages.json
+!.understand-anything/config.json
+!.understand-anything/knowledge-graph.json
 tmp/*
 tmp
 __pycache__/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tools/understand-anything"]
+	path = tools/understand-anything
+	url = https://github.com/LingRadiance/Understand-Anything.git

--- a/.understand-anything/config.json
+++ b/.understand-anything/config.json
@@ -1,0 +1,3 @@
+{
+    "outputLanguage":  "zh"
+}

--- a/.understand-anything/knowledge-graph.json
+++ b/.understand-anything/knowledge-graph.json
@@ -1,0 +1,20766 @@
+{
+  "version": "1.0.0",
+  "project": {
+    "name": "bilitickerbuy",
+    "languages": [
+      "bak",
+      "batch",
+      "config",
+      "css",
+      "dockerfile",
+      "icns",
+      "in",
+      "json",
+      "markdown",
+      "python",
+      "shell",
+      "spec",
+      "toml",
+      "txt",
+      "unknown",
+      "yaml"
+    ],
+    "frameworks": [
+      "Gradio",
+      "Pydantic",
+      "Textual",
+      "pytest"
+    ],
+    "description": "开源的 B 站会员购/票务辅助工具，包含命令行、Gradio 界面、接口适配、核心购票任务、请求/Cookie 管理、代理、通知、日志和容器化发布支持。当前知识图谱包含文件、类、函数和调用关系，用于帮助贡献者按层级阅读代码。",
+    "analyzedAt": "2026-07-05T08:58:01Z",
+    "gitCommitHash": "141462fb1d9edc37f1eb776b573f0f848d60bebb",
+    "analysisWarnings": []
+  },
+  "nodes": [
+    {
+      "id": "file:__init__.py",
+      "type": "file",
+      "name": "__init__.py",
+      "filePath": "__init__.py",
+      "summary": "__init__.py 属于项目通用模块，主要包含以模块级常量或导入装配为主。",
+      "tags": [
+        "文件"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "resource:.dockerignore",
+      "type": "resource",
+      "name": ".dockerignore",
+      "filePath": ".dockerignore",
+      "summary": ".dockerignore 描述项目容器化、CI/CD 或部署自动化配置。",
+      "tags": [
+        "部署",
+        "unknown"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.github/ISSUE_TEMPLATE/bug-report.yml",
+      "type": "config",
+      "name": "bug-report.yml",
+      "filePath": ".github/ISSUE_TEMPLATE/bug-report.yml",
+      "summary": "bug-report.yml 配置项目打包、依赖、仓库流程或运行时资源。",
+      "tags": [
+        "yaml"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.github/ISSUE_TEMPLATE/feature-request.yml",
+      "type": "config",
+      "name": "feature-request.yml",
+      "filePath": ".github/ISSUE_TEMPLATE/feature-request.yml",
+      "summary": "feature-request.yml 配置项目打包、依赖、仓库流程或运行时资源。",
+      "tags": [
+        "接口",
+        "yaml"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:.github/pull_request_template.md",
+      "type": "document",
+      "name": "pull_request_template.md",
+      "filePath": ".github/pull_request_template.md",
+      "summary": "pull_request_template.md 说明项目安装、部署、代理自建或使用支持流程。",
+      "tags": [
+        "接口",
+        "文档",
+        "markdown"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.github/release-drafter.yml",
+      "type": "config",
+      "name": "release-drafter.yml",
+      "filePath": ".github/release-drafter.yml",
+      "summary": "release-drafter.yml 配置项目打包、依赖、仓库流程或运行时资源。",
+      "tags": [
+        "yaml"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "pipeline:.github/workflows/container-image.yml",
+      "type": "pipeline",
+      "name": "container-image.yml",
+      "filePath": ".github/workflows/container-image.yml",
+      "summary": "container-image.yml 描述项目容器化、CI/CD 或部署自动化配置。",
+      "tags": [
+        "部署",
+        "yaml"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "pipeline:.github/workflows/drawer.yml",
+      "type": "pipeline",
+      "name": "drawer.yml",
+      "filePath": ".github/workflows/drawer.yml",
+      "summary": "drawer.yml 描述项目容器化、CI/CD 或部署自动化配置。",
+      "tags": [
+        "部署",
+        "yaml"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "pipeline:.github/workflows/publish-pypi.yml",
+      "type": "pipeline",
+      "name": "publish-pypi.yml",
+      "filePath": ".github/workflows/publish-pypi.yml",
+      "summary": "publish-pypi.yml 描述项目容器化、CI/CD 或部署自动化配置。",
+      "tags": [
+        "部署",
+        "yaml"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "pipeline:.github/workflows/ruff-check.yml",
+      "type": "pipeline",
+      "name": "ruff-check.yml",
+      "filePath": ".github/workflows/ruff-check.yml",
+      "summary": "ruff-check.yml 描述项目容器化、CI/CD 或部署自动化配置。",
+      "tags": [
+        "部署",
+        "yaml"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "pipeline:.github/workflows/ruff-format.yml",
+      "type": "pipeline",
+      "name": "ruff-format.yml",
+      "filePath": ".github/workflows/ruff-format.yml",
+      "summary": "ruff-format.yml 描述项目容器化、CI/CD 或部署自动化配置。",
+      "tags": [
+        "部署",
+        "yaml"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.pre-commit-config.yaml",
+      "type": "config",
+      "name": ".pre-commit-config.yaml",
+      "filePath": ".pre-commit-config.yaml",
+      "summary": ".pre-commit-config.yaml 配置项目打包、依赖、仓库流程或运行时资源。",
+      "tags": [
+        "配置",
+        "yaml"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.python-version",
+      "type": "file",
+      "name": ".python-version",
+      "filePath": ".python-version",
+      "summary": ".python-version 是 unknown 文件，包含 0 个类和 0 个函数，参与 biliTickerBuy 的票务自动化流程。",
+      "tags": [
+        "unknown"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.understand-anything/.understandignore",
+      "type": "file",
+      "name": ".understandignore",
+      "filePath": ".understand-anything/.understandignore",
+      "summary": ".understandignore 是 unknown 文件，包含 0 个类和 0 个函数，参与 biliTickerBuy 的票务自动化流程。",
+      "tags": [
+        "unknown"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:app_cmd/__init__.py",
+      "type": "file",
+      "name": "__init__.py",
+      "filePath": "app_cmd/__init__.py",
+      "summary": "app_cmd/__init__.py 属于命令行购票流程，主要包含以模块级常量或导入装配为主。",
+      "tags": [
+        "文件",
+        "购票"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app_cmd/buy.py",
+      "type": "file",
+      "name": "buy.py",
+      "filePath": "app_cmd/buy.py",
+      "summary": "app_cmd/buy.py 属于命令行购票流程，主要包含函数：buy_cmd。",
+      "tags": [
+        "文件",
+        "购票",
+        "支付"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:app_cmd/cli_args.py",
+      "type": "file",
+      "name": "cli_args.py",
+      "filePath": "app_cmd/cli_args.py",
+      "summary": "app_cmd/cli_args.py 属于命令行购票流程，主要包含类：TickerCliArgs；函数：_env_bool、_env_optional_int、_env_optional_str。",
+      "tags": [
+        "文件",
+        "购票"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app_cmd/config/BuyConfig.py",
+      "type": "file",
+      "name": "BuyConfig.py",
+      "filePath": "app_cmd/config/BuyConfig.py",
+      "summary": "app_cmd/config/BuyConfig.py 属于命令行配置模型，主要包含类：BuyConfig。",
+      "tags": [
+        "文件",
+        "配置"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:app_cmd/config/ConfigBasic.py",
+      "type": "file",
+      "name": "ConfigBasic.py",
+      "filePath": "app_cmd/config/ConfigBasic.py",
+      "summary": "app_cmd/config/ConfigBasic.py 属于命令行配置模型，主要包含类：BasicConfig；函数：str_to_bool、normalize_log_level、config_field、nested_config_field。",
+      "tags": [
+        "文件",
+        "配置"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:app_cmd/config/NotifierConfig.py",
+      "type": "file",
+      "name": "NotifierConfig.py",
+      "filePath": "app_cmd/config/NotifierConfig.py",
+      "summary": "app_cmd/config/NotifierConfig.py 属于命令行配置模型，主要包含类：NotifierConfig。",
+      "tags": [
+        "文件",
+        "配置"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:app_cmd/ticker.py",
+      "type": "file",
+      "name": "ticker.py",
+      "filePath": "app_cmd/ticker.py",
+      "summary": "app_cmd/ticker.py 属于命令行购票流程，主要包含函数：exit_app_ui、shutdown_app_process、ticker_cmd。",
+      "tags": [
+        "文件",
+        "购票"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:app_update.py",
+      "type": "file",
+      "name": "app_update.py",
+      "filePath": "app_update.py",
+      "summary": "app_update.py 属于项目通用模块，主要包含类：UpdateError、ReleaseInfo；函数：normalize_version、select_update、fetch_update。",
+      "tags": [
+        "文件"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:app_version.py",
+      "type": "file",
+      "name": "app_version.py",
+      "filePath": "app_version.py",
+      "summary": "app_version.py 属于项目通用模块，主要包含函数：_read_pyproject_version、get_app_version。",
+      "tags": [
+        "文件"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:assets/fail_messages.json",
+      "type": "config",
+      "name": "fail_messages.json",
+      "filePath": "assets/fail_messages.json",
+      "summary": "fail_messages.json 配置项目打包、依赖、仓库流程或运行时资源。",
+      "tags": [
+        "json"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:assets/icon.icns",
+      "type": "file",
+      "name": "icon.icns",
+      "filePath": "assets/icon.icns",
+      "summary": "icon.icns 是 icns 文件，包含 0 个类和 0 个函数，参与 biliTickerBuy 的票务自动化流程。",
+      "tags": [
+        "icns"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:assets/style.css",
+      "type": "file",
+      "name": "style.css",
+      "filePath": "assets/style.css",
+      "summary": "style.css 是 css 文件，包含 0 个类和 0 个函数，参与 biliTickerBuy 的票务自动化流程。",
+      "tags": [
+        "界面",
+        "css"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "config:assets/updater/.env.install",
+      "type": "config",
+      "name": ".env.install",
+      "filePath": "assets/updater/.env.install",
+      "summary": ".env.install 配置项目打包、依赖、仓库流程或运行时资源。",
+      "tags": [
+        "config"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:assets/updater/update.bat",
+      "type": "file",
+      "name": "update.bat",
+      "filePath": "assets/updater/update.bat",
+      "summary": "update.bat 自动化安装、更新或本地运行辅助操作。",
+      "tags": [
+        "脚本",
+        "batch"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:assets/updater/update.sh",
+      "type": "file",
+      "name": "update.sh",
+      "filePath": "assets/updater/update.sh",
+      "summary": "update.sh 自动化安装、更新或本地运行辅助操作。",
+      "tags": [
+        "脚本",
+        "函数",
+        "shell"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:config.json.bak",
+      "type": "file",
+      "name": "config.json.bak",
+      "filePath": "config.json.bak",
+      "summary": "config.json.bak 是 bak 文件，包含 0 个类和 0 个函数，参与 biliTickerBuy 的票务自动化流程。",
+      "tags": [
+        "配置",
+        "bak"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:cookies.json.bak",
+      "type": "file",
+      "name": "cookies.json.bak",
+      "filePath": "cookies.json.bak",
+      "summary": "cookies.json.bak 是 bak 文件，包含 0 个类和 0 个函数，参与 biliTickerBuy 的票务自动化流程。",
+      "tags": [
+        "bak"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:cptoken/__init__.py",
+      "type": "file",
+      "name": "__init__.py",
+      "filePath": "cptoken/__init__.py",
+      "summary": "cptoken/__init__.py 属于项目通用模块，主要包含类：CTokenSnapshot、BrowserWindowState、CTokenRuntimeState；函数：generate_ctoken、generate_browser_window_state、init_ctoken_state、sim_ctoken_state。",
+      "tags": [
+        "文件"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "service:docker-compose.yml",
+      "type": "service",
+      "name": "docker-compose.yml",
+      "filePath": "docker-compose.yml",
+      "summary": "docker-compose.yml 描述项目容器化、CI/CD 或部署自动化配置。",
+      "tags": [
+        "部署",
+        "yaml"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "service:Dockerfile",
+      "type": "service",
+      "name": "Dockerfile",
+      "filePath": "Dockerfile",
+      "summary": "Dockerfile 描述项目容器化、CI/CD 或部署自动化配置。",
+      "tags": [
+        "部署",
+        "dockerfile"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:docs/docker-deployment.md",
+      "type": "document",
+      "name": "docker-deployment.md",
+      "filePath": "docs/docker-deployment.md",
+      "summary": "docker-deployment.md 说明项目安装、部署、代理自建或使用支持流程。",
+      "tags": [
+        "文档",
+        "markdown"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:docs/installation.md",
+      "type": "document",
+      "name": "installation.md",
+      "filePath": "docs/installation.md",
+      "summary": "installation.md 说明项目安装、部署、代理自建或使用支持流程。",
+      "tags": [
+        "文档",
+        "markdown"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/proxy-self-hosting.md",
+      "type": "document",
+      "name": "proxy-self-hosting.md",
+      "filePath": "docs/proxy-self-hosting.md",
+      "summary": "proxy-self-hosting.md 说明项目安装、部署、代理自建或使用支持流程。",
+      "tags": [
+        "代理",
+        "文档",
+        "markdown"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:install.sh",
+      "type": "file",
+      "name": "install.sh",
+      "filePath": "install.sh",
+      "summary": "install.sh 自动化安装、更新或本地运行辅助操作。",
+      "tags": [
+        "脚本",
+        "函数",
+        "shell"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:interface/__init__.py",
+      "type": "file",
+      "name": "__init__.py",
+      "filePath": "interface/__init__.py",
+      "summary": "interface/__init__.py 属于界面/API 适配层，主要包含以模块级常量或导入装配为主。",
+      "tags": [
+        "文件",
+        "界面"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:interface/auth.py",
+      "type": "file",
+      "name": "auth.py",
+      "filePath": "interface/auth.py",
+      "summary": "interface/auth.py 属于界面/API 适配层，主要包含函数：get_login_state、start_qr_login、poll_qr_login、login_with_cookies。",
+      "tags": [
+        "文件",
+        "界面",
+        "认证"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:interface/common.py",
+      "type": "file",
+      "name": "common.py",
+      "filePath": "interface/common.py",
+      "summary": "interface/common.py 属于界面/API 适配层，主要包含函数：_load_json_file、_read_tinydb_value、_cookie_store_path、_coerce_cookie_store、_resolve_cookie_list、_cookies_to_header、_fetch_username_silently、_deepcopy_dict。",
+      "tags": [
+        "文件",
+        "界面"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:interface/config.py",
+      "type": "file",
+      "name": "config.py",
+      "filePath": "interface/config.py",
+      "summary": "interface/config.py 属于界面/API 适配层，主要包含类：RuntimeOptions；函数：normalize_time_start、normalize_interval、normalize_non_negative_interval、normalize_positive_int、load_ticket_config、save_ticket_config、_normalize_buyer_info、generate_ticket_config。",
+      "tags": [
+        "文件",
+        "界面"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:interface/execution.py",
+      "type": "file",
+      "name": "execution.py",
+      "filePath": "interface/execution.py",
+      "summary": "interface/execution.py 属于界面/API 适配层，主要包含函数：_collect_payment_fields_from_event、_package_root、_managed_runs_root、_dump_json、_load_json、_read_text_tail、_heartbeat_timeout_seconds、_update_managed_status。",
+      "tags": [
+        "文件",
+        "界面"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:interface/managed_runner.py",
+      "type": "file",
+      "name": "managed_runner.py",
+      "filePath": "interface/managed_runner.py",
+      "summary": "interface/managed_runner.py 属于界面/API 适配层，主要包含函数：_load_json、_dump_json、_append_log、_heartbeat_loop、main。",
+      "tags": [
+        "文件",
+        "界面",
+        "执行"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:interface/project.py",
+      "type": "file",
+      "name": "project.py",
+      "filePath": "interface/project.py",
+      "summary": "interface/project.py 属于界面/API 适配层，主要包含函数：_normalize_new_project_payload、_fetch_project_payload_new、_fetch_project_payload_old、fetch_project_payload、_build_ticket_option、_merge_link_goods、_fetch_ticket_options、fetch_project_detail。",
+      "tags": [
+        "文件",
+        "界面"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:interface/search.py",
+      "type": "file",
+      "name": "search.py",
+      "filePath": "interface/search.py",
+      "summary": "interface/search.py 属于界面/API 适配层，主要包含函数：search_tickets、format_ticket_search_results_text。",
+      "tags": [
+        "文件",
+        "界面"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:interface/types.py",
+      "type": "file",
+      "name": "types.py",
+      "filePath": "interface/types.py",
+      "summary": "interface/types.py 属于界面/API 适配层，主要包含类：ValidationResult、BuyTaskRecord。",
+      "tags": [
+        "文件",
+        "界面"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:main.py",
+      "type": "file",
+      "name": "main.py",
+      "filePath": "main.py",
+      "summary": "main.py 属于项目通用模块，主要包含函数：_normalize_argv、main。",
+      "tags": [
+        "文件"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:main.spec",
+      "type": "file",
+      "name": "main.spec",
+      "filePath": "main.spec",
+      "summary": "main.spec 是 spec 文件，包含 0 个类和 0 个函数，参与 biliTickerBuy 的票务自动化流程。",
+      "tags": [
+        "spec"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:MANIFEST.in",
+      "type": "file",
+      "name": "MANIFEST.in",
+      "filePath": "MANIFEST.in",
+      "summary": "MANIFEST.in 是 in 文件，包含 0 个类和 0 个函数，参与 biliTickerBuy 的票务自动化流程。",
+      "tags": [
+        "in"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:pyproject.toml",
+      "type": "config",
+      "name": "pyproject.toml",
+      "filePath": "pyproject.toml",
+      "summary": "pyproject.toml 配置项目打包、依赖、仓库流程或运行时资源。",
+      "tags": [
+        "toml"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "README.md",
+      "summary": "README.md 说明项目安装、部署、代理自建或使用支持流程。",
+      "tags": [
+        "文档",
+        "markdown"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:requirements.txt",
+      "type": "document",
+      "name": "requirements.txt",
+      "filePath": "requirements.txt",
+      "summary": "requirements.txt 说明项目安装、部署、代理自建或使用支持流程。",
+      "tags": [
+        "文档",
+        "txt"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tab/__init__.py",
+      "type": "file",
+      "name": "__init__.py",
+      "filePath": "tab/__init__.py",
+      "summary": "tab/__init__.py 属于Gradio 界面标签页，主要包含以模块级常量或导入装配为主。",
+      "tags": [
+        "文件",
+        "界面"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tab/config.py",
+      "type": "file",
+      "name": "config.py",
+      "filePath": "tab/config.py",
+      "summary": "tab/config.py 属于Gradio 界面标签页，主要包含函数：go_settings_tab。",
+      "tags": [
+        "文件",
+        "界面"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tab/go.py",
+      "type": "file",
+      "name": "go.py",
+      "filePath": "tab/go.py",
+      "summary": "tab/go.py 属于Gradio 界面标签页，主要包含函数：withTimeString、_build_task_log_path、_build_task_proxy_list、_parse_sale_start、_preview_value、_format_price_cents、_format_buyer_identity、_render_ticket_preview。",
+      "tags": [
+        "文件",
+        "界面"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tab/log.py",
+      "type": "file",
+      "name": "log.py",
+      "filePath": "tab/log.py",
+      "summary": "tab/log.py 属于Gradio 界面标签页，主要包含函数：_status_class、_refresh_token、build_main_log_card、_render_log_path、_render_log_view_action、_list_log_files、_find_task_entry_by_log_file、clear_log_files。",
+      "tags": [
+        "文件",
+        "界面"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tab/problems.py",
+      "type": "file",
+      "name": "problems.py",
+      "filePath": "tab/problems.py",
+      "summary": "tab/problems.py 属于Gradio 界面标签页，主要包含函数：problems_tab。",
+      "tags": [
+        "文件",
+        "界面"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tab/settings.py",
+      "type": "file",
+      "name": "settings.py",
+      "filePath": "tab/settings.py",
+      "summary": "tab/settings.py 属于Gradio 界面标签页，主要包含函数：_format_account_choice、_find_uid_from_choice、_resolve_default_account_choice、_read_positive_int、_iter_project_dates、_fetch_screens_by_date、_normalize_date_string、_screen_matches_date。",
+      "tags": [
+        "文件",
+        "界面"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tab/update.py",
+      "type": "file",
+      "name": "update.py",
+      "filePath": "tab/update.py",
+      "summary": "tab/update.py 属于Gradio 界面标签页，主要包含函数：_saved_channel、_format_update、_update_script_name、_runtime_mode、_source_update_hint、_pip_update_hint、_bundled_update_hint、_update_hint。",
+      "tags": [
+        "文件",
+        "界面"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:task/__init__.py",
+      "type": "file",
+      "name": "__init__.py",
+      "filePath": "task/__init__.py",
+      "summary": "task/__init__.py 属于核心购票任务，主要包含以模块级常量或导入装配为主。",
+      "tags": [
+        "文件",
+        "购票"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:task/buy_helpers.py",
+      "type": "file",
+      "name": "buy_helpers.py",
+      "filePath": "task/buy_helpers.py",
+      "summary": "task/buy_helpers.py 属于核心购票任务，主要包含函数：get_qrcode_url、get_order_detail_url、build_payment_result、format_countdown、next_countdown_report_at、wait_until_start、build_token_payload、build_order_token。",
+      "tags": [
+        "文件",
+        "购票",
+        "支付"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:task/buy_types.py",
+      "type": "file",
+      "name": "buy_types.py",
+      "filePath": "task/buy_types.py",
+      "summary": "task/buy_types.py 属于核心购票任务，主要包含类：BuyStreamState、BuyStreamEvent、BuyStreamUpdate、RetryOutcome、CreateOrderTerminalRule、LatestValueWorker。",
+      "tags": [
+        "文件",
+        "购票",
+        "支付"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:task/buy.py",
+      "type": "file",
+      "name": "buy.py",
+      "filePath": "task/buy.py",
+      "summary": "task/buy.py 属于核心购票任务，主要包含类：Buy；函数：_extract_prepare_token、_format_reprepare_reason、buy_stream、buy_new_terminal。",
+      "tags": [
+        "文件",
+        "购票",
+        "支付"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/conftest.py",
+      "type": "file",
+      "name": "conftest.py",
+      "filePath": "tests/conftest.py",
+      "summary": "tests/conftest.py 属于自动化测试，主要包含以模块级常量或导入装配为主。",
+      "tags": [
+        "文件",
+        "测试"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/test_app_update.py",
+      "type": "file",
+      "name": "test_app_update.py",
+      "filePath": "tests/test_app_update.py",
+      "summary": "tests/test_app_update.py 属于自动化测试，主要包含函数：_release、test_stable_channel_skips_prereleases、test_prerelease_channel_selects_newest_version。",
+      "tags": [
+        "文件",
+        "测试"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/test_bili_request_h2_recovery.py",
+      "type": "file",
+      "name": "test_bili_request_h2_recovery.py",
+      "filePath": "tests/test_bili_request_h2_recovery.py",
+      "summary": "tests/test_bili_request_h2_recovery.py 属于自动化测试，主要包含函数：test_request_retries_once_after_h2_local_protocol_error、test_request_raises_connection_error_after_second_h2_local_protocol_error、test_request_raises_connection_error_after_second_read_timeout。",
+      "tags": [
+        "文件",
+        "测试"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/test_bili_request_maintenance.py",
+      "type": "file",
+      "name": "test_bili_request_maintenance.py",
+      "filePath": "tests/test_bili_request_maintenance.py",
+      "summary": "tests/test_bili_request_maintenance.py 属于自动化测试，主要包含函数：test_handle_100001_calls_registered_handler、test_handle_100001_ignores_other_errno。",
+      "tags": [
+        "文件",
+        "测试"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/test_bili_request_rate_limit.py",
+      "type": "file",
+      "name": "test_bili_request_rate_limit.py",
+      "filePath": "tests/test_bili_request_rate_limit.py",
+      "summary": "tests/test_bili_request_rate_limit.py 属于自动化测试，主要包含函数：test_request_raises_rate_limit_error。",
+      "tags": [
+        "文件",
+        "测试"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/test_buy_prepare_token.py",
+      "type": "file",
+      "name": "test_buy_prepare_token.py",
+      "filePath": "tests/test_buy_prepare_token.py",
+      "summary": "tests/test_buy_prepare_token.py 属于自动化测试，主要包含函数：test_extract_prepare_token_returns_none_when_missing、test_extract_prepare_token_returns_string_when_present。",
+      "tags": [
+        "文件",
+        "测试",
+        "支付"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/test_buy_refresh_count.py",
+      "type": "file",
+      "name": "test_buy_refresh_count.py",
+      "filePath": "tests/test_buy_refresh_count.py",
+      "summary": "tests/test_buy_refresh_count.py 属于自动化测试，主要包含函数：_make_scheduler、_config、test_trigger_after_target_count_then_resets、test_fetch_not_concurrent_with_create、test_disabled_when_max_zero、test_disabled_when_min_greater_than_max、test_100001_resets_counter、test_default_config_values。",
+      "tags": [
+        "文件",
+        "测试",
+        "支付"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/test_buy_reprepare_reason.py",
+      "type": "file",
+      "name": "test_buy_reprepare_reason.py",
+      "filePath": "tests/test_buy_reprepare_reason.py",
+      "summary": "tests/test_buy_reprepare_reason.py 属于自动化测试，主要包含函数：test_format_reprepare_reason_includes_cause。",
+      "tags": [
+        "文件",
+        "测试",
+        "支付"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/test_buy_time_sync.py",
+      "type": "file",
+      "name": "test_buy_time_sync.py",
+      "filePath": "tests/test_buy_time_sync.py",
+      "summary": "tests/test_buy_time_sync.py 属于自动化测试，主要包含类：_FakeTicketState、_FakeCreateState、_FakeTimeService；函数：test_prepare_create_request_uses_calibrated_timestamp。",
+      "tags": [
+        "文件",
+        "测试",
+        "支付"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/test_go_ticket_preview.py",
+      "type": "file",
+      "name": "test_go_ticket_preview.py",
+      "filePath": "tests/test_go_ticket_preview.py",
+      "summary": "tests/test_go_ticket_preview.py 属于自动化测试，主要包含函数：test_ticket_preview_appends_buyer_document_type。",
+      "tags": [
+        "文件",
+        "测试",
+        "支付"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/test_local_fanout_proxy_strategy.py",
+      "type": "file",
+      "name": "test_local_fanout_proxy_strategy.py",
+      "filePath": "tests/test_local_fanout_proxy_strategy.py",
+      "summary": "tests/test_local_fanout_proxy_strategy.py 属于自动化测试，主要包含类：FakeCookies、FakeH2Client、FakeH2Connection；函数：test_task_proxy_list_includes_direct_when_enabled、test_task_proxy_list_excludes_direct_when_disabled、test_task_proxy_list_can_require_configured_proxy、test_runtime_strategy_flows_into_buy_config、test_h2_client_constructor_uses_abstract_client_interface、test_replace_proxy_pool_updates_h2_client_options、test_proxy_pool_fanout_builds_one_create_connection_per_proxy、test_proxy_pool_fanout_repeats_until_one_proxy_succeeds。",
+      "tags": [
+        "文件",
+        "测试"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/test_login_account_defaults.py",
+      "type": "file",
+      "name": "test_login_account_defaults.py",
+      "filePath": "tests/test_login_account_defaults.py",
+      "summary": "tests/test_login_account_defaults.py 属于自动化测试，主要包含函数：test_resolve_default_account_choice_prefers_active_uid、test_resolve_default_account_choice_falls_back_to_first_choice。",
+      "tags": [
+        "文件",
+        "测试",
+        "认证"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/test_notifier_join_all.py",
+      "type": "file",
+      "name": "test_notifier_join_all.py",
+      "filePath": "tests/test_notifier_join_all.py",
+      "summary": "tests/test_notifier_join_all.py 属于自动化测试，主要包含类：_FakeNotifier；函数：_make_manager、test_join_all_waits_for_push_to_complete、test_join_all_blocks_until_thread_finishes、test_join_all_timeout_does_not_block_forever、test_join_all_no_notifiers_returns_immediately。",
+      "tags": [
+        "文件",
+        "测试"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/test_payment_result_fields.py",
+      "type": "file",
+      "name": "test_payment_result_fields.py",
+      "filePath": "tests/test_payment_result_fields.py",
+      "summary": "tests/test_payment_result_fields.py 属于自动化测试，主要包含类：_DummyRequest；函数：test_build_payment_result_contains_order_and_code_urls、test_collect_payment_fields_from_event_reads_new_fields。",
+      "tags": [
+        "文件",
+        "测试",
+        "支付"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/test_proxy_api_provider.py",
+      "type": "file",
+      "name": "test_proxy_api_provider.py",
+      "filePath": "tests/test_proxy_api_provider.py",
+      "summary": "tests/test_proxy_api_provider.py 属于自动化测试，主要包含函数：_proxy_url、test_build_proxy_api_url_overrides_required_params、test_parse_youdaili_success_response_as_http_proxy、test_parse_youdaili_success_response_as_socks_proxy、test_parse_proxy_api_keeps_auth_from_standard_url、test_parse_proxy_api_keeps_auth_from_host_port_user_pass、test_parse_proxy_api_keeps_auth_from_object_fields、test_parse_proxy_api_merges_auth_fields_with_proxy_field。",
+      "tags": [
+        "文件",
+        "测试"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/test_settings_ticket_selection.py",
+      "type": "file",
+      "name": "test_settings_ticket_selection.py",
+      "filePath": "tests/test_settings_ticket_selection.py",
+      "summary": "tests/test_settings_ticket_selection.py 属于自动化测试，主要包含类：_JsonResponse、_FakeRequest、_FakeCookieManager、_FakeAccountRequest；函数：_project_payload、test_submit_ticket_id_resets_stale_selection_values、test_has_invalid_index_detects_stale_buyer_selection、test_submit_all_rejects_ticket_context_from_previous_account。",
+      "tags": [
+        "文件",
+        "测试"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/test_task_log_controls.py",
+      "type": "file",
+      "name": "test_task_log_controls.py",
+      "filePath": "tests/test_task_log_controls.py",
+      "summary": "tests/test_task_log_controls.py 属于自动化测试，主要包含函数：test_is_task_running_treats_posix_zombie_as_stopped、test_terminate_task_falls_back_to_process_signal_when_group_denied、test_terminate_task_returns_message_when_signal_permission_denied、test_stop_all_running_tasks_stops_only_active_pid_entries。",
+      "tags": [
+        "文件",
+        "测试"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/test_time_util.py",
+      "type": "file",
+      "name": "test_time_util.py",
+      "filePath": "tests/test_time_util.py",
+      "summary": "tests/test_time_util.py 属于自动化测试，主要包含函数：test_current_time_ms_applies_local_minus_reference_offset、test_time_service_now_uses_calibrated_reference_time、test_countdown_now_prefers_bili_date_check、test_compute_ntp_sample_uses_low_delay_median、test_compute_ntp_sample_returns_fast_primary_without_backup_calls、test_compute_bili_time_check_parses_http_date。",
+      "tags": [
+        "文件",
+        "测试"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:util/__init__.py",
+      "type": "file",
+      "name": "__init__.py",
+      "filePath": "util/__init__.py",
+      "summary": "util/__init__.py 属于项目通用模块，主要包含类：TaskLogEntry、RuntimeStateStore、GlobalStatus；函数：get_application_path、get_exec_path、get_application_tmp_path、set_main_request、runtime_state_reader、runtime_state_writer。",
+      "tags": [
+        "文件"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:util/Constant.py",
+      "type": "file",
+      "name": "Constant.py",
+      "filePath": "util/Constant.py",
+      "summary": "util/Constant.py 属于项目通用模块，主要包含以模块级常量或导入装配为主。",
+      "tags": [
+        "文件"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:util/ErrorCodes.py",
+      "type": "file",
+      "name": "ErrorCodes.py",
+      "filePath": "util/ErrorCodes.py",
+      "summary": "util/ErrorCodes.py 属于项目通用模块，主要包含类：ErrorCodes。",
+      "tags": [
+        "文件"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:util/h2client/abstract_h2_client.py",
+      "type": "file",
+      "name": "abstract_h2_client.py",
+      "filePath": "util/h2client/abstract_h2_client.py",
+      "summary": "util/h2client/abstract_h2_client.py 属于HTTP/2 客户端，主要包含类：H2Headers、H2Cookies、H2Response、AbstractH2Client。",
+      "tags": [
+        "文件",
+        "请求"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:util/h2client/client_ja.py",
+      "type": "file",
+      "name": "client_ja.py",
+      "filePath": "util/h2client/client_ja.py",
+      "summary": "util/h2client/client_ja.py 属于HTTP/2 客户端，主要包含类：ClientHelloProfile、BuiltClientHello、Fingerprints、CipherSuiteSpec、TLSAlert、HandshakeBuffer；函数：u8、u16、u24、vec_u8、vec_u16、tls_ext、build_extension_body、build_extensions。",
+      "tags": [
+        "文件",
+        "请求"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:util/h2client/constants.py",
+      "type": "file",
+      "name": "constants.py",
+      "filePath": "util/h2client/constants.py",
+      "summary": "util/h2client/constants.py 属于HTTP/2 客户端，主要包含以模块级常量或导入装配为主。",
+      "tags": [
+        "文件",
+        "请求"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:util/h2client/h2connection.py",
+      "type": "file",
+      "name": "h2connection.py",
+      "filePath": "util/h2client/h2connection.py",
+      "summary": "util/h2client/h2connection.py 属于HTTP/2 客户端，主要包含类：H2Response、RequestTarget、JAMatch、H2ConnectionConfig、H2Connection；函数：format_authority、verify_client_hello_ja、assert_client_hello_ja、_coerce_body、_body_for_log、_header_value、_normalize_header_items、_parse_request_target。",
+      "tags": [
+        "文件",
+        "请求"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses Python dataclasses and context-managed client objects to structure network state."
+    },
+    {
+      "id": "file:util/h2client/ja_h2_client.py",
+      "type": "file",
+      "name": "ja_h2_client.py",
+      "filePath": "util/h2client/ja_h2_client.py",
+      "summary": "util/h2client/ja_h2_client.py 属于HTTP/2 客户端，主要包含类：SourceAddress、ConnectionSlot、FanoutOutcome、HealthcheckOutcome、_SourcePoolJA3H2Client、_CreateV2FanoutJA3H2Client；函数：_normalize_proxy_list、_dedupe_sources、_append_params、_json_body、_form_body、_header_mapping、_set_default_header、_timeout_seconds。",
+      "tags": [
+        "文件",
+        "请求"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses Python dataclasses and context-managed client objects to structure network state."
+    },
+    {
+      "id": "file:util/h2client/local_sources.py",
+      "type": "file",
+      "name": "local_sources.py",
+      "filePath": "util/h2client/local_sources.py",
+      "summary": "util/h2client/local_sources.py 属于HTTP/2 客户端，主要包含函数：_is_usable_source_ip、_source_address、_dedupe_sources、_discover_sources_with_powershell、_discover_sources_with_socket、discover_interface_source_ips。",
+      "tags": [
+        "文件",
+        "请求"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:util/log/LogConfig.py",
+      "type": "file",
+      "name": "LogConfig.py",
+      "filePath": "util/log/LogConfig.py",
+      "summary": "util/log/LogConfig.py 属于日志与终端输出，主要包含函数：loguru_config。",
+      "tags": [
+        "文件"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:util/log/LogWeb.py",
+      "type": "file",
+      "name": "LogWeb.py",
+      "filePath": "util/log/LogWeb.py",
+      "summary": "util/log/LogWeb.py 属于日志与终端输出，主要包含函数：build_log_view_url、_resolve_log_path、_read_log_text、attach_log_routes、build_log_stream_url、_sse。",
+      "tags": [
+        "文件"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:util/log/TerminalRenderer.py",
+      "type": "file",
+      "name": "TerminalRenderer.py",
+      "filePath": "util/log/TerminalRenderer.py",
+      "summary": "util/log/TerminalRenderer.py 属于日志与终端输出，主要包含类：TerminalRenderContext、TerminalViewState、LogItem、BaseTerminalRenderer、PlainTerminalRenderer、TextualTerminalRenderer；函数：_extract_message_meta、_make_log_item、_can_merge_log_item、_merge_log_item、create_terminal_renderer、render_message_stream。",
+      "tags": [
+        "文件"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:util/notifer/AudioUtil.py",
+      "type": "file",
+      "name": "AudioUtil.py",
+      "filePath": "util/notifer/AudioUtil.py",
+      "summary": "util/notifer/AudioUtil.py 属于通知渠道，主要包含类：AudioNotifier。",
+      "tags": [
+        "文件",
+        "通知"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:util/notifer/BarkUtil.py",
+      "type": "file",
+      "name": "BarkUtil.py",
+      "filePath": "util/notifer/BarkUtil.py",
+      "summary": "util/notifer/BarkUtil.py 属于通知渠道，主要包含类：BarkNotifier。",
+      "tags": [
+        "文件",
+        "通知"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:util/notifer/MeoWUtil.py",
+      "type": "file",
+      "name": "MeoWUtil.py",
+      "filePath": "util/notifer/MeoWUtil.py",
+      "summary": "util/notifer/MeoWUtil.py 属于通知渠道，主要包含类：MeoWNotifier。",
+      "tags": [
+        "文件",
+        "通知"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:util/notifer/Notifier.py",
+      "type": "file",
+      "name": "Notifier.py",
+      "filePath": "util/notifer/Notifier.py",
+      "summary": "util/notifer/Notifier.py 属于通知渠道，主要包含类：NotifierBase、NotifierManager。",
+      "tags": [
+        "文件",
+        "通知"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:util/notifer/NtfyUtil.py",
+      "type": "file",
+      "name": "NtfyUtil.py",
+      "filePath": "util/notifer/NtfyUtil.py",
+      "summary": "util/notifer/NtfyUtil.py 属于通知渠道，主要包含类：RepeatedNotifier、NtfyNotifier；函数：send_message、send_repeat_message、stop_notification、test_connection。",
+      "tags": [
+        "文件",
+        "通知"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:util/notifer/RandomMessages.py",
+      "type": "file",
+      "name": "RandomMessages.py",
+      "filePath": "util/notifer/RandomMessages.py",
+      "summary": "util/notifer/RandomMessages.py 属于通知渠道，主要包含函数：_load_messages、get_random_fail_message。",
+      "tags": [
+        "文件",
+        "通知"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:util/notifer/ServerChanUtil.py",
+      "type": "file",
+      "name": "ServerChanUtil.py",
+      "filePath": "util/notifer/ServerChanUtil.py",
+      "summary": "util/notifer/ServerChanUtil.py 属于通知渠道，主要包含类：ServerChanTurboNotifier、ServerChan3Notifier。",
+      "tags": [
+        "文件",
+        "通知"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:util/proxy/ProxyApiProvider.py",
+      "type": "file",
+      "name": "ProxyApiProvider.py",
+      "filePath": "util/proxy/ProxyApiProvider.py",
+      "summary": "util/proxy/ProxyApiProvider.py 属于代理管理，主要包含类：ProxyApiError、ProxyApiResult；函数：normalize_proxy_api_protocol、build_proxy_api_url、_iter_proxy_items、_normalize_proxy_scheme、_format_proxy_url、_get_any_key、_extract_proxy_parts、parse_proxy_api_response。",
+      "tags": [
+        "文件",
+        "代理"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:util/proxy/ProxyBackoff.py",
+      "type": "file",
+      "name": "ProxyBackoff.py",
+      "filePath": "util/proxy/ProxyBackoff.py",
+      "summary": "util/proxy/ProxyBackoff.py 属于代理管理，主要包含类：ProxyBackoff。",
+      "tags": [
+        "文件",
+        "代理"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:util/proxy/ProxyManager.py",
+      "type": "file",
+      "name": "ProxyManager.py",
+      "filePath": "util/proxy/ProxyManager.py",
+      "summary": "util/proxy/ProxyManager.py 属于代理管理，主要包含类：ProxyManager。",
+      "tags": [
+        "文件",
+        "代理"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:util/proxy/ProxyState.py",
+      "type": "file",
+      "name": "ProxyState.py",
+      "filePath": "util/proxy/ProxyState.py",
+      "summary": "util/proxy/ProxyState.py 属于代理管理，主要包含类：ProxyStateEntry、ProxyStateRegistry。",
+      "tags": [
+        "文件",
+        "代理"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:util/proxy/ProxyTester.py",
+      "type": "file",
+      "name": "ProxyTester.py",
+      "filePath": "util/proxy/ProxyTester.py",
+      "summary": "util/proxy/ProxyTester.py 属于代理管理，主要包含类：ProxyTester；函数：test_proxy_connectivity。",
+      "tags": [
+        "文件",
+        "代理"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:util/proxy/PushPlusUtil.py",
+      "type": "file",
+      "name": "PushPlusUtil.py",
+      "filePath": "util/proxy/PushPlusUtil.py",
+      "summary": "util/proxy/PushPlusUtil.py 属于代理管理，主要包含类：PushPlusNotifier。",
+      "tags": [
+        "文件",
+        "代理",
+        "推送"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:util/request/BiliRequest.py",
+      "type": "file",
+      "name": "BiliRequest.py",
+      "filePath": "util/request/BiliRequest.py",
+      "summary": "util/request/BiliRequest.py 属于请求与 Cookie 管理，主要包含类：BiliRequest。",
+      "tags": [
+        "文件",
+        "请求"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:util/request/BrowerState.py",
+      "type": "file",
+      "name": "BrowerState.py",
+      "filePath": "util/request/BrowerState.py",
+      "summary": "util/request/BrowerState.py 属于请求与 Cookie 管理，主要包含类：BrowserWindowState、BrowserDisplayState、BrowserNavigatorState、BrowserLocaleState、BrowserLocationState、BrowserWebGLState；函数：random_hex、build_chrome_user_agent、extract_app_version_from_ua、generate_browser_window_state、generate_browser_display_state、generate_browser_navigator_state、generate_browser_locale_state、generate_browser_location_state。",
+      "tags": [
+        "文件",
+        "请求"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:util/request/CookieManager.py",
+      "type": "file",
+      "name": "CookieManager.py",
+      "filePath": "util/request/CookieManager.py",
+      "summary": "util/request/CookieManager.py 属于请求与 Cookie 管理，主要包含类：Account、CookieManager；函数：parse_cookie_list。",
+      "tags": [
+        "文件",
+        "请求",
+        "认证"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:util/request/exceptions/__init__.py",
+      "type": "file",
+      "name": "__init__.py",
+      "filePath": "util/request/exceptions/__init__.py",
+      "summary": "util/request/exceptions/__init__.py 属于请求与 Cookie 管理，主要包含以模块级常量或导入装配为主。",
+      "tags": [
+        "文件",
+        "请求"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:util/request/exceptions/connection.py",
+      "type": "file",
+      "name": "connection.py",
+      "filePath": "util/request/exceptions/connection.py",
+      "summary": "util/request/exceptions/connection.py 属于请求与 Cookie 管理，主要包含类：BiliConnectionError。",
+      "tags": [
+        "文件",
+        "请求"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:util/request/exceptions/rate_limit.py",
+      "type": "file",
+      "name": "rate_limit.py",
+      "filePath": "util/request/exceptions/rate_limit.py",
+      "summary": "util/request/exceptions/rate_limit.py 属于请求与 Cookie 管理，主要包含类：BiliRateLimitError。",
+      "tags": [
+        "文件",
+        "请求"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:util/request/TokenUtil.py",
+      "type": "file",
+      "name": "TokenUtil.py",
+      "filePath": "util/request/TokenUtil.py",
+      "summary": "util/request/TokenUtil.py 属于请求与 Cookie 管理，主要包含函数：generate_token。",
+      "tags": [
+        "文件",
+        "请求"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:util/Storage/CleanupUtil.py",
+      "type": "file",
+      "name": "CleanupUtil.py",
+      "filePath": "util/Storage/CleanupUtil.py",
+      "summary": "util/Storage/CleanupUtil.py 属于本地存储，主要包含函数：_trim_old_paths、_remove_path、cleanup_runtime_artifacts。",
+      "tags": [
+        "文件"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:util/Storage/KVDatabase.py",
+      "type": "file",
+      "name": "KVDatabase.py",
+      "filePath": "util/Storage/KVDatabase.py",
+      "summary": "util/Storage/KVDatabase.py 属于本地存储，主要包含类：KVDatabase；函数：_ensure_valid_tinydb_file。",
+      "tags": [
+        "文件"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:util/TimeUtil.py",
+      "type": "file",
+      "name": "TimeUtil.py",
+      "filePath": "util/TimeUtil.py",
+      "summary": "util/TimeUtil.py 属于项目通用模块，主要包含类：TimeSyncSample、BiliTimeCheck、TimeUtil；函数：current_time_ms。",
+      "tags": [
+        "文件"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:interface/auth.py:get_login_state",
+      "type": "function",
+      "name": "get_login_state",
+      "filePath": "interface/auth.py",
+      "lineRange": [
+        17,
+        33
+      ],
+      "summary": "`get_login_state(cookies, cookies_path)` 位于界面/API 适配层，负责处理登录认证或 Cookie 状态；内部主要调用 _resolve_cookie_list、bool、_fetch_username_silently、_cookie_store_path。",
+      "tags": [
+        "函数",
+        "界面",
+        "认证"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 17 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:interface/auth.py:start_qr_login",
+      "type": "function",
+      "name": "start_qr_login",
+      "filePath": "interface/auth.py",
+      "lineRange": [
+        36,
+        84
+      ],
+      "summary": "`start_qr_login(headers, max_retry, retry_interval, qr_image_path)` 位于界面/API 适配层，负责处理登录认证或 Cookie 状态；内部主要调用 range、get、json、sleep、mkdir、QRCode。",
+      "tags": [
+        "函数",
+        "界面",
+        "认证"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 4 个，约 49 行，直接调用约 16 次。"
+    },
+    {
+      "id": "function:interface/auth.py:poll_qr_login",
+      "type": "function",
+      "name": "poll_qr_login",
+      "filePath": "interface/auth.py",
+      "lineRange": [
+        87,
+        146
+      ],
+      "summary": "`poll_qr_login(qrcode_key, cookies_path, timeout_seconds, poll_interval, headers)` 位于界面/API 适配层，负责处理登录认证或 Cookie 状态；内部主要调用 ValueError、time、get、json。",
+      "tags": [
+        "函数",
+        "界面",
+        "认证"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 5 个，约 60 行，直接调用约 17 次。"
+    },
+    {
+      "id": "function:interface/auth.py:login_with_cookies",
+      "type": "function",
+      "name": "login_with_cookies",
+      "filePath": "interface/auth.py",
+      "lineRange": [
+        149,
+        162
+      ],
+      "summary": "`login_with_cookies(cookies, cookies_path)` 位于界面/API 适配层，负责处理登录认证或 Cookie 状态；内部主要调用 _resolve_cookie_list、_fetch_username_silently、_cookie_store_path。",
+      "tags": [
+        "函数",
+        "界面",
+        "认证"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 14 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:interface/common.py:_load_json_file",
+      "type": "function",
+      "name": "_load_json_file",
+      "filePath": "interface/common.py",
+      "lineRange": [
+        45,
+        47
+      ],
+      "summary": "`_load_json_file(path)` 位于界面/API 适配层，负责读取并解析数据；内部主要调用 open、load。",
+      "tags": [
+        "函数",
+        "界面",
+        "读取"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 3 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:interface/common.py:_read_tinydb_value",
+      "type": "function",
+      "name": "_read_tinydb_value",
+      "filePath": "interface/common.py",
+      "lineRange": [
+        50,
+        70
+      ],
+      "summary": "`_read_tinydb_value(path, key)` 位于界面/API 适配层，负责读取并解析数据；内部主要调用 Path、isinstance、exists、_load_json_file、get、values。",
+      "tags": [
+        "函数",
+        "界面",
+        "读取"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 2 个，约 21 行，直接调用约 16 次。"
+    },
+    {
+      "id": "function:interface/common.py:_cookie_store_path",
+      "type": "function",
+      "name": "_cookie_store_path",
+      "filePath": "interface/common.py",
+      "lineRange": [
+        73,
+        82
+      ],
+      "summary": "`_cookie_store_path(cookies_path)` 位于界面/API 适配层，负责处理登录认证或 Cookie 状态；内部主要调用 _read_tinydb_value、str、Path、resolve。",
+      "tags": [
+        "函数",
+        "界面",
+        "认证"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 10 行，直接调用约 8 次。"
+    },
+    {
+      "id": "function:interface/common.py:_coerce_cookie_store",
+      "type": "function",
+      "name": "_coerce_cookie_store",
+      "filePath": "interface/common.py",
+      "lineRange": [
+        85,
+        100
+      ],
+      "summary": "`_coerce_cookie_store(raw)` 位于界面/API 适配层，负责规范化输入值；内部主要调用 isinstance、deepcopy、get。",
+      "tags": [
+        "函数",
+        "界面",
+        "规范化"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 16 行，直接调用约 14 次。"
+    },
+    {
+      "id": "function:interface/common.py:_resolve_cookie_list",
+      "type": "function",
+      "name": "_resolve_cookie_list",
+      "filePath": "interface/common.py",
+      "lineRange": [
+        103,
+        117
+      ],
+      "summary": "`_resolve_cookie_list(cookies, cookies_path)` 位于界面/API 适配层，负责处理登录认证或 Cookie 状态；内部主要调用 _cookie_store_path、_coerce_cookie_store、_load_json_file。",
+      "tags": [
+        "函数",
+        "界面",
+        "认证"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 15 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:interface/common.py:_cookies_to_header",
+      "type": "function",
+      "name": "_cookies_to_header",
+      "filePath": "interface/common.py",
+      "lineRange": [
+        120,
+        129
+      ],
+      "summary": "`_cookies_to_header(cookies)` 位于界面/API 适配层，负责处理登录认证或 Cookie 状态；内部主要调用 join、get、append、format。",
+      "tags": [
+        "函数",
+        "界面",
+        "认证"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 10 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:interface/common.py:_fetch_username_silently",
+      "type": "function",
+      "name": "_fetch_username_silently",
+      "filePath": "interface/common.py",
+      "lineRange": [
+        132,
+        164
+      ],
+      "summary": "`_fetch_username_silently(cookies, timeout)` 位于界面/API 适配层，负责封装接口请求；内部主要调用 _cookies_to_header、get、raise_for_status、json、isinstance、strip。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 2 个，约 33 行，直接调用约 9 次。"
+    },
+    {
+      "id": "function:interface/common.py:_deepcopy_dict",
+      "type": "function",
+      "name": "_deepcopy_dict",
+      "filePath": "interface/common.py",
+      "lineRange": [
+        167,
+        170
+      ],
+      "summary": "`_deepcopy_dict(data)` 位于界面/API 适配层，负责处理 deepcopy dict 相关逻辑；内部主要调用 isinstance、TypeError、deepcopy。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 4 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:interface/common.py:_load_config",
+      "type": "function",
+      "name": "_load_config",
+      "filePath": "interface/common.py",
+      "lineRange": [
+        173,
+        176
+      ],
+      "summary": "`_load_config(config_or_path)` 位于界面/API 适配层，负责读取并解析数据；内部主要调用 isinstance、_deepcopy_dict、_load_json_file。",
+      "tags": [
+        "函数",
+        "界面",
+        "读取"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 4 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:interface/common.py:_extract_project_id",
+      "type": "function",
+      "name": "_extract_project_id",
+      "filePath": "interface/common.py",
+      "lineRange": [
+        179,
+        194
+      ],
+      "summary": "`_extract_project_id(project_input)` 位于界面/API 适配层，负责处理 extract project id 相关逻辑；内部主要调用 isinstance、strip、isdigit、urlparse、parse_qs、get、ValueError。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 16 行，直接调用约 12 次。"
+    },
+    {
+      "id": "function:interface/common.py:_format_sale_status",
+      "type": "function",
+      "name": "_format_sale_status",
+      "filePath": "interface/common.py",
+      "lineRange": [
+        197,
+        203
+      ],
+      "summary": "`_format_sale_status(ticket)` 位于界面/API 适配层，负责格式化展示内容；内部主要调用 get。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 7 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:interface/common.py:_make_request",
+      "type": "function",
+      "name": "_make_request",
+      "filePath": "interface/common.py",
+      "lineRange": [
+        206,
+        216
+      ],
+      "summary": "`_make_request(cookies, cookies_path)` 位于界面/API 适配层，负责封装接口请求；内部主要调用 BiliRequest、_cookie_store_path。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 11 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:interface/config.py:normalize_time_start",
+      "type": "function",
+      "name": "normalize_time_start",
+      "filePath": "interface/config.py",
+      "lineRange": [
+        76,
+        118
+      ],
+      "summary": "`normalize_time_start(value)` 位于界面/API 适配层，负责规范化输入值；内部主要调用 isinstance、strip、fullmatch、int、now、replace。",
+      "tags": [
+        "函数",
+        "界面",
+        "规范化"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 1 个，约 43 行，直接调用约 21 次。"
+    },
+    {
+      "id": "function:interface/config.py:normalize_interval",
+      "type": "function",
+      "name": "normalize_interval",
+      "filePath": "interface/config.py",
+      "lineRange": [
+        121,
+        162
+      ],
+      "summary": "`normalize_interval(value)` 位于界面/API 适配层，负责规范化输入值；内部主要调用 isinstance、lower、isdigit、fullmatch、float、max。",
+      "tags": [
+        "函数",
+        "界面",
+        "规范化"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 1 个，约 42 行，直接调用约 24 次。"
+    },
+    {
+      "id": "function:interface/config.py:normalize_non_negative_interval",
+      "type": "function",
+      "name": "normalize_non_negative_interval",
+      "filePath": "interface/config.py",
+      "lineRange": [
+        165,
+        203
+      ],
+      "summary": "`normalize_non_negative_interval(value, default)` 位于界面/API 适配层，负责规范化输入值；内部主要调用 isinstance、lower、isdigit、fullmatch、float、max。",
+      "tags": [
+        "函数",
+        "界面",
+        "规范化"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 2 个，约 39 行，直接调用约 23 次。"
+    },
+    {
+      "id": "function:interface/config.py:normalize_positive_int",
+      "type": "function",
+      "name": "normalize_positive_int",
+      "filePath": "interface/config.py",
+      "lineRange": [
+        206,
+        217
+      ],
+      "summary": "`normalize_positive_int(value, default)` 位于界面/API 适配层，负责规范化输入值；内部主要调用 isinstance、ValueError、int。",
+      "tags": [
+        "函数",
+        "界面",
+        "规范化"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 12 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:interface/config.py:load_ticket_config",
+      "type": "function",
+      "name": "load_ticket_config",
+      "filePath": "interface/config.py",
+      "lineRange": [
+        220,
+        221
+      ],
+      "summary": "`load_ticket_config(path)` 位于界面/API 适配层，负责读取并解析数据；内部主要调用 _load_config。",
+      "tags": [
+        "函数",
+        "界面",
+        "读取"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 2 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:interface/config.py:save_ticket_config",
+      "type": "function",
+      "name": "save_ticket_config",
+      "filePath": "interface/config.py",
+      "lineRange": [
+        224,
+        235
+      ],
+      "summary": "`save_ticket_config(config, path, ensure_ascii, indent)` 位于界面/API 适配层，负责写入或持久化数据；内部主要调用 Path、mkdir、open、dump。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 4 个，约 12 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:interface/config.py:_normalize_buyer_info",
+      "type": "function",
+      "name": "_normalize_buyer_info",
+      "filePath": "interface/config.py",
+      "lineRange": [
+        238,
+        243
+      ],
+      "summary": "`_normalize_buyer_info(value)` 位于界面/API 适配层，负责规范化输入值；内部主要调用 isinstance、deepcopy。",
+      "tags": [
+        "函数",
+        "界面",
+        "规范化"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 6 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:interface/config.py:generate_ticket_config",
+      "type": "function",
+      "name": "generate_ticket_config",
+      "filePath": "interface/config.py",
+      "lineRange": [
+        246,
+        290
+      ],
+      "summary": "`generate_ticket_config(parameters, defaults)` 位于界面/API 适配层，负责处理配置项；内部主要调用 deepcopy、update、get、pop、setdefault。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 2 个，约 45 行，直接调用约 27 次。"
+    },
+    {
+      "id": "function:interface/config.py:build_runtime_options",
+      "type": "function",
+      "name": "build_runtime_options",
+      "filePath": "interface/config.py",
+      "lineRange": [
+        293,
+        375
+      ],
+      "summary": "`build_runtime_options(interval, outer_interval, create_retry_limit, create_request_batch_size, create_request_proxy_strategy, time_start, audio_path, pushplusToken, serverchanKey, barkToken, meowNickname, https_proxys, proxy_api_url, proxy_api_protocol, proxy_api_request_count, serverchan3ApiUrl, ntfy_url, ntfy_username, ntfy_password, notify_proxy_exhausted, show_random_message, show_qrcode, use_local_token, proxy_max_consecutive_failures, proxy_cooldown_seconds, proxy_backoff_max_seconds, auto_open_payment_url, log_level, log_retention_days)` 位于界面/API 适配层，负责启动或执行任务；内部主要调用 RuntimeOptions、normalize_interval、normalize_non_negative_interval、normalize_positive_int、lower、normalize_time_start。",
+      "tags": [
+        "函数",
+        "界面",
+        "执行"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 29 个，约 83 行，直接调用约 15 次。"
+    },
+    {
+      "id": "function:interface/config.py:build_ticket_config_from_selection",
+      "type": "function",
+      "name": "build_ticket_config_from_selection",
+      "filePath": "interface/config.py",
+      "lineRange": [
+        378,
+        461
+      ],
+      "summary": "`build_ticket_config_from_selection(purchase_context, selection, defaults)` 位于界面/API 适配层，负责处理配置项；内部主要调用 get、any、deepcopy。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 3 个，约 84 行，直接调用约 53 次。"
+    },
+    {
+      "id": "function:interface/config.py:validate_config",
+      "type": "function",
+      "name": "validate_config",
+      "filePath": "interface/config.py",
+      "lineRange": [
+        464,
+        531
+      ],
+      "summary": "`validate_config(config_or_path)` 位于界面/API 适配层，负责校验状态或参数；内部主要调用 get、ValidationResult、generate_ticket_config、isinstance、append。",
+      "tags": [
+        "函数",
+        "界面",
+        "校验"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 1 个，约 68 行，直接调用约 41 次。"
+    },
+    {
+      "id": "class:interface/config.py:RuntimeOptions",
+      "type": "class",
+      "name": "RuntimeOptions",
+      "filePath": "interface/config.py",
+      "lineRange": [
+        25,
+        73
+      ],
+      "summary": "`RuntimeOptions` 位于界面/API 适配层，用于启动或执行任务，包含方法 from_mapping、merged_with、to_dict。",
+      "tags": [
+        "类",
+        "界面",
+        "执行"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 类，约 49 行，包含 3 个方法。"
+    },
+    {
+      "id": "function:interface/execution.py:_collect_payment_fields_from_event",
+      "type": "function",
+      "name": "_collect_payment_fields_from_event",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        23,
+        43
+      ],
+      "summary": "`_collect_payment_fields_from_event(event)` 位于界面/API 适配层，负责推进购票、订单或支付流程；内部主要调用 getattr、isinstance、items、startswith、split。",
+      "tags": [
+        "函数",
+        "界面",
+        "支付"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 21 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:interface/execution.py:_package_root",
+      "type": "function",
+      "name": "_package_root",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        46,
+        47
+      ],
+      "summary": "`_package_root()` 位于界面/API 适配层，负责处理 package root 相关逻辑；内部主要调用 resolve、Path。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 2 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:interface/execution.py:_managed_runs_root",
+      "type": "function",
+      "name": "_managed_runs_root",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        50,
+        53
+      ],
+      "summary": "`_managed_runs_root(root)` 位于界面/API 适配层，负责启动或执行任务；内部主要调用 mkdir、Path、_package_root。",
+      "tags": [
+        "函数",
+        "界面",
+        "执行"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 4 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:interface/execution.py:_dump_json",
+      "type": "function",
+      "name": "_dump_json",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        56,
+        61
+      ],
+      "summary": "`_dump_json(path, payload)` 位于界面/API 适配层，负责写入或持久化数据；内部主要调用 mkdir、with_suffix、replace、open、dump。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 6 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:interface/execution.py:_load_json",
+      "type": "function",
+      "name": "_load_json",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        64,
+        66
+      ],
+      "summary": "`_load_json(path)` 位于界面/API 适配层，负责读取并解析数据；内部主要调用 open、load。",
+      "tags": [
+        "函数",
+        "界面",
+        "读取"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 3 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:interface/execution.py:_read_text_tail",
+      "type": "function",
+      "name": "_read_text_tail",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        69,
+        74
+      ],
+      "summary": "`_read_text_tail(path, max_lines)` 位于界面/API 适配层，负责读取并解析数据；内部主要调用 strip、exists、open、readlines、join。",
+      "tags": [
+        "函数",
+        "界面",
+        "读取"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 6 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:interface/execution.py:_heartbeat_timeout_seconds",
+      "type": "function",
+      "name": "_heartbeat_timeout_seconds",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        77,
+        81
+      ],
+      "summary": "`_heartbeat_timeout_seconds(status)` 位于界面/API 适配层，负责处理 heartbeat timeout seconds 相关逻辑；内部主要调用 get、isinstance、float。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 5 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:interface/execution.py:_update_managed_status",
+      "type": "function",
+      "name": "_update_managed_status",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        84,
+        93
+      ],
+      "summary": "`_update_managed_status(run_dir, **fields)` 位于界面/API 适配层，负责处理 update managed status 相关逻辑；内部主要调用 _load_json、update、time、_dump_json。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 10 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:interface/execution.py:_pid_is_running",
+      "type": "function",
+      "name": "_pid_is_running",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        96,
+        125
+      ],
+      "summary": "`_pid_is_running(pid)` 位于界面/API 适配层，负责启动或执行任务；内部主要调用 OpenProcess、kill、isinstance、c_ulong、CloseHandle、GetExitCodeProcess、byref。",
+      "tags": [
+        "函数",
+        "界面",
+        "执行"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 30 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:interface/execution.py:_terminate_pid",
+      "type": "function",
+      "name": "_terminate_pid",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        128,
+        137
+      ],
+      "summary": "`_terminate_pid(pid)` 位于界面/API 适配层，负责停止任务或清理进程；内部主要调用 kill、run、str。",
+      "tags": [
+        "函数",
+        "界面",
+        "停止"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 10 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:interface/execution.py:_build_managed_failure_result",
+      "type": "function",
+      "name": "_build_managed_failure_result",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        140,
+        165
+      ],
+      "summary": "`_build_managed_failure_result(run_dir, run_id, error, status)` 位于界面/API 适配层，负责处理 build managed failure result 相关逻辑；内部主要调用 _read_text_tail、get。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 4 个，约 26 行，直接调用约 8 次。"
+    },
+    {
+      "id": "function:interface/execution.py:_mark_managed_run_failed",
+      "type": "function",
+      "name": "_mark_managed_run_failed",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        168,
+        183
+      ],
+      "summary": "`_mark_managed_run_failed(run_dir, run_id, error)` 位于界面/API 适配层，负责启动或执行任务；内部主要调用 _update_managed_status、_build_managed_failure_result、_dump_json、time。",
+      "tags": [
+        "函数",
+        "界面",
+        "执行"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 3 个，约 16 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:interface/execution.py:_reconcile_managed_run",
+      "type": "function",
+      "name": "_reconcile_managed_run",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        186,
+        250
+      ],
+      "summary": "`_reconcile_managed_run(run_dir, status)` 位于界面/API 适配层，负责启动或执行任务；内部主要调用 get、_pid_is_running、exists、_read_text_tail、_mark_managed_run_failed。",
+      "tags": [
+        "函数",
+        "界面",
+        "执行"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 2 个，约 65 行，直接调用约 27 次。"
+    },
+    {
+      "id": "function:interface/execution.py:_append_log",
+      "type": "function",
+      "name": "_append_log",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        253,
+        258
+      ],
+      "summary": "`_append_log(task_id, message)` 位于界面/API 适配层，负责处理 append log 相关逻辑；内部主要调用 append、len。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 6 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:interface/execution.py:_update_task",
+      "type": "function",
+      "name": "_update_task",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        261,
+        265
+      ],
+      "summary": "`_update_task(task_id, **fields)` 位于界面/API 适配层，负责处理 update task 相关逻辑；内部主要调用 items、setattr。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 5 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:interface/execution.py:_run_buy_task",
+      "type": "function",
+      "name": "_run_buy_task",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        268,
+        308
+      ],
+      "summary": "`_run_buy_task(task_id, config, runtime_options)` 位于界面/API 适配层，负责推进购票、订单或支付流程；内部主要调用 Buy、_update_task、stream、from_runtime_options、time、_append_log、_collect_payment_fields_from_event。",
+      "tags": [
+        "函数",
+        "界面",
+        "支付"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 3 个，约 41 行，直接调用约 16 次。"
+    },
+    {
+      "id": "function:interface/execution.py:start_buy",
+      "type": "function",
+      "name": "start_buy",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        311,
+        346
+      ],
+      "summary": "`start_buy(config_or_path, runtime_options)` 位于界面/API 适配层，负责推进购票、订单或支付流程；内部主要调用 validate_config、build_runtime_options、merged_with、BuyTaskRecord、Thread、start、uuid4、to_dict。",
+      "tags": [
+        "函数",
+        "界面",
+        "支付"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 2 个，约 36 行，直接调用约 13 次。"
+    },
+    {
+      "id": "function:interface/execution.py:task_status",
+      "type": "function",
+      "name": "task_status",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        349,
+        354
+      ],
+      "summary": "`task_status(task_id)` 位于界面/API 适配层，负责处理 task status 相关逻辑；内部主要调用 get、to_dict。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 6 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:interface/execution.py:run_buy_sync",
+      "type": "function",
+      "name": "run_buy_sync",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        357,
+        417
+      ],
+      "summary": "`run_buy_sync(config_or_path, runtime_options)` 位于界面/API 适配层，负责推进购票、订单或支付流程；内部主要调用 validate_config、build_runtime_options、merged_with、Buy、stream、append、_collect_payment_fields_from_event、to_dict。",
+      "tags": [
+        "函数",
+        "界面",
+        "支付"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 2 个，约 61 行，直接调用约 11 次。"
+    },
+    {
+      "id": "function:interface/execution.py:start_managed_buy",
+      "type": "function",
+      "name": "start_managed_buy",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        420,
+        543
+      ],
+      "summary": "`start_managed_buy(config_or_path, runtime_options, run_id, runs_root)` 位于界面/API 适配层，负责推进购票、订单或支付流程；内部主要调用 validate_config、build_runtime_options、merged_with、_managed_runs_root、exists、mkdir、_dump_json。",
+      "tags": [
+        "函数",
+        "界面",
+        "支付"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 4 个，约 124 行，直接调用约 54 次。"
+    },
+    {
+      "id": "function:interface/execution.py:managed_task_status",
+      "type": "function",
+      "name": "managed_task_status",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        546,
+        559
+      ],
+      "summary": "`managed_task_status(run_id, runs_root)` 位于界面/API 适配层，负责处理 managed task status 相关逻辑；内部主要调用 _reconcile_managed_run、exists、_managed_runs_root、_load_json。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 14 行，直接调用约 6 次。"
+    },
+    {
+      "id": "function:interface/execution.py:cancel_managed_buy",
+      "type": "function",
+      "name": "cancel_managed_buy",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        562,
+        622
+      ],
+      "summary": "`cancel_managed_buy(run_id, runs_root)` 位于界面/API 适配层，负责推进购票、订单或支付流程；内部主要调用 _load_json、get、_pid_is_running、_update_managed_status、_dump_json、_managed_runs_root、exists。",
+      "tags": [
+        "函数",
+        "界面",
+        "支付"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 2 个，约 61 行，直接调用约 15 次。"
+    },
+    {
+      "id": "function:interface/execution.py:delete_managed_buy",
+      "type": "function",
+      "name": "delete_managed_buy",
+      "filePath": "interface/execution.py",
+      "lineRange": [
+        625,
+        665
+      ],
+      "summary": "`delete_managed_buy(run_id, runs_root, force)` 位于界面/API 适配层，负责推进购票、订单或支付流程；内部主要调用 _managed_runs_root、get、_pid_is_running、rmtree、exists、relative_to、_load_json。",
+      "tags": [
+        "函数",
+        "界面",
+        "支付"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 3 个，约 41 行，直接调用约 9 次。"
+    },
+    {
+      "id": "function:interface/project.py:_normalize_new_project_payload",
+      "type": "function",
+      "name": "_normalize_new_project_payload",
+      "filePath": "interface/project.py",
+      "lineRange": [
+        13,
+        70
+      ],
+      "summary": "`_normalize_new_project_payload(new_payload, project_id)` 位于界面/API 适配层，负责读取并解析数据；内部主要调用 int、get、deepcopy、setdefault。",
+      "tags": [
+        "函数",
+        "界面",
+        "读取"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 2 个，约 58 行，直接调用约 44 次。"
+    },
+    {
+      "id": "function:interface/project.py:_fetch_project_payload_new",
+      "type": "function",
+      "name": "_fetch_project_payload_new",
+      "filePath": "interface/project.py",
+      "lineRange": [
+        73,
+        115
+      ],
+      "summary": "`_fetch_project_payload_new(request, project_id)` 位于界面/API 适配层，负责读取并解析数据；内部主要调用 getattr、isinstance、get、_normalize_new_project_payload、update、json。",
+      "tags": [
+        "函数",
+        "界面",
+        "读取"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 2 个，约 43 行，直接调用约 21 次。"
+    },
+    {
+      "id": "function:interface/project.py:_fetch_project_payload_old",
+      "type": "function",
+      "name": "_fetch_project_payload_old",
+      "filePath": "interface/project.py",
+      "lineRange": [
+        118,
+        135
+      ],
+      "summary": "`_fetch_project_payload_old(request, project_id)` 位于界面/API 适配层，负责读取并解析数据；内部主要调用 json、get、RuntimeError、isinstance。",
+      "tags": [
+        "函数",
+        "界面",
+        "读取"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 2 个，约 18 行，直接调用约 11 次。"
+    },
+    {
+      "id": "function:interface/project.py:fetch_project_payload",
+      "type": "function",
+      "name": "fetch_project_payload",
+      "filePath": "interface/project.py",
+      "lineRange": [
+        138,
+        151
+      ],
+      "summary": "`fetch_project_payload(request, project_id)` 位于界面/API 适配层，负责读取并解析数据；内部主要调用 _fetch_project_payload_new、_fetch_project_payload_old、RuntimeError、format。",
+      "tags": [
+        "函数",
+        "界面",
+        "读取"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 14 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:interface/project.py:_build_ticket_option",
+      "type": "function",
+      "name": "_build_ticket_option",
+      "filePath": "interface/project.py",
+      "lineRange": [
+        154,
+        181
+      ],
+      "summary": "`_build_ticket_option(screen, ticket, hot_project, has_eticket)` 位于界面/API 适配层，负责推进购票、订单或支付流程；内部主要调用 deepcopy、get、_format_sale_status、format、max、int。",
+      "tags": [
+        "函数",
+        "界面",
+        "支付"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 4 个，约 28 行，直接调用约 15 次。"
+    },
+    {
+      "id": "function:interface/project.py:_merge_link_goods",
+      "type": "function",
+      "name": "_merge_link_goods",
+      "filePath": "interface/project.py",
+      "lineRange": [
+        184,
+        215
+      ],
+      "summary": "`_merge_link_goods(request, screen_list, project_id)` 位于界面/API 适配层，负责处理 merge link goods 相关逻辑；内部主要调用 deepcopy、json、get。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 3 个，约 32 行，直接调用约 14 次。"
+    },
+    {
+      "id": "function:interface/project.py:_fetch_ticket_options",
+      "type": "function",
+      "name": "_fetch_ticket_options",
+      "filePath": "interface/project.py",
+      "lineRange": [
+        218,
+        258
+      ],
+      "summary": "`_fetch_ticket_options(request, project_payload, selected_date)` 位于界面/API 适配层，负责封装接口请求；内部主要调用 bool、int、get、json、_merge_link_goods。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 3 个，约 41 行，直接调用约 17 次。"
+    },
+    {
+      "id": "function:interface/project.py:fetch_project_detail",
+      "type": "function",
+      "name": "fetch_project_detail",
+      "filePath": "interface/project.py",
+      "lineRange": [
+        261,
+        273
+      ],
+      "summary": "`fetch_project_detail(project_input, cookies, cookies_path)` 位于界面/API 适配层，负责封装接口请求；内部主要调用 _make_request、_extract_project_id、fetch_project_payload、format。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 3 个，约 13 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:interface/project.py:fetch_ticket_options",
+      "type": "function",
+      "name": "fetch_ticket_options",
+      "filePath": "interface/project.py",
+      "lineRange": [
+        276,
+        299
+      ],
+      "summary": "`fetch_ticket_options(project_input, cookies, cookies_path, selected_date)` 位于界面/API 适配层，负责封装接口请求；内部主要调用 _make_request、_extract_project_id、fetch_project_payload、_fetch_ticket_options、get。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 4 个，约 24 行，直接调用约 6 次。"
+    },
+    {
+      "id": "function:interface/project.py:fetch_buyers",
+      "type": "function",
+      "name": "fetch_buyers",
+      "filePath": "interface/project.py",
+      "lineRange": [
+        302,
+        322
+      ],
+      "summary": "`fetch_buyers(project_input, cookies, cookies_path)` 位于界面/API 适配层，负责封装接口请求；内部主要调用 _make_request、_extract_project_id、fetch_project_payload、json、get。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 3 个，约 21 行，直接调用约 9 次。"
+    },
+    {
+      "id": "function:interface/project.py:fetch_addresses",
+      "type": "function",
+      "name": "fetch_addresses",
+      "filePath": "interface/project.py",
+      "lineRange": [
+        325,
+        334
+      ],
+      "summary": "`fetch_addresses(cookies, cookies_path)` 位于界面/API 适配层，负责封装接口请求；内部主要调用 _make_request、json、get。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 10 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:interface/project.py:fetch_purchase_context",
+      "type": "function",
+      "name": "fetch_purchase_context",
+      "filePath": "interface/project.py",
+      "lineRange": [
+        337,
+        388
+      ],
+      "summary": "`fetch_purchase_context(project_input, cookies, cookies_path, selected_date, phone)` 位于界面/API 适配层，负责封装接口请求；内部主要调用 _extract_project_id、_make_request、fetch_project_payload、_fetch_ticket_options、json、get。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 5 个，约 52 行，直接调用约 24 次。"
+    },
+    {
+      "id": "function:interface/search.py:search_tickets",
+      "type": "function",
+      "name": "search_tickets",
+      "filePath": "interface/search.py",
+      "lineRange": [
+        13,
+        87
+      ],
+      "summary": "`search_tickets(keyword, page, pagesize, platform, cookies, cookies_path)` 位于界面/API 适配层，负责推进购票、订单或支付流程；内部主要调用 get_login_state、_resolve_cookie_list、urlencode、json、get、ValueError、format。",
+      "tags": [
+        "函数",
+        "界面",
+        "支付"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 6 个，约 75 行，直接调用约 29 次。"
+    },
+    {
+      "id": "function:interface/search.py:format_ticket_search_results_text",
+      "type": "function",
+      "name": "format_ticket_search_results_text",
+      "filePath": "interface/search.py",
+      "lineRange": [
+        90,
+        138
+      ],
+      "summary": "`format_ticket_search_results_text(search_result, limit)` 位于界面/API 适配层，负责推进购票、订单或支付流程；内部主要调用 get、enumerate、rstrip、format、list。",
+      "tags": [
+        "函数",
+        "界面",
+        "支付"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 2 个，约 49 行，直接调用约 31 次。"
+    },
+    {
+      "id": "class:interface/types.py:ValidationResult",
+      "type": "class",
+      "name": "ValidationResult",
+      "filePath": "interface/types.py",
+      "lineRange": [
+        8,
+        15
+      ],
+      "summary": "`ValidationResult` 位于界面/API 适配层，用于处理 Validation Result 相关逻辑，包含方法 to_dict。",
+      "tags": [
+        "类",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 8 行，包含 1 个方法。"
+    },
+    {
+      "id": "class:interface/types.py:BuyTaskRecord",
+      "type": "class",
+      "name": "BuyTaskRecord",
+      "filePath": "interface/types.py",
+      "lineRange": [
+        19,
+        34
+      ],
+      "summary": "`BuyTaskRecord` 位于界面/API 适配层，用于推进购票、订单或支付流程，包含方法 to_dict。",
+      "tags": [
+        "类",
+        "界面",
+        "支付"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 16 行，包含 1 个方法。"
+    },
+    {
+      "id": "function:tab/settings.py:_format_account_choice",
+      "type": "function",
+      "name": "_format_account_choice",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        40,
+        41
+      ],
+      "summary": "`_format_account_choice(uid, name, level)` 位于Gradio 界面标签页，负责格式化展示内容；内部主要调用 无明显外部调用。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 3 个，约 2 行，直接调用约 0 次。"
+    },
+    {
+      "id": "function:tab/settings.py:_find_uid_from_choice",
+      "type": "function",
+      "name": "_find_uid_from_choice",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        44,
+        47
+      ],
+      "summary": "`_find_uid_from_choice(choice)` 位于Gradio 界面标签页，负责处理 find uid from choice 相关逻辑；内部主要调用 split。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 4 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tab/settings.py:_resolve_default_account_choice",
+      "type": "function",
+      "name": "_resolve_default_account_choice",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        50,
+        62
+      ],
+      "summary": "`_resolve_default_account_choice(choices, active_uid)` 位于Gradio 界面标签页，负责处理 resolve default account choice 相关逻辑；内部主要调用 str、_find_uid_from_choice。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 13 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:tab/settings.py:_read_positive_int",
+      "type": "function",
+      "name": "_read_positive_int",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        65,
+        72
+      ],
+      "summary": "`_read_positive_int(value)` 位于Gradio 界面标签页，负责读取并解析数据；内部主要调用 int。",
+      "tags": [
+        "函数",
+        "界面",
+        "读取"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 8 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tab/settings.py:_iter_project_dates",
+      "type": "function",
+      "name": "_iter_project_dates",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        75,
+        81
+      ],
+      "summary": "`_iter_project_dates(start_ts, end_ts)` 位于Gradio 界面标签页，负责处理 iter project dates 相关逻辑；内部主要调用 date、timedelta、fromtimestamp、strftime。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 7 行，直接调用约 6 次。"
+    },
+    {
+      "id": "function:tab/settings.py:_fetch_screens_by_date",
+      "type": "function",
+      "name": "_fetch_screens_by_date",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        84,
+        97
+      ],
+      "summary": "`_fetch_screens_by_date(request, project_id, date_str)` 位于Gradio 界面标签页，负责封装接口请求；内部主要调用 get、json、RuntimeError、isinstance。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 3 个，约 14 行，直接调用约 12 次。"
+    },
+    {
+      "id": "function:tab/settings.py:_normalize_date_string",
+      "type": "function",
+      "name": "_normalize_date_string",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        100,
+        123
+      ],
+      "summary": "`_normalize_date_string(value)` 位于Gradio 界面标签页，负责规范化输入值；内部主要调用 isinstance、strip、search、int、strftime、str。",
+      "tags": [
+        "函数",
+        "界面",
+        "规范化"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 24 行，直接调用约 11 次。"
+    },
+    {
+      "id": "function:tab/settings.py:_screen_matches_date",
+      "type": "function",
+      "name": "_screen_matches_date",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        126,
+        138
+      ],
+      "summary": "`_screen_matches_date(screen, date_str)` 位于Gradio 界面标签页，负责处理 screen matches date 相关逻辑；内部主要调用 get、any、isinstance、append。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 2 个，约 13 行，直接调用约 9 次。"
+    },
+    {
+      "id": "function:tab/settings.py:_fetch_screens_by_date_with_fallback",
+      "type": "function",
+      "name": "_fetch_screens_by_date_with_fallback",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        141,
+        157
+      ],
+      "summary": "`_fetch_screens_by_date_with_fallback(request, project_id, date_str)` 位于Gradio 界面标签页，负责封装接口请求；内部主要调用 _fetch_screens_by_date、fetch_project_payload、get、append、isinstance、_screen_matches_date。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 3 个，约 17 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:tab/settings.py:_merge_screens",
+      "type": "function",
+      "name": "_merge_screens",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        160,
+        173
+      ],
+      "summary": "`_merge_screens(base_screens, extra_screens)` 位于Gradio 界面标签页，负责处理 merge screens 相关逻辑；内部主要调用 set、_read_positive_int、add、append、isinstance、get。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 14 行，直接调用约 6 次。"
+    },
+    {
+      "id": "function:tab/settings.py:filename_filter",
+      "type": "function",
+      "name": "filename_filter",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        176,
+        177
+      ],
+      "summary": "`filename_filter(filename)` 位于Gradio 界面标签页，负责处理 filename filter 相关逻辑；内部主要调用 sub。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 2 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tab/settings.py:_format_price",
+      "type": "function",
+      "name": "_format_price",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        180,
+        181
+      ],
+      "summary": "`_format_price(price)` 位于Gradio 界面标签页，负责格式化展示内容；内部主要调用 rstrip。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 2 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:tab/settings.py:_render_ticket_info_html",
+      "type": "function",
+      "name": "_render_ticket_info_html",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        184,
+        203
+      ],
+      "summary": "`_render_ticket_info_html(title, lines, badge, hint)` 位于Gradio 界面标签页，负责推进购票、订单或支付流程；内部主要调用 join、escape。",
+      "tags": [
+        "函数",
+        "界面",
+        "支付"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 4 个，约 20 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:tab/settings.py:_empty_ticket_info_updates",
+      "type": "function",
+      "name": "_empty_ticket_info_updates",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        206,
+        214
+      ],
+      "summary": "`_empty_ticket_info_updates()` 位于Gradio 界面标签页，负责推进购票、订单或支付流程；内部主要调用 update。",
+      "tags": [
+        "函数",
+        "界面",
+        "支付"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 9 行，直接调用约 6 次。"
+    },
+    {
+      "id": "function:tab/settings.py:_has_invalid_index",
+      "type": "function",
+      "name": "_has_invalid_index",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        217,
+        220
+      ],
+      "summary": "`_has_invalid_index(indices, values)` 位于Gradio 界面标签页，负责处理 has invalid index 相关逻辑；内部主要调用 any、isinstance、len。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 4 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:tab/settings.py:_get_active_account_uid",
+      "type": "function",
+      "name": "_get_active_account_uid",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        223,
+        231
+      ],
+      "summary": "`_get_active_account_uid()` 位于Gradio 界面标签页，负责封装接口请求；内部主要调用 get_cookies_value、str、have_cookies。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 9 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:tab/settings.py:_reset_ticket_context",
+      "type": "function",
+      "name": "_reset_ticket_context",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        234,
+        255
+      ],
+      "summary": "`_reset_ticket_context(invalidated)` 位于Gradio 界面标签页，负责推进购票、订单或支付流程；内部主要调用 无明显外部调用。",
+      "tags": [
+        "函数",
+        "界面",
+        "支付"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 22 行，直接调用约 0 次。"
+    },
+    {
+      "id": "function:tab/settings.py:_format_ticket_option",
+      "type": "function",
+      "name": "_format_ticket_option",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        258,
+        264
+      ],
+      "summary": "`_format_ticket_option(screen_name, ticket, ticket_price)` 位于Gradio 界面标签页，负责推进购票、订单或支付流程；内部主要调用 get、str、_format_price、_format_sale_status。",
+      "tags": [
+        "函数",
+        "界面",
+        "支付"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 3 个，约 7 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:tab/settings.py:_resolve_project_input",
+      "type": "function",
+      "name": "_resolve_project_input",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        267,
+        297
+      ],
+      "summary": "`_resolve_project_input(project_input)` 位于Gradio 界面标签页，负责处理 resolve project input 相关逻辑；内部主要调用 isinstance、str、strip、isdigit、Error、extract_id_from_url。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 31 行，直接调用约 14 次。"
+    },
+    {
+      "id": "function:tab/settings.py:on_submit_ticket_id",
+      "type": "function",
+      "name": "on_submit_ticket_id",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        300,
+        452
+      ],
+      "summary": "`on_submit_ticket_id(num)` 位于Gradio 界面标签页，负责推进购票、订单或支付流程；内部主要调用 strip、_reset_ticket_context、_resolve_project_input、_iter_project_dates、_merge_screens、_get_active_account_uid、Error、fetch_project_payload。",
+      "tags": [
+        "函数",
+        "界面",
+        "支付"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 1 个，约 153 行，直接调用约 52 次。"
+    },
+    {
+      "id": "function:tab/settings.py:extract_id_from_url",
+      "type": "function",
+      "name": "extract_id_from_url",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        455,
+        461
+      ],
+      "summary": "`extract_id_from_url(url)` 位于Gradio 界面标签页，负责处理 extract id from url 相关逻辑；内部主要调用 urlparse、parse_qs、get、isinstance、isdigit。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 7 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:tab/settings.py:on_submit_all",
+      "type": "function",
+      "name": "on_submit_all",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        464,
+        568
+      ],
+      "summary": "`on_submit_all(ticket_id, ticket_info, people_indices, people_buyer_name, people_buyer_phone, address_index)` 位于Gradio 界面标签页，负责处理 on submit all 相关逻辑；内部主要调用 _has_invalid_index、_resolve_project_input、insert、get_request_name、join、Error。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 6 个，约 105 行，直接调用约 37 次。"
+    },
+    {
+      "id": "function:tab/settings.py:upload_file",
+      "type": "function",
+      "name": "upload_file",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        571,
+        595
+      ],
+      "summary": "`upload_file(filepath)`：导入 cookie 文件并添加到账号池。位于Gradio 界面标签页，调用 BiliRequest、get_cookies、add_account、set_main_request、insert、_reset_ticket_context、Info。",
+      "tags": [
+        "函数",
+        "界面",
+        "读取"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 25 行，直接调用约 14 次。"
+    },
+    {
+      "id": "function:tab/settings.py:login_tab",
+      "type": "function",
+      "name": "login_tab",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        598,
+        965
+      ],
+      "summary": "`login_tab(account_change_state)` 位于Gradio 界面标签页，负责处理登录认证或 Cookie 状态；内部主要调用 Column、State、click、on、change、upload。",
+      "tags": [
+        "函数",
+        "界面",
+        "认证"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 1 个，约 368 行，直接调用约 146 次。"
+    },
+    {
+      "id": "function:tab/settings.py:setting_tab",
+      "type": "function",
+      "name": "setting_tab",
+      "filePath": "tab/settings.py",
+      "lineRange": [
+        968,
+        1187
+      ],
+      "summary": "`setting_tab(account_change_state)` 位于Gradio 界面标签页，负责处理配置项；内部主要调用 Column、HTML、click、change、Row、Textbox。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 1 个，约 220 行，直接调用约 59 次。"
+    },
+    {
+      "id": "function:tests/test_local_fanout_proxy_strategy.py:test_task_proxy_list_includes_direct_when_enabled",
+      "type": "function",
+      "name": "test_task_proxy_list_includes_direct_when_enabled",
+      "filePath": "tests/test_local_fanout_proxy_strategy.py",
+      "lineRange": [
+        123,
+        131
+      ],
+      "summary": "`test_task_proxy_list_includes_direct_when_enabled()` 位于自动化测试，负责选择、检测或维护代理；内部主要调用 _build_task_proxy_list。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 9 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tests/test_local_fanout_proxy_strategy.py:test_task_proxy_list_excludes_direct_when_disabled",
+      "type": "function",
+      "name": "test_task_proxy_list_excludes_direct_when_disabled",
+      "filePath": "tests/test_local_fanout_proxy_strategy.py",
+      "lineRange": [
+        134,
+        141
+      ],
+      "summary": "`test_task_proxy_list_excludes_direct_when_disabled()` 位于自动化测试，负责选择、检测或维护代理；内部主要调用 _build_task_proxy_list。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 8 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tests/test_local_fanout_proxy_strategy.py:test_task_proxy_list_can_require_configured_proxy",
+      "type": "function",
+      "name": "test_task_proxy_list_can_require_configured_proxy",
+      "filePath": "tests/test_local_fanout_proxy_strategy.py",
+      "lineRange": [
+        144,
+        145
+      ],
+      "summary": "`test_task_proxy_list_can_require_configured_proxy()` 位于自动化测试，负责处理配置项；内部主要调用 _build_task_proxy_list。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 2 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tests/test_local_fanout_proxy_strategy.py:test_runtime_strategy_flows_into_buy_config",
+      "type": "function",
+      "name": "test_runtime_strategy_flows_into_buy_config",
+      "filePath": "tests/test_local_fanout_proxy_strategy.py",
+      "lineRange": [
+        148,
+        156
+      ],
+      "summary": "`test_runtime_strategy_flows_into_buy_config()` 位于自动化测试，负责处理配置项；内部主要调用 build_runtime_options、from_runtime_options、to_cli_args。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 9 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:tests/test_local_fanout_proxy_strategy.py:test_h2_client_constructor_uses_abstract_client_interface",
+      "type": "function",
+      "name": "test_h2_client_constructor_uses_abstract_client_interface",
+      "filePath": "tests/test_local_fanout_proxy_strategy.py",
+      "lineRange": [
+        159,
+        189
+      ],
+      "summary": "`test_h2_client_constructor_uses_abstract_client_interface()` 位于自动化测试，负责验证对应业务行为；内部主要调用 BiliRequest、prewarm_h2_connection、_h2_send、_invalidate_h2_client、get_user_agent。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 31 行，直接调用约 6 次。"
+    },
+    {
+      "id": "function:tests/test_local_fanout_proxy_strategy.py:test_replace_proxy_pool_updates_h2_client_options",
+      "type": "function",
+      "name": "test_replace_proxy_pool_updates_h2_client_options",
+      "filePath": "tests/test_local_fanout_proxy_strategy.py",
+      "lineRange": [
+        192,
+        212
+      ],
+      "summary": "`test_replace_proxy_pool_updates_h2_client_options()` 位于自动化测试，负责选择、检测或维护代理；内部主要调用 BiliRequest、_h2_send、replace_proxy_pool。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 21 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:tests/test_local_fanout_proxy_strategy.py:test_proxy_pool_fanout_builds_one_create_connection_per_proxy",
+      "type": "function",
+      "name": "test_proxy_pool_fanout_builds_one_create_connection_per_proxy",
+      "filePath": "tests/test_local_fanout_proxy_strategy.py",
+      "lineRange": [
+        215,
+        243
+      ],
+      "summary": "`test_proxy_pool_fanout_builds_one_create_connection_per_proxy()` 位于自动化测试，负责选择、检测或维护代理；内部主要调用 ProxyPoolCreateV2FanoutJA3H2Client、post、sorted。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 29 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:tests/test_local_fanout_proxy_strategy.py:test_proxy_pool_fanout_repeats_until_one_proxy_succeeds",
+      "type": "function",
+      "name": "test_proxy_pool_fanout_repeats_until_one_proxy_succeeds",
+      "filePath": "tests/test_local_fanout_proxy_strategy.py",
+      "lineRange": [
+        246,
+        273
+      ],
+      "summary": "`test_proxy_pool_fanout_repeats_until_one_proxy_succeeds()` 位于自动化测试，负责选择、检测或维护代理；内部主要调用 ProxyPoolCreateV2FanoutJA3H2Client、post、sum、json。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 28 行，直接调用约 4 次。"
+    },
+    {
+      "id": "class:tests/test_local_fanout_proxy_strategy.py:FakeCookies",
+      "type": "class",
+      "name": "FakeCookies",
+      "filePath": "tests/test_local_fanout_proxy_strategy.py",
+      "lineRange": [
+        13,
+        24
+      ],
+      "summary": "`FakeCookies` 位于自动化测试，用于处理登录认证或 Cookie 状态，包含方法 __init__、set。",
+      "tags": [
+        "类",
+        "测试",
+        "认证"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 12 行，包含 2 个方法。"
+    },
+    {
+      "id": "class:tests/test_local_fanout_proxy_strategy.py:FakeH2Client",
+      "type": "class",
+      "name": "FakeH2Client",
+      "filePath": "tests/test_local_fanout_proxy_strategy.py",
+      "lineRange": [
+        27,
+        73
+      ],
+      "summary": "`FakeH2Client` 位于自动化测试，继承 AbstractH2Client，用于处理 Fake H2 Client 相关逻辑，包含方法 __init__、headers、cookies、head、get、post、close。",
+      "tags": [
+        "类",
+        "测试"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 类，约 47 行，包含 7 个方法。"
+    },
+    {
+      "id": "class:tests/test_local_fanout_proxy_strategy.py:FakeH2Connection",
+      "type": "class",
+      "name": "FakeH2Connection",
+      "filePath": "tests/test_local_fanout_proxy_strategy.py",
+      "lineRange": [
+        76,
+        120
+      ],
+      "summary": "`FakeH2Connection` 位于自动化测试，用于处理 Fake H2 Connection 相关逻辑，包含方法 __init__、get、post、close。",
+      "tags": [
+        "类",
+        "测试"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 类，约 45 行，包含 4 个方法。"
+    },
+    {
+      "id": "function:tests/test_login_account_defaults.py:test_resolve_default_account_choice_prefers_active_uid",
+      "type": "function",
+      "name": "test_resolve_default_account_choice_prefers_active_uid",
+      "filePath": "tests/test_login_account_defaults.py",
+      "lineRange": [
+        4,
+        13
+      ],
+      "summary": "`test_resolve_default_account_choice_prefers_active_uid()` 位于自动化测试，负责验证对应业务行为；内部主要调用 _resolve_default_account_choice。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 10 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tests/test_login_account_defaults.py:test_resolve_default_account_choice_falls_back_to_first_choice",
+      "type": "function",
+      "name": "test_resolve_default_account_choice_falls_back_to_first_choice",
+      "filePath": "tests/test_login_account_defaults.py",
+      "lineRange": [
+        16,
+        24
+      ],
+      "summary": "`test_resolve_default_account_choice_falls_back_to_first_choice()` 位于自动化测试，负责验证对应业务行为；内部主要调用 _resolve_default_account_choice。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 9 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:tests/test_payment_result_fields.py:test_build_payment_result_contains_order_and_code_urls",
+      "type": "function",
+      "name": "test_build_payment_result_contains_order_and_code_urls",
+      "filePath": "tests/test_payment_result_fields.py",
+      "lineRange": [
+        21,
+        29
+      ],
+      "summary": "`test_build_payment_result_contains_order_and_code_urls()` 位于自动化测试，负责推进购票、订单或支付流程；内部主要调用 build_payment_result、endswith、_DummyRequest。",
+      "tags": [
+        "函数",
+        "测试",
+        "支付"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 9 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:tests/test_payment_result_fields.py:test_collect_payment_fields_from_event_reads_new_fields",
+      "type": "function",
+      "name": "test_collect_payment_fields_from_event_reads_new_fields",
+      "filePath": "tests/test_payment_result_fields.py",
+      "lineRange": [
+        32,
+        51
+      ],
+      "summary": "`test_collect_payment_fields_from_event_reads_new_fields()` 位于自动化测试，负责读取并解析数据；内部主要调用 BuyStreamEvent、_collect_payment_fields_from_event、BuyStreamState。",
+      "tags": [
+        "函数",
+        "测试",
+        "读取"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 20 行，直接调用约 3 次。"
+    },
+    {
+      "id": "class:tests/test_payment_result_fields.py:_DummyRequest",
+      "type": "class",
+      "name": "_DummyRequest",
+      "filePath": "tests/test_payment_result_fields.py",
+      "lineRange": [
+        10,
+        18
+      ],
+      "summary": "`_DummyRequest` 位于自动化测试，用于封装接口请求，包含方法 get。",
+      "tags": [
+        "类",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 9 行，包含 1 个方法。"
+    },
+    {
+      "id": "function:tests/test_settings_ticket_selection.py:_project_payload",
+      "type": "function",
+      "name": "_project_payload",
+      "filePath": "tests/test_settings_ticket_selection.py",
+      "lineRange": [
+        67,
+        91
+      ],
+      "summary": "`_project_payload()` 位于自动化测试，负责读取并解析数据；内部主要调用 无明显外部调用。",
+      "tags": [
+        "函数",
+        "测试",
+        "读取"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 25 行，直接调用约 0 次。"
+    },
+    {
+      "id": "function:tests/test_settings_ticket_selection.py:test_submit_ticket_id_resets_stale_selection_values",
+      "type": "function",
+      "name": "test_submit_ticket_id_resets_stale_selection_values",
+      "filePath": "tests/test_settings_ticket_selection.py",
+      "lineRange": [
+        94,
+        112
+      ],
+      "summary": "`test_submit_ticket_id_resets_stale_selection_values(monkeypatch)` 位于自动化测试，负责推进购票、订单或支付流程；内部主要调用 setattr、next、_FakeRequest、on_submit_ticket_id、_project_payload。",
+      "tags": [
+        "函数",
+        "测试",
+        "支付"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 19 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:tests/test_settings_ticket_selection.py:test_has_invalid_index_detects_stale_buyer_selection",
+      "type": "function",
+      "name": "test_has_invalid_index_detects_stale_buyer_selection",
+      "filePath": "tests/test_settings_ticket_selection.py",
+      "lineRange": [
+        115,
+        117
+      ],
+      "summary": "`test_has_invalid_index_detects_stale_buyer_selection()` 位于自动化测试，负责推进购票、订单或支付流程；内部主要调用 _has_invalid_index。",
+      "tags": [
+        "函数",
+        "测试",
+        "支付"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 3 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:tests/test_settings_ticket_selection.py:test_submit_all_rejects_ticket_context_from_previous_account",
+      "type": "function",
+      "name": "test_submit_all_rejects_ticket_context_from_previous_account",
+      "filePath": "tests/test_settings_ticket_selection.py",
+      "lineRange": [
+        120,
+        168
+      ],
+      "summary": "`test_submit_all_rejects_ticket_context_from_previous_account(monkeypatch)` 位于自动化测试，负责推进购票、订单或支付流程；内部主要调用 _reset_ticket_context、setattr、_FakeAccountRequest、list、append、on_submit_all。",
+      "tags": [
+        "函数",
+        "测试",
+        "支付"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 49 行，直接调用约 7 次。"
+    },
+    {
+      "id": "class:tests/test_settings_ticket_selection.py:_JsonResponse",
+      "type": "class",
+      "name": "_JsonResponse",
+      "filePath": "tests/test_settings_ticket_selection.py",
+      "lineRange": [
+        6,
+        11
+      ],
+      "summary": "`_JsonResponse` 位于自动化测试，用于处理 Json Response 相关逻辑，包含方法 __init__、json。",
+      "tags": [
+        "类",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 6 行，包含 2 个方法。"
+    },
+    {
+      "id": "class:tests/test_settings_ticket_selection.py:_FakeRequest",
+      "type": "class",
+      "name": "_FakeRequest",
+      "filePath": "tests/test_settings_ticket_selection.py",
+      "lineRange": [
+        14,
+        46
+      ],
+      "summary": "`_FakeRequest` 位于自动化测试，用于封装接口请求，包含方法 get。",
+      "tags": [
+        "类",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 33 行，包含 1 个方法。"
+    },
+    {
+      "id": "class:tests/test_settings_ticket_selection.py:_FakeCookieManager",
+      "type": "class",
+      "name": "_FakeCookieManager",
+      "filePath": "tests/test_settings_ticket_selection.py",
+      "lineRange": [
+        49,
+        59
+      ],
+      "summary": "`_FakeCookieManager` 位于自动化测试，用于处理登录认证或 Cookie 状态，包含方法 __init__、have_cookies、get_cookies_value。",
+      "tags": [
+        "类",
+        "测试",
+        "认证"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 11 行，包含 3 个方法。"
+    },
+    {
+      "id": "class:tests/test_settings_ticket_selection.py:_FakeAccountRequest",
+      "type": "class",
+      "name": "_FakeAccountRequest",
+      "filePath": "tests/test_settings_ticket_selection.py",
+      "lineRange": [
+        62,
+        64
+      ],
+      "summary": "`_FakeAccountRequest` 位于自动化测试，用于封装接口请求，包含方法 __init__。",
+      "tags": [
+        "类",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 3 行，包含 1 个方法。"
+    },
+    {
+      "id": "function:util/h2client/h2connection.py:format_authority",
+      "type": "function",
+      "name": "format_authority",
+      "filePath": "util/h2client/h2connection.py",
+      "lineRange": [
+        138,
+        140
+      ],
+      "summary": "`format_authority(host, port)` 位于HTTP/2 客户端，负责处理登录认证或 Cookie 状态；内部主要调用 startswith。",
+      "tags": [
+        "函数",
+        "请求",
+        "认证"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 3 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:util/h2client/h2connection.py:verify_client_hello_ja",
+      "type": "function",
+      "name": "verify_client_hello_ja",
+      "filePath": "util/h2client/h2connection.py",
+      "lineRange": [
+        143,
+        164
+      ],
+      "summary": "`verify_client_hello_ja(sni, profile, expected)` 位于HTTP/2 客户端，负责处理 verify client hello ja 相关逻辑；内部主要调用 build_client_hello、fingerprints_from_client_hello、JAMatch、ClientHelloProfile、update。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 3 个，约 22 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:util/h2client/h2connection.py:assert_client_hello_ja",
+      "type": "function",
+      "name": "assert_client_hello_ja",
+      "filePath": "util/h2client/h2connection.py",
+      "lineRange": [
+        167,
+        184
+      ],
+      "summary": "`assert_client_hello_ja(sni, profile, expected)` 位于HTTP/2 客户端，负责处理 assert client hello ja 相关逻辑；内部主要调用 verify_client_hello_ja、join、RuntimeError、items。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 3 个，约 18 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:util/h2client/h2connection.py:_coerce_body",
+      "type": "function",
+      "name": "_coerce_body",
+      "filePath": "util/h2client/h2connection.py",
+      "lineRange": [
+        187,
+        192
+      ],
+      "summary": "`_coerce_body(content)` 位于HTTP/2 客户端，负责规范化输入值；内部主要调用 isinstance、encode。",
+      "tags": [
+        "函数",
+        "请求",
+        "规范化"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 6 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:util/h2client/h2connection.py:_body_for_log",
+      "type": "function",
+      "name": "_body_for_log",
+      "filePath": "util/h2client/h2connection.py",
+      "lineRange": [
+        195,
+        196
+      ],
+      "summary": "`_body_for_log(body)` 位于HTTP/2 客户端，负责处理 body for log 相关逻辑；内部主要调用 decode。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 2 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:util/h2client/h2connection.py:_header_value",
+      "type": "function",
+      "name": "_header_value",
+      "filePath": "util/h2client/h2connection.py",
+      "lineRange": [
+        199,
+        203
+      ],
+      "summary": "`_header_value(headers, name)` 位于HTTP/2 客户端，负责处理 header value 相关逻辑；内部主要调用 无明显外部调用。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 5 行，直接调用约 0 次。"
+    },
+    {
+      "id": "function:util/h2client/h2connection.py:_normalize_header_items",
+      "type": "function",
+      "name": "_normalize_header_items",
+      "filePath": "util/h2client/h2connection.py",
+      "lineRange": [
+        206,
+        223
+      ],
+      "summary": "`_normalize_header_items(headers)` 位于HTTP/2 客户端，负责规范化输入值；内部主要调用 isinstance、items、lower、startswith、append、str。",
+      "tags": [
+        "函数",
+        "请求",
+        "规范化"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 18 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:util/h2client/h2connection.py:_parse_request_target",
+      "type": "function",
+      "name": "_parse_request_target",
+      "filePath": "util/h2client/h2connection.py",
+      "lineRange": [
+        226,
+        259
+      ],
+      "summary": "`_parse_request_target(url, remote_host, port)` 位于HTTP/2 客户端，负责规范化输入值；内部主要调用 urlsplit、RequestTarget、startswith、ValueError、format_authority。",
+      "tags": [
+        "函数",
+        "请求",
+        "规范化"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 3 个，约 34 行，直接调用约 11 次。"
+    },
+    {
+      "id": "function:util/h2client/h2connection.py:build_request_headers",
+      "type": "function",
+      "name": "build_request_headers",
+      "filePath": "util/h2client/h2connection.py",
+      "lineRange": [
+        262,
+        290
+      ],
+      "summary": "`build_request_headers(method, url, remote_host, port, headers, content_length)` 位于HTTP/2 客户端，负责封装接口请求；内部主要调用 upper、_parse_request_target、_normalize_header_items、extend、append、str。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 6 个，约 29 行，直接调用约 6 次。"
+    },
+    {
+      "id": "class:util/h2client/h2connection.py:H2Response",
+      "type": "class",
+      "name": "H2Response",
+      "filePath": "util/h2client/h2connection.py",
+      "lineRange": [
+        67,
+        78
+      ],
+      "summary": "`H2Response` 位于HTTP/2 客户端，用于处理 H2 Response 相关逻辑，包含方法 text、json。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 12 行，包含 2 个方法。"
+    },
+    {
+      "id": "class:util/h2client/h2connection.py:RequestTarget",
+      "type": "class",
+      "name": "RequestTarget",
+      "filePath": "util/h2client/h2connection.py",
+      "lineRange": [
+        82,
+        85
+      ],
+      "summary": "`RequestTarget` 位于HTTP/2 客户端，用于封装接口请求，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 4 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/h2client/h2connection.py:JAMatch",
+      "type": "class",
+      "name": "JAMatch",
+      "filePath": "util/h2client/h2connection.py",
+      "lineRange": [
+        89,
+        115
+      ],
+      "summary": "`JAMatch` 位于HTTP/2 客户端，用于处理 JAMatch 相关逻辑，包含方法 ok、mismatches。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 27 行，包含 2 个方法。"
+    },
+    {
+      "id": "class:util/h2client/h2connection.py:H2ConnectionConfig",
+      "type": "class",
+      "name": "H2ConnectionConfig",
+      "filePath": "util/h2client/h2connection.py",
+      "lineRange": [
+        119,
+        135
+      ],
+      "summary": "`H2ConnectionConfig` 位于HTTP/2 客户端，用于处理配置项，包含方法 effective_sni、authority。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 17 行，包含 2 个方法。"
+    },
+    {
+      "id": "class:util/h2client/h2connection.py:H2Connection",
+      "type": "class",
+      "name": "H2Connection",
+      "filePath": "util/h2client/h2connection.py",
+      "lineRange": [
+        293,
+        579
+      ],
+      "summary": "`H2Connection` 位于HTTP/2 客户端，用于处理 H2 Connection 相关逻辑，包含方法 __init__、connected、selected_alpn、cipher_suite、verify_ja、connect、close、__enter__、__exit__、get。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 类，约 287 行，包含 19 个方法。"
+    },
+    {
+      "id": "function:util/h2client/ja_h2_client.py:_normalize_proxy_list",
+      "type": "function",
+      "name": "_normalize_proxy_list",
+      "filePath": "util/h2client/ja_h2_client.py",
+      "lineRange": [
+        43,
+        57
+      ],
+      "summary": "`_normalize_proxy_list(proxy)` 位于HTTP/2 客户端，负责规范化输入值；内部主要调用 set、split、strip、lower、add、append、str。",
+      "tags": [
+        "函数",
+        "请求",
+        "规范化"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 15 行，直接调用约 8 次。"
+    },
+    {
+      "id": "function:util/h2client/ja_h2_client.py:_dedupe_sources",
+      "type": "function",
+      "name": "_dedupe_sources",
+      "filePath": "util/h2client/ja_h2_client.py",
+      "lineRange": [
+        96,
+        105
+      ],
+      "summary": "`_dedupe_sources(sources)` 位于HTTP/2 客户端，负责处理 dedupe sources 相关逻辑；内部主要调用 set、add、append。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 10 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:util/h2client/ja_h2_client.py:_append_params",
+      "type": "function",
+      "name": "_append_params",
+      "filePath": "util/h2client/ja_h2_client.py",
+      "lineRange": [
+        108,
+        120
+      ],
+      "summary": "`_append_params(url, params)` 位于HTTP/2 客户端，负责处理 append params 相关逻辑；内部主要调用 urlsplit、isinstance、urlunsplit、urlencode。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 13 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:util/h2client/ja_h2_client.py:_json_body",
+      "type": "function",
+      "name": "_json_body",
+      "filePath": "util/h2client/ja_h2_client.py",
+      "lineRange": [
+        123,
+        124
+      ],
+      "summary": "`_json_body(value)` 位于HTTP/2 客户端，负责处理 json body 相关逻辑；内部主要调用 encode、dumps。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 2 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:util/h2client/ja_h2_client.py:_form_body",
+      "type": "function",
+      "name": "_form_body",
+      "filePath": "util/h2client/ja_h2_client.py",
+      "lineRange": [
+        127,
+        134
+      ],
+      "summary": "`_form_body(value)` 位于HTTP/2 客户端，负责处理 form body 相关逻辑；内部主要调用 isinstance、encode、urlencode。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 8 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:util/h2client/ja_h2_client.py:_header_mapping",
+      "type": "function",
+      "name": "_header_mapping",
+      "filePath": "util/h2client/ja_h2_client.py",
+      "lineRange": [
+        137,
+        138
+      ],
+      "summary": "`_header_mapping(headers)` 位于HTTP/2 客户端，负责处理 header mapping 相关逻辑；内部主要调用 Headers。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 2 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:util/h2client/ja_h2_client.py:_set_default_header",
+      "type": "function",
+      "name": "_set_default_header",
+      "filePath": "util/h2client/ja_h2_client.py",
+      "lineRange": [
+        141,
+        143
+      ],
+      "summary": "`_set_default_header(headers, name, value)` 位于HTTP/2 客户端，负责处理 set default header 相关逻辑；内部主要调用 无明显外部调用。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 3 个，约 3 行，直接调用约 0 次。"
+    },
+    {
+      "id": "function:util/h2client/ja_h2_client.py:_timeout_seconds",
+      "type": "function",
+      "name": "_timeout_seconds",
+      "filePath": "util/h2client/ja_h2_client.py",
+      "lineRange": [
+        146,
+        160
+      ],
+      "summary": "`_timeout_seconds(timeout, default)` 位于HTTP/2 客户端，负责处理 timeout seconds 相关逻辑；内部主要调用 isinstance、float、max、getattr。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 2 个，约 15 行，直接调用约 8 次。"
+    },
+    {
+      "id": "function:util/h2client/ja_h2_client.py:_content_length",
+      "type": "function",
+      "name": "_content_length",
+      "filePath": "util/h2client/ja_h2_client.py",
+      "lineRange": [
+        163,
+        168
+      ],
+      "summary": "`_content_length(content)` 位于HTTP/2 客户端，负责处理 content length 相关逻辑；内部主要调用 isinstance、len、encode。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 6 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:util/h2client/ja_h2_client.py:_response_errno",
+      "type": "function",
+      "name": "_response_errno",
+      "filePath": "util/h2client/ja_h2_client.py",
+      "lineRange": [
+        171,
+        184
+      ],
+      "summary": "`_response_errno(response)` 位于HTTP/2 客户端，负责处理 response errno 相关逻辑；内部主要调用 get、json、isinstance、int。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 14 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:util/h2client/ja_h2_client.py:_is_create_success_response",
+      "type": "function",
+      "name": "_is_create_success_response",
+      "filePath": "util/h2client/ja_h2_client.py",
+      "lineRange": [
+        187,
+        190
+      ],
+      "summary": "`_is_create_success_response(response)` 位于HTTP/2 客户端，负责处理 is create success response 相关逻辑；内部主要调用 _response_errno。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 4 行，直接调用约 1 次。"
+    },
+    {
+      "id": "class:util/h2client/ja_h2_client.py:SourceAddress",
+      "type": "class",
+      "name": "SourceAddress",
+      "filePath": "util/h2client/ja_h2_client.py",
+      "lineRange": [
+        61,
+        69
+      ],
+      "summary": "`SourceAddress` 位于HTTP/2 客户端，用于处理 Source Address 相关逻辑，包含方法 display。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 9 行，包含 1 个方法。"
+    },
+    {
+      "id": "class:util/h2client/ja_h2_client.py:ConnectionSlot",
+      "type": "class",
+      "name": "ConnectionSlot",
+      "filePath": "util/h2client/ja_h2_client.py",
+      "lineRange": [
+        73,
+        79
+      ],
+      "summary": "`ConnectionSlot` 位于HTTP/2 客户端，用于处理 Connection Slot 相关逻辑，包含方法 close。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 7 行，包含 1 个方法。"
+    },
+    {
+      "id": "class:util/h2client/ja_h2_client.py:FanoutOutcome",
+      "type": "class",
+      "name": "FanoutOutcome",
+      "filePath": "util/h2client/ja_h2_client.py",
+      "lineRange": [
+        83,
+        86
+      ],
+      "summary": "`FanoutOutcome` 位于HTTP/2 客户端，用于处理 Fanout Outcome 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 4 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/h2client/ja_h2_client.py:HealthcheckOutcome",
+      "type": "class",
+      "name": "HealthcheckOutcome",
+      "filePath": "util/h2client/ja_h2_client.py",
+      "lineRange": [
+        90,
+        93
+      ],
+      "summary": "`HealthcheckOutcome` 位于HTTP/2 客户端，用于校验状态或参数，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "请求",
+        "校验"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 4 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/h2client/ja_h2_client.py:_SourcePoolJA3H2Client",
+      "type": "class",
+      "name": "_SourcePoolJA3H2Client",
+      "filePath": "util/h2client/ja_h2_client.py",
+      "lineRange": [
+        193,
+        605
+      ],
+      "summary": "`_SourcePoolJA3H2Client` 位于HTTP/2 客户端，继承 AbstractH2Client，用于处理 Source Pool JA3 H2 Client 相关逻辑，包含方法 __init__、headers、cookies、available_source_ips、close、head、get、post、_should_use_fallback、_init_healthchecked_pool。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 类，约 413 行，包含 18 个方法。"
+    },
+    {
+      "id": "class:util/h2client/ja_h2_client.py:_CreateV2FanoutJA3H2Client",
+      "type": "class",
+      "name": "_CreateV2FanoutJA3H2Client",
+      "filePath": "util/h2client/ja_h2_client.py",
+      "lineRange": [
+        608,
+        760
+      ],
+      "summary": "`_CreateV2FanoutJA3H2Client` 位于HTTP/2 客户端，继承 _SourcePoolJA3H2Client，用于处理 Create V2 Fanout JA3 H2 Client 相关逻辑，包含方法 _request、_should_fanout_create_v2、_send_fanout_request、_handle_fanout_done。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 类，约 153 行，包含 4 个方法。"
+    },
+    {
+      "id": "class:util/h2client/ja_h2_client.py:ProxyPoolCreateV2FanoutJA3H2Client",
+      "type": "class",
+      "name": "ProxyPoolCreateV2FanoutJA3H2Client",
+      "filePath": "util/h2client/ja_h2_client.py",
+      "lineRange": [
+        763,
+        882
+      ],
+      "summary": "`ProxyPoolCreateV2FanoutJA3H2Client` 位于HTTP/2 客户端，继承 _CreateV2FanoutJA3H2Client，用于选择、检测或维护代理，包含方法 __init__、_proxy_sources、_request。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 类，约 120 行，包含 3 个方法。"
+    },
+    {
+      "id": "function:assets/updater/update.sh:resolve_url",
+      "type": "function",
+      "name": "resolve_url",
+      "filePath": "assets/updater/update.sh",
+      "lineRange": [
+        62,
+        74
+      ],
+      "summary": "resolve_url 封装 update.sh 中的一段可复用业务逻辑。",
+      "tags": [
+        "脚本",
+        "函数",
+        "函数"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:assets/updater/update.sh:http_get",
+      "type": "function",
+      "name": "http_get",
+      "filePath": "assets/updater/update.sh",
+      "lineRange": [
+        76,
+        115
+      ],
+      "summary": "http_get 封装 update.sh 中的一段可复用业务逻辑。",
+      "tags": [
+        "脚本",
+        "函数",
+        "函数"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:assets/updater/update.sh:request_release_json",
+      "type": "function",
+      "name": "request_release_json",
+      "filePath": "assets/updater/update.sh",
+      "lineRange": [
+        117,
+        139
+      ],
+      "summary": "request_release_json 封装 update.sh 中的一段可复用业务逻辑。",
+      "tags": [
+        "脚本",
+        "函数",
+        "函数"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:assets/updater/update.sh:find_package_binary",
+      "type": "function",
+      "name": "find_package_binary",
+      "filePath": "assets/updater/update.sh",
+      "lineRange": [
+        150,
+        163
+      ],
+      "summary": "find_package_binary 封装 update.sh 中的一段可复用业务逻辑。",
+      "tags": [
+        "脚本",
+        "函数",
+        "函数"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:interface/managed_runner.py:_load_json",
+      "type": "function",
+      "name": "_load_json",
+      "filePath": "interface/managed_runner.py",
+      "lineRange": [
+        16,
+        18
+      ],
+      "summary": "`_load_json(path)` 位于界面/API 适配层，负责读取并解析数据；内部主要调用 open、load。",
+      "tags": [
+        "函数",
+        "界面",
+        "读取"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 3 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:interface/managed_runner.py:_dump_json",
+      "type": "function",
+      "name": "_dump_json",
+      "filePath": "interface/managed_runner.py",
+      "lineRange": [
+        21,
+        25
+      ],
+      "summary": "`_dump_json(path, payload)` 位于界面/API 适配层，负责写入或持久化数据；内部主要调用 with_suffix、replace、open、dump。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 5 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:interface/managed_runner.py:_append_log",
+      "type": "function",
+      "name": "_append_log",
+      "filePath": "interface/managed_runner.py",
+      "lineRange": [
+        28,
+        31
+      ],
+      "summary": "`_append_log(path, message)` 位于界面/API 适配层，负责处理 append log 相关逻辑；内部主要调用 open、write。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 4 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:interface/managed_runner.py:_heartbeat_loop",
+      "type": "function",
+      "name": "_heartbeat_loop",
+      "filePath": "interface/managed_runner.py",
+      "lineRange": [
+        34,
+        46
+      ],
+      "summary": "`_heartbeat_loop(status_path, status, lock, stop_event, interval_seconds)` 位于界面/API 适配层，负责处理 heartbeat loop 相关逻辑；内部主要调用 wait、time、_dump_json、get。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 5 个，约 13 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:interface/managed_runner.py:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "interface/managed_runner.py",
+      "lineRange": [
+        49,
+        187
+      ],
+      "summary": "`main(run_dir_arg)` 位于界面/API 适配层，负责处理 main 相关逻辑；内部主要调用 Path、_load_json、from_mapping、_dump_json、Lock、Event。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 1 个，约 139 行，直接调用约 55 次。"
+    },
+    {
+      "id": "function:tab/problems.py:problems_tab",
+      "type": "function",
+      "name": "problems_tab",
+      "filePath": "tab/problems.py",
+      "lineRange": [
+        4,
+        68
+      ],
+      "summary": "`problems_tab()` 位于Gradio 界面标签页，负责处理 problems tab 相关逻辑；内部主要调用 HTML。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 0 个，约 65 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tests/test_buy_time_sync.py:test_prepare_create_request_uses_calibrated_timestamp",
+      "type": "function",
+      "name": "test_prepare_create_request_uses_calibrated_timestamp",
+      "filePath": "tests/test_buy_time_sync.py",
+      "lineRange": [
+        30,
+        61
+      ],
+      "summary": "`test_prepare_create_request_uses_calibrated_timestamp(monkeypatch)` 位于自动化测试，负责封装接口请求；内部主要调用 setattr、prepare_create_request、_FakeTimeService、_FakeCreateState、_FakeTicketState。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 32 行，直接调用约 6 次。"
+    },
+    {
+      "id": "class:tests/test_buy_time_sync.py:_FakeTicketState",
+      "type": "class",
+      "name": "_FakeTicketState",
+      "filePath": "tests/test_buy_time_sync.py",
+      "lineRange": [
+        16,
+        17
+      ],
+      "summary": "`_FakeTicketState` 位于自动化测试，用于推进购票、订单或支付流程，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "测试",
+        "支付"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 2 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:tests/test_buy_time_sync.py:_FakeCreateState",
+      "type": "class",
+      "name": "_FakeCreateState",
+      "filePath": "tests/test_buy_time_sync.py",
+      "lineRange": [
+        20,
+        22
+      ],
+      "summary": "`_FakeCreateState` 位于自动化测试，用于验证对应业务行为，包含方法 generate_create_ctoken。",
+      "tags": [
+        "类",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 3 行，包含 1 个方法。"
+    },
+    {
+      "id": "class:tests/test_buy_time_sync.py:_FakeTimeService",
+      "type": "class",
+      "name": "_FakeTimeService",
+      "filePath": "tests/test_buy_time_sync.py",
+      "lineRange": [
+        25,
+        27
+      ],
+      "summary": "`_FakeTimeService` 位于自动化测试，用于处理 Fake Time Service 相关逻辑，包含方法 current_time_ms。",
+      "tags": [
+        "类",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 3 行，包含 1 个方法。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:u8",
+      "type": "function",
+      "name": "u8",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        50,
+        51
+      ],
+      "summary": "`u8(value)` 位于HTTP/2 客户端，负责处理 u8 相关逻辑；内部主要调用 pack。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 2 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:u16",
+      "type": "function",
+      "name": "u16",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        54,
+        55
+      ],
+      "summary": "`u16(value)` 位于HTTP/2 客户端，负责处理 u16 相关逻辑；内部主要调用 pack。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 2 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:u24",
+      "type": "function",
+      "name": "u24",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        58,
+        59
+      ],
+      "summary": "`u24(value)` 位于HTTP/2 客户端，负责处理 u24 相关逻辑；内部主要调用 to_bytes。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 2 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:vec_u8",
+      "type": "function",
+      "name": "vec_u8",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        62,
+        65
+      ],
+      "summary": "`vec_u8(data)` 位于HTTP/2 客户端，负责处理 vec u8 相关逻辑；内部主要调用 len、ValueError、u8。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 4 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:vec_u16",
+      "type": "function",
+      "name": "vec_u16",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        68,
+        71
+      ],
+      "summary": "`vec_u16(data)` 位于HTTP/2 客户端，负责处理 vec u16 相关逻辑；内部主要调用 len、ValueError、u16。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 4 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:tls_ext",
+      "type": "function",
+      "name": "tls_ext",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        74,
+        75
+      ],
+      "summary": "`tls_ext(ext_type, body)` 位于HTTP/2 客户端，负责处理 tls ext 相关逻辑；内部主要调用 u16、vec_u16。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 2 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:build_extension_body",
+      "type": "function",
+      "name": "build_extension_body",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        155,
+        189
+      ],
+      "summary": "`build_extension_body(ext_type, sni, profile, key_share_public, padding_len)` 位于HTTP/2 客户端，负责处理 build extension body 相关逻辑；内部主要调用 ValueError、encode、vec_u16、vec_u8。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 5 个，约 35 行，直接调用约 23 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:build_extensions",
+      "type": "function",
+      "name": "build_extensions",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        192,
+        209
+      ],
+      "summary": "`build_extensions(sni, profile, key_share_public, padding_len)` 位于HTTP/2 客户端，负责处理 build extensions 相关逻辑；内部主要调用 join、build_extension_body、append、tls_ext。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 4 个，约 18 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:build_client_hello",
+      "type": "function",
+      "name": "build_client_hello",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        212,
+        275
+      ],
+      "summary": "`build_client_hello(sni, profile, random_bytes, session_id)` 位于HTTP/2 客户端，负责处理 build client hello 相关逻辑；内部主要调用 generate、public_bytes、body_with_padding、BuiltClientHello、urandom、len。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 4 个，约 64 行，直接调用约 29 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:md5_hex",
+      "type": "function",
+      "name": "md5_hex",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        278,
+        279
+      ],
+      "summary": "`md5_hex(text)` 位于HTTP/2 客户端，负责处理 md5 hex 相关逻辑；内部主要调用 hexdigest、md5、encode。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 2 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:sha256_12",
+      "type": "function",
+      "name": "sha256_12",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        282,
+        283
+      ],
+      "summary": "`sha256_12(text)` 位于HTTP/2 客户端，负责处理 sha256 12 相关逻辑；内部主要调用 hexdigest、sha256、encode。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 2 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:tls_version_for_ja4",
+      "type": "function",
+      "name": "tls_version_for_ja4",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        286,
+        293
+      ],
+      "summary": "`tls_version_for_ja4(version)` 位于HTTP/2 客户端，负责处理 tls version for ja4 相关逻辑；内部主要调用 get。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 8 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:is_domain_name",
+      "type": "function",
+      "name": "is_domain_name",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        296,
+        301
+      ],
+      "summary": "`is_domain_name(value)` 位于HTTP/2 客户端，负责处理 is domain name 相关逻辑；内部主要调用 ip_address。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 6 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:parse_client_hello_record",
+      "type": "function",
+      "name": "parse_client_hello_record",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        304,
+        407
+      ],
+      "summary": "`parse_client_hello_record(record)` 位于HTTP/2 客户端，负责规范化输入值；内部主要调用 from_bytes、len、ValueError、unpack。",
+      "tags": [
+        "函数",
+        "请求",
+        "规范化"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 1 个，约 104 行，直接调用约 38 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:fingerprints_from_client_hello",
+      "type": "function",
+      "name": "fingerprints_from_client_hello",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        410,
+        468
+      ],
+      "summary": "`fingerprints_from_client_hello(record)` 位于HTTP/2 客户端，负责处理 fingerprints from client hello 相关逻辑；内部主要调用 parse_client_hello_record、isinstance。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 1 个，约 59 行，直接调用约 34 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:read_targets_from_file",
+      "type": "function",
+      "name": "read_targets_from_file",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        471,
+        488
+      ],
+      "summary": "`read_targets_from_file(path)` 位于HTTP/2 客户端，负责读取并解析数据；内部主要调用 items、read、search、strip、open、group。",
+      "tags": [
+        "函数",
+        "请求",
+        "读取"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 18 行，直接调用约 6 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:hash_bytes",
+      "type": "function",
+      "name": "hash_bytes",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        556,
+        559
+      ],
+      "summary": "`hash_bytes(data, spec)` 位于HTTP/2 客户端，负责处理 hash bytes 相关逻辑；内部主要调用 Hash、update、finalize、hash_factory。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 4 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:hmac_bytes",
+      "type": "function",
+      "name": "hmac_bytes",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        562,
+        565
+      ],
+      "summary": "`hmac_bytes(key, data, spec)` 位于HTTP/2 客户端，负责处理 hmac bytes 相关逻辑；内部主要调用 HMAC、update、finalize、hash_factory。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 3 个，约 4 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:hkdf_extract",
+      "type": "function",
+      "name": "hkdf_extract",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        568,
+        571
+      ],
+      "summary": "`hkdf_extract(salt, ikm, spec)` 位于HTTP/2 客户端，负责处理 hkdf extract 相关逻辑；内部主要调用 hmac_bytes。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 3 个，约 4 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:hkdf_expand",
+      "type": "function",
+      "name": "hkdf_expand",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        574,
+        586
+      ],
+      "summary": "`hkdf_expand(secret, info, length, spec)` 位于HTTP/2 客户端，负责处理 hkdf expand 相关逻辑；内部主要调用 len、HMAC、update、finalize、hash_factory、bytes。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 4 个，约 13 行，直接调用约 6 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:hkdf_expand_label",
+      "type": "function",
+      "name": "hkdf_expand_label",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        589,
+        594
+      ],
+      "summary": "`hkdf_expand_label(secret, label, context, length, spec)` 位于HTTP/2 客户端，负责处理 hkdf expand label 相关逻辑；内部主要调用 hkdf_expand、vec_u8、u16。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 5 个，约 6 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:derive_secret",
+      "type": "function",
+      "name": "derive_secret",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        597,
+        600
+      ],
+      "summary": "`derive_secret(secret, label, transcript_hash, spec)` 位于HTTP/2 客户端，负责处理 derive secret 相关逻辑；内部主要调用 hkdf_expand_label。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 4 个，约 4 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:xor_bytes",
+      "type": "function",
+      "name": "xor_bytes",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        603,
+        604
+      ],
+      "summary": "`xor_bytes(left, right)` 位于HTTP/2 客户端，负责处理 xor bytes 相关逻辑；内部主要调用 bytes、zip。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 2 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:recvall",
+      "type": "function",
+      "name": "recvall",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        700,
+        707
+      ],
+      "summary": "`recvall(sock, length)` 位于HTTP/2 客户端，负责处理 recvall 相关逻辑；内部主要调用 bytearray、bytes、len、recv、extend、EOFError。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 2 个，约 8 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:read_tls_record",
+      "type": "function",
+      "name": "read_tls_record",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        710,
+        716
+      ],
+      "summary": "`read_tls_record(sock)` 位于HTTP/2 客户端，负责读取并解析数据；内部主要调用 recvall、unpack。",
+      "tags": [
+        "函数",
+        "请求",
+        "读取"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 7 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:raise_for_alert",
+      "type": "function",
+      "name": "raise_for_alert",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        719,
+        726
+      ],
+      "summary": "`raise_for_alert(fragment)` 位于HTTP/2 客户端，负责处理 raise for alert 相关逻辑；内部主要调用 get、TLSAlert、len。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 8 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:parse_server_hello",
+      "type": "function",
+      "name": "parse_server_hello",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        729,
+        790
+      ],
+      "summary": "`parse_server_hello(message)` 位于HTTP/2 客户端，负责规范化输入值；内部主要调用 fromhex、ServerHello、ValueError、unpack、NotImplementedError。",
+      "tags": [
+        "函数",
+        "请求",
+        "规范化"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 62 行，直接调用约 16 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:parse_encrypted_extensions",
+      "type": "function",
+      "name": "parse_encrypted_extensions",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        793,
+        816
+      ],
+      "summary": "`parse_encrypted_extensions(message)` 位于HTTP/2 客户端，负责规范化输入值；内部主要调用 ValueError、unpack、len、decode。",
+      "tags": [
+        "函数",
+        "请求",
+        "规范化"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 24 行，直接调用约 8 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:pop_first_handshake_message",
+      "type": "function",
+      "name": "pop_first_handshake_message",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        819,
+        835
+      ],
+      "summary": "`pop_first_handshake_message(sock, buffer)` 位于HTTP/2 客户端，负责处理 pop first handshake message 相关逻辑；内部主要调用 read_tls_record、feed、pop_messages、raise_for_alert、ValueError、len。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 2 个，约 17 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "type": "function",
+      "name": "open_tls13_connection",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        838,
+        957
+      ],
+      "summary": "`open_tls13_connection(sock, built)` 位于HTTP/2 客户端，负责处理 open tls13 connection 相关逻辑；内部主要调用 sendall、HandshakeBuffer、pop_first_handshake_message、bytearray、extend、parse_server_hello、from_public_bytes、exchange。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 2 个，约 120 行，直接调用约 55 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "type": "function",
+      "name": "complete_tls13_handshake",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        960,
+        1106
+      ],
+      "summary": "`complete_tls13_handshake(sock, built)` 位于HTTP/2 客户端，负责处理 complete tls13 handshake 相关逻辑；内部主要调用 sendall、HandshakeBuffer、pop_first_handshake_message、bytearray、extend、parse_server_hello、from_public_bytes、exchange。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 2 个，约 147 行，直接调用约 60 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:connect_tcp",
+      "type": "function",
+      "name": "connect_tcp",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        1109,
+        1149
+      ],
+      "summary": "`connect_tcp(host, port, family, source_ip, timeout, proxy_url)` 位于HTTP/2 客户端，负责处理 connect tcp 相关逻辑；内部主要调用 getaddrinfo、OSError、connect_tcp_via_proxy、socket、settimeout、connect、close、bind。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 6 个，约 41 行，直接调用约 9 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:connect_tcp_via_proxy",
+      "type": "function",
+      "name": "connect_tcp_via_proxy",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        1152,
+        1230
+      ],
+      "summary": "`connect_tcp_via_proxy(host, port, timeout, proxy_url)` 位于HTTP/2 客户端，负责选择、检测或维护代理；内部主要调用 urlsplit、lower、create_connection、settimeout、encode、OSError、socksocket。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 4 个，约 79 行，直接调用约 39 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:send_client_hello_only",
+      "type": "function",
+      "name": "send_client_hello_only",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        1233,
+        1240
+      ],
+      "summary": "`send_client_hello_only(sock, built)` 位于HTTP/2 客户端，负责发送通知或推送消息；内部主要调用 sendall、read_tls_record、raise_for_alert、len。",
+      "tags": [
+        "函数",
+        "请求",
+        "推送"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 8 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:print_fingerprint_report",
+      "type": "function",
+      "name": "print_fingerprint_report",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        1243,
+        1266
+      ],
+      "summary": "`print_fingerprint_report(generated, targets, padding_len)` 位于HTTP/2 客户端，负责处理 print fingerprint report 相关逻辑；内部主要调用 get、print。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 3 个，约 24 行，直接调用约 13 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:parse_args",
+      "type": "function",
+      "name": "parse_args",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        1269,
+        1316
+      ],
+      "summary": "`parse_args()` 位于HTTP/2 客户端，负责规范化输入值；内部主要调用 ArgumentParser、add_argument。",
+      "tags": [
+        "函数",
+        "请求",
+        "规范化"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 0 个，约 48 行，直接调用约 12 次。"
+    },
+    {
+      "id": "function:util/h2client/client_ja.py:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        1319,
+        1363
+      ],
+      "summary": "`main()` 位于HTTP/2 客户端，负责处理 main 相关逻辑；内部主要调用 parse_args、ClientHelloProfile、build_client_hello、fingerprints_from_client_hello、read_targets_from_file、print_fingerprint_report、connect_tcp、print。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 0 个，约 45 行，直接调用约 21 次。"
+    },
+    {
+      "id": "class:util/h2client/client_ja.py:ClientHelloProfile",
+      "type": "class",
+      "name": "ClientHelloProfile",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        79,
+        134
+      ],
+      "summary": "`ClientHelloProfile` 位于HTTP/2 客户端，用于处理 Client Hello Profile 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 类，约 56 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/h2client/client_ja.py:BuiltClientHello",
+      "type": "class",
+      "name": "BuiltClientHello",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        138,
+        144
+      ],
+      "summary": "`BuiltClientHello` 位于HTTP/2 客户端，用于处理 Built Client Hello 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 7 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/h2client/client_ja.py:Fingerprints",
+      "type": "class",
+      "name": "Fingerprints",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        148,
+        152
+      ],
+      "summary": "`Fingerprints` 位于HTTP/2 客户端，用于处理 Fingerprints 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 5 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/h2client/client_ja.py:CipherSuiteSpec",
+      "type": "class",
+      "name": "CipherSuiteSpec",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        492,
+        497
+      ],
+      "summary": "`CipherSuiteSpec` 位于HTTP/2 客户端，用于处理 Cipher Suite Spec 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 6 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/h2client/client_ja.py:TLSAlert",
+      "type": "class",
+      "name": "TLSAlert",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        533,
+        534
+      ],
+      "summary": "`TLSAlert` 位于HTTP/2 客户端，继承 RuntimeError，用于处理 TLSAlert 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 2 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/h2client/client_ja.py:HandshakeBuffer",
+      "type": "class",
+      "name": "HandshakeBuffer",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        537,
+        553
+      ],
+      "summary": "`HandshakeBuffer` 位于HTTP/2 客户端，用于处理 Handshake Buffer 相关逻辑，包含方法 __init__、feed、pop_messages。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 17 行，包含 3 个方法。"
+    },
+    {
+      "id": "class:util/h2client/client_ja.py:TrafficCipher",
+      "type": "class",
+      "name": "TrafficCipher",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        608,
+        640
+      ],
+      "summary": "`TrafficCipher` 位于HTTP/2 客户端，用于处理 Traffic Cipher 相关逻辑，包含方法 __post_init__、nonce、decrypt_record、encrypt_record。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 33 行，包含 4 个方法。"
+    },
+    {
+      "id": "class:util/h2client/client_ja.py:ServerHello",
+      "type": "class",
+      "name": "ServerHello",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        644,
+        649
+      ],
+      "summary": "`ServerHello` 位于HTTP/2 客户端，用于处理 Server Hello 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 6 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/h2client/client_ja.py:TLSHandshakeResult",
+      "type": "class",
+      "name": "TLSHandshakeResult",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        653,
+        658
+      ],
+      "summary": "`TLSHandshakeResult` 位于HTTP/2 客户端，用于处理 TLSHandshake Result 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 6 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/h2client/client_ja.py:TLS13Connection",
+      "type": "class",
+      "name": "TLS13Connection",
+      "filePath": "util/h2client/client_ja.py",
+      "lineRange": [
+        662,
+        697
+      ],
+      "summary": "`TLS13Connection` 位于HTTP/2 客户端，用于处理 TLS13 Connection 相关逻辑，包含方法 send_application_data、read_inner_record、read_application_data。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 类，约 36 行，包含 3 个方法。"
+    },
+    {
+      "id": "function:util/h2client/local_sources.py:_is_usable_source_ip",
+      "type": "function",
+      "name": "_is_usable_source_ip",
+      "filePath": "util/h2client/local_sources.py",
+      "lineRange": [
+        20,
+        27
+      ],
+      "summary": "`_is_usable_source_ip(value)` 位于HTTP/2 客户端，负责处理 is usable source ip 相关逻辑；内部主要调用 ip_address、split。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 8 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:util/h2client/local_sources.py:_source_address",
+      "type": "function",
+      "name": "_source_address",
+      "filePath": "util/h2client/local_sources.py",
+      "lineRange": [
+        30,
+        38
+      ],
+      "summary": "`_source_address(value, interface_alias)` 位于HTTP/2 客户端，负责处理 source address 相关逻辑；内部主要调用 ip_address、SourceAddress、_is_usable_source_ip、split、str。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 9 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:util/h2client/local_sources.py:_dedupe_sources",
+      "type": "function",
+      "name": "_dedupe_sources",
+      "filePath": "util/h2client/local_sources.py",
+      "lineRange": [
+        41,
+        50
+      ],
+      "summary": "`_dedupe_sources(sources)` 位于HTTP/2 客户端，负责处理 dedupe sources 相关逻辑；内部主要调用 set、add、append。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 10 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:util/h2client/local_sources.py:_discover_sources_with_powershell",
+      "type": "function",
+      "name": "_discover_sources_with_powershell",
+      "filePath": "util/h2client/local_sources.py",
+      "lineRange": [
+        53,
+        104
+      ],
+      "summary": "`_discover_sources_with_powershell(interface_aliases)` 位于HTTP/2 客户端，负责处理 discover sources with powershell 相关逻辑；内部主要调用 join、loads、_dedupe_sources、run、strip、isinstance、str。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 52 行，直接调用约 14 次。"
+    },
+    {
+      "id": "function:util/h2client/local_sources.py:_discover_sources_with_socket",
+      "type": "function",
+      "name": "_discover_sources_with_socket",
+      "filePath": "util/h2client/local_sources.py",
+      "lineRange": [
+        107,
+        124
+      ],
+      "summary": "`_discover_sources_with_socket()` 位于HTTP/2 客户端，负责处理 discover sources with socket 相关逻辑；内部主要调用 _dedupe_sources、getaddrinfo、_source_address、gethostname、append。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 18 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:util/h2client/local_sources.py:discover_interface_source_ips",
+      "type": "function",
+      "name": "discover_interface_source_ips",
+      "filePath": "util/h2client/local_sources.py",
+      "lineRange": [
+        127,
+        136
+      ],
+      "summary": "`discover_interface_source_ips(interface_aliases)` 位于HTTP/2 客户端，负责处理 discover interface source ips 相关逻辑；内部主要调用 _discover_sources_with_socket、_discover_sources_with_powershell。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 10 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:util/log/TerminalRenderer.py:_extract_message_meta",
+      "type": "function",
+      "name": "_extract_message_meta",
+      "filePath": "util/log/TerminalRenderer.py",
+      "lineRange": [
+        35,
+        41
+      ],
+      "summary": "`_extract_message_meta(item)` 位于日志与终端输出，负责处理 extract message meta 相关逻辑；内部主要调用 getattr、str。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 7 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:util/log/TerminalRenderer.py:_make_log_item",
+      "type": "function",
+      "name": "_make_log_item",
+      "filePath": "util/log/TerminalRenderer.py",
+      "lineRange": [
+        118,
+        138
+      ],
+      "summary": "`_make_log_item(item)` 位于日志与终端输出，负责处理 make log item 相关逻辑；内部主要调用 _extract_message_meta、LogItem。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 21 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:util/log/TerminalRenderer.py:_can_merge_log_item",
+      "type": "function",
+      "name": "_can_merge_log_item",
+      "filePath": "util/log/TerminalRenderer.py",
+      "lineRange": [
+        141,
+        157
+      ],
+      "summary": "`_can_merge_log_item(item, next_item)` 位于日志与终端输出，负责处理 can merge log item 相关逻辑；内部主要调用 _extract_message_meta。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 17 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:util/log/TerminalRenderer.py:_merge_log_item",
+      "type": "function",
+      "name": "_merge_log_item",
+      "filePath": "util/log/TerminalRenderer.py",
+      "lineRange": [
+        160,
+        181
+      ],
+      "summary": "`_merge_log_item(item, next_item)` 位于日志与终端输出，负责处理 merge log item 相关逻辑；内部主要调用 _extract_message_meta、rstrip。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 22 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:util/log/TerminalRenderer.py:create_terminal_renderer",
+      "type": "function",
+      "name": "create_terminal_renderer",
+      "filePath": "util/log/TerminalRenderer.py",
+      "lineRange": [
+        482,
+        501
+      ],
+      "summary": "`create_terminal_renderer(context, prefer_rich)` 位于日志与终端输出，负责格式化展示内容；内部主要调用 PlainTerminalRenderer、TextualTerminalRenderer。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 20 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:util/log/TerminalRenderer.py:render_message_stream",
+      "type": "function",
+      "name": "render_message_stream",
+      "filePath": "util/log/TerminalRenderer.py",
+      "lineRange": [
+        504,
+        531
+      ],
+      "summary": "`render_message_stream(renderer, messages, on_message)` 位于日志与终端输出，负责格式化展示内容；内部主要调用 render_header、getattr、close、render_state、on_message、render_message。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 3 个，约 28 行，直接调用约 7 次。"
+    },
+    {
+      "id": "class:util/log/TerminalRenderer.py:TerminalRenderContext",
+      "type": "class",
+      "name": "TerminalRenderContext",
+      "filePath": "util/log/TerminalRenderer.py",
+      "lineRange": [
+        9,
+        12
+      ],
+      "summary": "`TerminalRenderContext` 位于日志与终端输出，用于格式化展示内容，包含方法 无显式方法。",
+      "tags": [
+        "类"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 4 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/log/TerminalRenderer.py:TerminalViewState",
+      "type": "class",
+      "name": "TerminalViewState",
+      "filePath": "util/log/TerminalRenderer.py",
+      "lineRange": [
+        16,
+        20
+      ],
+      "summary": "`TerminalViewState` 位于日志与终端输出，用于处理 Terminal View State 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 5 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/log/TerminalRenderer.py:LogItem",
+      "type": "class",
+      "name": "LogItem",
+      "filePath": "util/log/TerminalRenderer.py",
+      "lineRange": [
+        24,
+        32
+      ],
+      "summary": "`LogItem` 位于日志与终端输出，用于处理 Log Item 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 9 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/log/TerminalRenderer.py:BaseTerminalRenderer",
+      "type": "class",
+      "name": "BaseTerminalRenderer",
+      "filePath": "util/log/TerminalRenderer.py",
+      "lineRange": [
+        44,
+        58
+      ],
+      "summary": "`BaseTerminalRenderer` 位于日志与终端输出，用于格式化展示内容，包含方法 __init__、render_header、render_message、render_state、close。",
+      "tags": [
+        "类"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 15 行，包含 5 个方法。"
+    },
+    {
+      "id": "class:util/log/TerminalRenderer.py:PlainTerminalRenderer",
+      "type": "class",
+      "name": "PlainTerminalRenderer",
+      "filePath": "util/log/TerminalRenderer.py",
+      "lineRange": [
+        61,
+        115
+      ],
+      "summary": "`PlainTerminalRenderer`：Stable fallback for terminals where Textual cannot render reliably.。位于日志与终端输出，继承 BaseTerminalRenderer，包含方法 __init__、render_header、render_message、render_state、_print_snapshot。",
+      "tags": [
+        "类"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 类，约 55 行，包含 5 个方法。"
+    },
+    {
+      "id": "class:util/log/TerminalRenderer.py:TextualTerminalRenderer",
+      "type": "class",
+      "name": "TextualTerminalRenderer",
+      "filePath": "util/log/TerminalRenderer.py",
+      "lineRange": [
+        184,
+        479
+      ],
+      "summary": "`TextualTerminalRenderer` 位于日志与终端输出，继承 BaseTerminalRenderer，用于格式化展示内容，包含方法 __init__、_dump_final_snapshot、render_header、render_message、render_state、close。",
+      "tags": [
+        "类"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 类，约 296 行，包含 6 个方法。"
+    },
+    {
+      "id": "function:util/Storage/CleanupUtil.py:_trim_old_paths",
+      "type": "function",
+      "name": "_trim_old_paths",
+      "filePath": "util/Storage/CleanupUtil.py",
+      "lineRange": [
+        9,
+        13
+      ],
+      "summary": "`_trim_old_paths(paths, max_count)` 位于本地存储，负责处理 trim old paths 相关逻辑；内部主要调用 sorted、len、stat。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 5 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:util/Storage/CleanupUtil.py:_remove_path",
+      "type": "function",
+      "name": "_remove_path",
+      "filePath": "util/Storage/CleanupUtil.py",
+      "lineRange": [
+        16,
+        24
+      ],
+      "summary": "`_remove_path(path)` 位于本地存储，负责处理 remove path 相关逻辑；内部主要调用 is_dir、rmtree、unlink、exists。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 9 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:util/Storage/CleanupUtil.py:cleanup_runtime_artifacts",
+      "type": "function",
+      "name": "cleanup_runtime_artifacts",
+      "filePath": "util/Storage/CleanupUtil.py",
+      "lineRange": [
+        27,
+        73
+      ],
+      "summary": "`cleanup_runtime_artifacts(logs_dir, runs_dir, retention_days, max_log_files, max_run_dirs)` 位于本地存储，负责启动或执行任务；内部主要调用 time、Path、exists、list、_trim_old_paths。",
+      "tags": [
+        "函数",
+        "执行"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 5 个，约 47 行，直接调用约 33 次。"
+    },
+    {
+      "id": "class:app_cmd/config/BuyConfig.py:BuyConfig",
+      "type": "class",
+      "name": "BuyConfig",
+      "filePath": "app_cmd/config/BuyConfig.py",
+      "lineRange": [
+        19,
+        309
+      ],
+      "summary": "`BuyConfig`：Ticket buying runtime configuration.。位于命令行配置模型，继承 BasicConfig，包含方法 from_runtime_options、from_config_db、apply_log_env。",
+      "tags": [
+        "类",
+        "配置"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 类，约 291 行，包含 3 个方法。"
+    },
+    {
+      "id": "function:app_cmd/config/ConfigBasic.py:str_to_bool",
+      "type": "function",
+      "name": "str_to_bool",
+      "filePath": "app_cmd/config/ConfigBasic.py",
+      "lineRange": [
+        14,
+        17
+      ],
+      "summary": "`str_to_bool(value)` 位于命令行配置模型，负责处理 str to bool 相关逻辑；内部主要调用 isinstance、lower、strip、str。",
+      "tags": [
+        "函数",
+        "配置"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 4 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:app_cmd/config/ConfigBasic.py:normalize_log_level",
+      "type": "function",
+      "name": "normalize_log_level",
+      "filePath": "app_cmd/config/ConfigBasic.py",
+      "lineRange": [
+        20,
+        21
+      ],
+      "summary": "`normalize_log_level(value)` 位于命令行配置模型，负责规范化输入值；内部主要调用 lower、str。",
+      "tags": [
+        "函数",
+        "配置",
+        "规范化"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 2 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:app_cmd/config/ConfigBasic.py:config_field",
+      "type": "function",
+      "name": "config_field",
+      "filePath": "app_cmd/config/ConfigBasic.py",
+      "lineRange": [
+        24,
+        69
+      ],
+      "summary": "`config_field(default, default_factory, env, runtime, db, cli, cast, env_default, runtime_default, db_default, env_transform, runtime_transform, db_transform, cli_false, cli_true, omit_cli_if_empty)` 位于命令行配置模型，负责处理配置项；内部主要调用 field、ValueError。",
+      "tags": [
+        "函数",
+        "配置"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 16 个，约 46 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:app_cmd/config/ConfigBasic.py:nested_config_field",
+      "type": "function",
+      "name": "nested_config_field",
+      "filePath": "app_cmd/config/ConfigBasic.py",
+      "lineRange": [
+        72,
+        78
+      ],
+      "summary": "`nested_config_field(default_factory)` 位于命令行配置模型，负责处理配置项；内部主要调用 field。",
+      "tags": [
+        "函数",
+        "配置"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 7 行，直接调用约 1 次。"
+    },
+    {
+      "id": "class:app_cmd/config/ConfigBasic.py:BasicConfig",
+      "type": "class",
+      "name": "BasicConfig",
+      "filePath": "app_cmd/config/ConfigBasic.py",
+      "lineRange": [
+        81,
+        288
+      ],
+      "summary": "`BasicConfig`：通用配置基类。。位于命令行配置模型，包含方法 _field_default、_source_default、_safe_apply、_normalize_value、_is_nested_config_field、from_mapping、from_env、from_config_getter、with_overrides、to_cli_args。",
+      "tags": [
+        "类",
+        "配置"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 类，约 208 行，包含 10 个方法。"
+    },
+    {
+      "id": "class:app_cmd/config/NotifierConfig.py:NotifierConfig",
+      "type": "class",
+      "name": "NotifierConfig",
+      "filePath": "app_cmd/config/NotifierConfig.py",
+      "lineRange": [
+        7,
+        114
+      ],
+      "summary": "`NotifierConfig`：Notification channels used after success or proxy exhaustion.。位于命令行配置模型，继承 BasicConfig，包含方法 from_runtime_options、from_config_db。",
+      "tags": [
+        "类",
+        "配置"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 类，约 108 行，包含 2 个方法。"
+    },
+    {
+      "id": "function:tab/config.py:go_settings_tab",
+      "type": "function",
+      "name": "go_settings_tab",
+      "filePath": "tab/config.py",
+      "lineRange": [
+        24,
+        981
+      ],
+      "summary": "`go_settings_tab(header_ui)` 位于Gradio 界面标签页，负责处理配置项；内部主要调用 from_config_db、get_as_bool、lower、click、then。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 1 个，约 958 行，直接调用约 381 次。"
+    },
+    {
+      "id": "function:tests/test_buy_refresh_count.py:_make_scheduler",
+      "type": "function",
+      "name": "_make_scheduler",
+      "filePath": "tests/test_buy_refresh_count.py",
+      "lineRange": [
+        16,
+        61
+      ],
+      "summary": "`_make_scheduler(config)`：复刻 task/buy.py 里 buy_stream 的计数调度结构，便于隔离测试。。位于自动化测试，调用 max、int、randint、_reset_refresh_counter、_fetch_project_detail_only。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 46 行，直接调用约 9 次。"
+    },
+    {
+      "id": "function:tests/test_buy_refresh_count.py:_config",
+      "type": "function",
+      "name": "_config",
+      "filePath": "tests/test_buy_refresh_count.py",
+      "lineRange": [
+        64,
+        68
+      ],
+      "summary": "`_config(min_count, max_count)` 位于自动化测试，负责处理配置项；内部主要调用 BuyConfig。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 5 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tests/test_buy_refresh_count.py:test_trigger_after_target_count_then_resets",
+      "type": "function",
+      "name": "test_trigger_after_target_count_then_resets",
+      "filePath": "tests/test_buy_refresh_count.py",
+      "lineRange": [
+        71,
+        86
+      ],
+      "summary": "`test_trigger_after_target_count_then_resets()` 位于自动化测试，负责封装接口请求；内部主要调用 seed、_make_scheduler、range、_config、append。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 16 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:tests/test_buy_refresh_count.py:test_fetch_not_concurrent_with_create",
+      "type": "function",
+      "name": "test_fetch_not_concurrent_with_create",
+      "filePath": "tests/test_buy_refresh_count.py",
+      "lineRange": [
+        89,
+        94
+      ],
+      "summary": "`test_fetch_not_concurrent_with_create()`：tick() 同步返回，fetch 在 tick 内完成 —— 模拟 fetch 落在 sleep 窗口，不与 create 并发。。位于自动化测试，调用 _make_scheduler、range、_config。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 6 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:tests/test_buy_refresh_count.py:test_disabled_when_max_zero",
+      "type": "function",
+      "name": "test_disabled_when_max_zero",
+      "filePath": "tests/test_buy_refresh_count.py",
+      "lineRange": [
+        97,
+        102
+      ],
+      "summary": "`test_disabled_when_max_zero()` 位于自动化测试，负责验证对应业务行为；内部主要调用 _make_scheduler、range、_config。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 6 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:tests/test_buy_refresh_count.py:test_disabled_when_min_greater_than_max",
+      "type": "function",
+      "name": "test_disabled_when_min_greater_than_max",
+      "filePath": "tests/test_buy_refresh_count.py",
+      "lineRange": [
+        105,
+        110
+      ],
+      "summary": "`test_disabled_when_min_greater_than_max()` 位于自动化测试，负责验证对应业务行为；内部主要调用 _make_scheduler、range、_config。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 6 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:tests/test_buy_refresh_count.py:test_100001_resets_counter",
+      "type": "function",
+      "name": "test_100001_resets_counter",
+      "filePath": "tests/test_buy_refresh_count.py",
+      "lineRange": [
+        113,
+        129
+      ],
+      "summary": "`test_100001_resets_counter()` 位于自动化测试，负责验证对应业务行为；内部主要调用 seed、_make_scheduler、range、_config、append。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 17 行，直接调用约 6 次。"
+    },
+    {
+      "id": "function:tests/test_buy_refresh_count.py:test_default_config_values",
+      "type": "function",
+      "name": "test_default_config_values",
+      "filePath": "tests/test_buy_refresh_count.py",
+      "lineRange": [
+        132,
+        136
+      ],
+      "summary": "`test_default_config_values()` 位于自动化测试，负责处理配置项；内部主要调用 BuyConfig。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 5 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tests/test_notifier_join_all.py:_make_manager",
+      "type": "function",
+      "name": "_make_manager",
+      "filePath": "tests/test_notifier_join_all.py",
+      "lineRange": [
+        32,
+        36
+      ],
+      "summary": "`_make_manager(*notifiers)` 位于自动化测试，负责处理 make manager 相关逻辑；内部主要调用 NotifierManager、enumerate、register_notifier。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 5 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:tests/test_notifier_join_all.py:test_join_all_waits_for_push_to_complete",
+      "type": "function",
+      "name": "test_join_all_waits_for_push_to_complete",
+      "filePath": "tests/test_notifier_join_all.py",
+      "lineRange": [
+        39,
+        49
+      ],
+      "summary": "`test_join_all_waits_for_push_to_complete()` 位于自动化测试，负责发送通知或推送消息；内部主要调用 _FakeNotifier、_make_manager、start_all、join_all、is_set。",
+      "tags": [
+        "函数",
+        "测试",
+        "推送"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 11 行，直接调用约 6 次。"
+    },
+    {
+      "id": "function:tests/test_notifier_join_all.py:test_join_all_blocks_until_thread_finishes",
+      "type": "function",
+      "name": "test_join_all_blocks_until_thread_finishes",
+      "filePath": "tests/test_notifier_join_all.py",
+      "lineRange": [
+        52,
+        63
+      ],
+      "summary": "`test_join_all_blocks_until_thread_finishes()` 位于自动化测试，负责读取并解析数据；内部主要调用 _FakeNotifier、_make_manager、start_all、monotonic、join_all、is_set。",
+      "tags": [
+        "函数",
+        "测试",
+        "读取"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 0 个，约 12 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:tests/test_notifier_join_all.py:test_join_all_timeout_does_not_block_forever",
+      "type": "function",
+      "name": "test_join_all_timeout_does_not_block_forever",
+      "filePath": "tests/test_notifier_join_all.py",
+      "lineRange": [
+        66,
+        87
+      ],
+      "summary": "`test_join_all_timeout_does_not_block_forever()` 位于自动化测试，负责验证对应业务行为；内部主要调用 _Slow、_make_manager、start_all、monotonic、join_all、is_set、__init__。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 0 个，约 22 行，直接调用约 12 次。"
+    },
+    {
+      "id": "function:tests/test_notifier_join_all.py:test_join_all_no_notifiers_returns_immediately",
+      "type": "function",
+      "name": "test_join_all_no_notifiers_returns_immediately",
+      "filePath": "tests/test_notifier_join_all.py",
+      "lineRange": [
+        90,
+        95
+      ],
+      "summary": "`test_join_all_no_notifiers_returns_immediately()` 位于自动化测试，负责验证对应业务行为；内部主要调用 NotifierManager、monotonic、join_all。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 6 行，直接调用约 4 次。"
+    },
+    {
+      "id": "class:tests/test_notifier_join_all.py:_FakeNotifier",
+      "type": "class",
+      "name": "_FakeNotifier",
+      "filePath": "tests/test_notifier_join_all.py",
+      "lineRange": [
+        17,
+        29
+      ],
+      "summary": "`_FakeNotifier`：记一次 send_message 调用并短暂阻塞，模拟一次网络往返。。位于自动化测试，继承 NotifierBase，包含方法 __init__、send_message。",
+      "tags": [
+        "类",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 13 行，包含 2 个方法。"
+    },
+    {
+      "id": "class:util/notifer/AudioUtil.py:AudioNotifier",
+      "type": "class",
+      "name": "AudioNotifier",
+      "filePath": "util/notifer/AudioUtil.py",
+      "lineRange": [
+        5,
+        31
+      ],
+      "summary": "`AudioNotifier`：音频通知器，播放本地音频文件。位于通知渠道，继承 NotifierBase，包含方法 __init__、send_message、run。",
+      "tags": [
+        "类",
+        "通知"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 27 行，包含 3 个方法。"
+    },
+    {
+      "id": "class:util/notifer/BarkUtil.py:BarkNotifier",
+      "type": "class",
+      "name": "BarkNotifier",
+      "filePath": "util/notifer/BarkUtil.py",
+      "lineRange": [
+        8,
+        31
+      ],
+      "summary": "`BarkNotifier` 位于通知渠道，继承 NotifierBase，用于处理 Bark Notifier 相关逻辑，包含方法 __init__、send_message。",
+      "tags": [
+        "类",
+        "通知"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 24 行，包含 2 个方法。"
+    },
+    {
+      "id": "class:util/notifer/MeoWUtil.py:MeoWNotifier",
+      "type": "class",
+      "name": "MeoWNotifier",
+      "filePath": "util/notifer/MeoWUtil.py",
+      "lineRange": [
+        7,
+        36
+      ],
+      "summary": "`MeoWNotifier` 位于通知渠道，继承 NotifierBase，用于处理 Meo WNotifier 相关逻辑，包含方法 __init__、send_message。",
+      "tags": [
+        "类",
+        "通知"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 30 行，包含 2 个方法。"
+    },
+    {
+      "id": "class:util/notifer/Notifier.py:NotifierBase",
+      "type": "class",
+      "name": "NotifierBase",
+      "filePath": "util/notifer/Notifier.py",
+      "lineRange": [
+        9,
+        80
+      ],
+      "summary": "`NotifierBase`：推送器基类。。位于通知渠道，继承 ABC，包含方法 __init__、run、start、stop、send_message。",
+      "tags": [
+        "类",
+        "通知"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 类，约 72 行，包含 5 个方法。"
+    },
+    {
+      "id": "class:util/notifer/Notifier.py:NotifierManager",
+      "type": "class",
+      "name": "NotifierManager",
+      "filePath": "util/notifer/Notifier.py",
+      "lineRange": [
+        83,
+        331
+      ],
+      "summary": "`NotifierManager` 位于通知渠道，用于处理 Notifier Manager 相关逻辑，包含方法 __init__、register_notifier、remove_notifier、start_all、join_all、stop_all、start_notifier、stop_notifier、list_notifiers、create_from_config。",
+      "tags": [
+        "类",
+        "通知"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 类，约 249 行，包含 11 个方法。"
+    },
+    {
+      "id": "function:util/notifer/NtfyUtil.py:send_message",
+      "type": "function",
+      "name": "send_message",
+      "filePath": "util/notifer/NtfyUtil.py",
+      "lineRange": [
+        87,
+        128
+      ],
+      "summary": "`send_message(title, message)`：使用send_message函数发送单次通知。位于通知渠道，调用 send_message。",
+      "tags": [
+        "函数",
+        "通知",
+        "推送"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 3 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:util/notifer/NtfyUtil.py:send_repeat_message",
+      "type": "function",
+      "name": "send_repeat_message",
+      "filePath": "util/notifer/NtfyUtil.py",
+      "lineRange": [
+        131,
+        184
+      ],
+      "summary": "`send_repeat_message(server_url, content, title, username, password, interval_seconds, duration_minutes, thread_id)`：在后台线程中重复发送ntfy通知。位于通知渠道，调用 stop_notification、RepeatedNotifier、start、info、time。",
+      "tags": [
+        "函数",
+        "通知",
+        "推送"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 8 个，约 54 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:util/notifer/NtfyUtil.py:stop_notification",
+      "type": "function",
+      "name": "stop_notification",
+      "filePath": "util/notifer/NtfyUtil.py",
+      "lineRange": [
+        187,
+        202
+      ],
+      "summary": "`stop_notification(thread_id)`：停止指定的通知线程。位于通知渠道，调用 set、info。",
+      "tags": [
+        "函数",
+        "通知",
+        "停止"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 16 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:util/notifer/NtfyUtil.py:test_connection",
+      "type": "function",
+      "name": "test_connection",
+      "filePath": "util/notifer/NtfyUtil.py",
+      "lineRange": [
+        205,
+        246
+      ],
+      "summary": "`test_connection(server_url, username, password)`：测试ntfy连接是否正常。位于通知渠道，调用 post、decode、encode、b64encode、str。",
+      "tags": [
+        "函数",
+        "通知"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 3 个，约 42 行，直接调用约 7 次。"
+    },
+    {
+      "id": "class:util/notifer/NtfyUtil.py:RepeatedNotifier",
+      "type": "class",
+      "name": "RepeatedNotifier",
+      "filePath": "util/notifer/NtfyUtil.py",
+      "lineRange": [
+        14,
+        84
+      ],
+      "summary": "`RepeatedNotifier`：后台通知发送线程类，用于重复发送ntfy通知。位于通知渠道，继承 Thread，包含方法 __init__、run。",
+      "tags": [
+        "类",
+        "通知"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 类，约 71 行，包含 2 个方法。"
+    },
+    {
+      "id": "class:util/notifer/NtfyUtil.py:NtfyNotifier",
+      "type": "class",
+      "name": "NtfyNotifier",
+      "filePath": "util/notifer/NtfyUtil.py",
+      "lineRange": [
+        249,
+        305
+      ],
+      "summary": "`NtfyNotifier`：Ntfy通知器，继承自NotifierBase，实现统一接口。位于通知渠道，继承 NotifierBase，包含方法 __init__、send_message、run。",
+      "tags": [
+        "类",
+        "通知"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 类，约 57 行，包含 3 个方法。"
+    },
+    {
+      "id": "class:util/notifer/ServerChanUtil.py:ServerChanTurboNotifier",
+      "type": "class",
+      "name": "ServerChanTurboNotifier",
+      "filePath": "util/notifer/ServerChanUtil.py",
+      "lineRange": [
+        7,
+        17
+      ],
+      "summary": "`ServerChanTurboNotifier` 位于通知渠道，继承 NotifierBase，用于处理 Server Chan Turbo Notifier 相关逻辑，包含方法 __init__、send_message。",
+      "tags": [
+        "类",
+        "通知"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 11 行，包含 2 个方法。"
+    },
+    {
+      "id": "class:util/notifer/ServerChanUtil.py:ServerChan3Notifier",
+      "type": "class",
+      "name": "ServerChan3Notifier",
+      "filePath": "util/notifer/ServerChanUtil.py",
+      "lineRange": [
+        20,
+        30
+      ],
+      "summary": "`ServerChan3Notifier` 位于通知渠道，继承 NotifierBase，用于处理 Server Chan3 Notifier 相关逻辑，包含方法 __init__、send_message。",
+      "tags": [
+        "类",
+        "通知"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 11 行，包含 2 个方法。"
+    },
+    {
+      "id": "class:util/proxy/PushPlusUtil.py:PushPlusNotifier",
+      "type": "class",
+      "name": "PushPlusNotifier",
+      "filePath": "util/proxy/PushPlusUtil.py",
+      "lineRange": [
+        7,
+        17
+      ],
+      "summary": "`PushPlusNotifier` 位于代理管理，继承 NotifierBase，用于发送通知或推送消息，包含方法 __init__、send_message。",
+      "tags": [
+        "类",
+        "代理",
+        "推送"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 11 行，包含 2 个方法。"
+    },
+    {
+      "id": "function:tests/test_bili_request_h2_recovery.py:test_request_retries_once_after_h2_local_protocol_error",
+      "type": "function",
+      "name": "test_request_retries_once_after_h2_local_protocol_error",
+      "filePath": "tests/test_bili_request_h2_recovery.py",
+      "lineRange": [
+        7,
+        40
+      ],
+      "summary": "`test_request_retries_once_after_h2_local_protocol_error(monkeypatch)` 位于自动化测试，负责封装接口请求；内部主要调用 BiliRequest、Response、setattr、post、Request、LocalProtocolError。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 34 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:tests/test_bili_request_h2_recovery.py:test_request_raises_connection_error_after_second_h2_local_protocol_error",
+      "type": "function",
+      "name": "test_request_raises_connection_error_after_second_h2_local_protocol_error",
+      "filePath": "tests/test_bili_request_h2_recovery.py",
+      "lineRange": [
+        43,
+        68
+      ],
+      "summary": "`test_request_raises_connection_error_after_second_h2_local_protocol_error(monkeypatch)` 位于自动化测试，负责封装接口请求；内部主要调用 BiliRequest、setattr、LocalProtocolError、post、AssertionError、isinstance、str。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 26 行，直接调用约 8 次。"
+    },
+    {
+      "id": "function:tests/test_bili_request_h2_recovery.py:test_request_raises_connection_error_after_second_read_timeout",
+      "type": "function",
+      "name": "test_request_raises_connection_error_after_second_read_timeout",
+      "filePath": "tests/test_bili_request_h2_recovery.py",
+      "lineRange": [
+        71,
+        94
+      ],
+      "summary": "`test_request_raises_connection_error_after_second_read_timeout(monkeypatch)` 位于自动化测试，负责读取并解析数据；内部主要调用 BiliRequest、setattr、ReadTimeout、post、AssertionError、isinstance、str。",
+      "tags": [
+        "函数",
+        "测试",
+        "读取"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 24 行，直接调用约 8 次。"
+    },
+    {
+      "id": "function:tests/test_bili_request_maintenance.py:test_handle_100001_calls_registered_handler",
+      "type": "function",
+      "name": "test_handle_100001_calls_registered_handler",
+      "filePath": "tests/test_bili_request_maintenance.py",
+      "lineRange": [
+        4,
+        14
+      ],
+      "summary": "`test_handle_100001_calls_registered_handler()` 位于自动化测试，负责验证对应业务行为；内部主要调用 BiliRequest、set_100001_handler、handle_100001。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 11 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:tests/test_bili_request_maintenance.py:test_handle_100001_ignores_other_errno",
+      "type": "function",
+      "name": "test_handle_100001_ignores_other_errno",
+      "filePath": "tests/test_bili_request_maintenance.py",
+      "lineRange": [
+        17,
+        27
+      ],
+      "summary": "`test_handle_100001_ignores_other_errno()` 位于自动化测试，负责验证对应业务行为；内部主要调用 BiliRequest、set_100001_handler、handle_100001。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 11 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:tests/test_bili_request_rate_limit.py:test_request_raises_rate_limit_error",
+      "type": "function",
+      "name": "test_request_raises_rate_limit_error",
+      "filePath": "tests/test_bili_request_rate_limit.py",
+      "lineRange": [
+        7,
+        23
+      ],
+      "summary": "`test_request_raises_rate_limit_error(monkeypatch)` 位于自动化测试，负责封装接口请求；内部主要调用 BiliRequest、Response、setattr、post、AssertionError、Request、str。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 17 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:util/Storage/KVDatabase.py:_ensure_valid_tinydb_file",
+      "type": "function",
+      "name": "_ensure_valid_tinydb_file",
+      "filePath": "util/Storage/KVDatabase.py",
+      "lineRange": [
+        11,
+        76
+      ],
+      "summary": "`_ensure_valid_tinydb_file(path)`：检查 TinyDB JSON 文件是否有效，无效则备份并重建。。位于本地存储，调用 items、isfile、isinstance、all、copy2、open。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 1 个，约 66 行，直接调用约 22 次。"
+    },
+    {
+      "id": "class:util/Storage/KVDatabase.py:KVDatabase",
+      "type": "class",
+      "name": "KVDatabase",
+      "filePath": "util/Storage/KVDatabase.py",
+      "lineRange": [
+        79,
+        171
+      ],
+      "summary": "`KVDatabase` 位于本地存储，用于处理 KVDatabase 相关逻辑，包含方法 __init__、insert、get、get_as_int、get_as_bool、update、delete、contains、close。",
+      "tags": [
+        "类"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 类，约 93 行，包含 9 个方法。"
+    },
+    {
+      "id": "class:util/h2client/abstract_h2_client.py:H2Headers",
+      "type": "class",
+      "name": "H2Headers",
+      "filePath": "util/h2client/abstract_h2_client.py",
+      "lineRange": [
+        8,
+        9
+      ],
+      "summary": "`H2Headers` 位于HTTP/2 客户端，继承 Protocol，用于处理 H2 Headers 相关逻辑，包含方法 __setitem__。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 2 行，包含 1 个方法。"
+    },
+    {
+      "id": "class:util/h2client/abstract_h2_client.py:H2Cookies",
+      "type": "class",
+      "name": "H2Cookies",
+      "filePath": "util/h2client/abstract_h2_client.py",
+      "lineRange": [
+        12,
+        19
+      ],
+      "summary": "`H2Cookies` 位于HTTP/2 客户端，继承 Protocol，用于处理登录认证或 Cookie 状态，包含方法 set。",
+      "tags": [
+        "类",
+        "请求",
+        "认证"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 8 行，包含 1 个方法。"
+    },
+    {
+      "id": "class:util/h2client/abstract_h2_client.py:H2Response",
+      "type": "class",
+      "name": "H2Response",
+      "filePath": "util/h2client/abstract_h2_client.py",
+      "lineRange": [
+        22,
+        30
+      ],
+      "summary": "`H2Response` 位于HTTP/2 客户端，继承 Protocol，用于处理 H2 Response 相关逻辑，包含方法 json、raise_for_status。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 9 行，包含 2 个方法。"
+    },
+    {
+      "id": "class:util/h2client/abstract_h2_client.py:AbstractH2Client",
+      "type": "class",
+      "name": "AbstractH2Client",
+      "filePath": "util/h2client/abstract_h2_client.py",
+      "lineRange": [
+        33,
+        66
+      ],
+      "summary": "`AbstractH2Client`：BiliRequest only needs headers, cookies, head/get/post, and close.。位于HTTP/2 客户端，继承 ABC，包含方法 headers、cookies、head、get、post、close。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 34 行，包含 6 个方法。"
+    },
+    {
+      "id": "class:util/proxy/ProxyManager.py:ProxyManager",
+      "type": "class",
+      "name": "ProxyManager",
+      "filePath": "util/proxy/ProxyManager.py",
+      "lineRange": [
+        6,
+        150
+      ],
+      "summary": "`ProxyManager` 位于代理管理，用于选择、检测或维护代理，包含方法 __init__、now_proxy_idx、now_proxy_idx、normalize_proxy_value、parse_proxy_list、mask_proxy_value、mask_proxy_string、current_proxy、current_proxy_display、current_proxy_status。",
+      "tags": [
+        "类",
+        "代理"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 类，约 145 行，包含 21 个方法。"
+    },
+    {
+      "id": "class:util/proxy/ProxyState.py:ProxyStateEntry",
+      "type": "class",
+      "name": "ProxyStateEntry",
+      "filePath": "util/proxy/ProxyState.py",
+      "lineRange": [
+        10,
+        25
+      ],
+      "summary": "`ProxyStateEntry` 位于代理管理，用于选择、检测或维护代理，包含方法 is_available、cooldown_remaining。",
+      "tags": [
+        "类",
+        "代理"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 16 行，包含 2 个方法。"
+    },
+    {
+      "id": "class:util/proxy/ProxyState.py:ProxyStateRegistry",
+      "type": "class",
+      "name": "ProxyStateRegistry",
+      "filePath": "util/proxy/ProxyState.py",
+      "lineRange": [
+        28,
+        133
+      ],
+      "summary": "`ProxyStateRegistry` 位于代理管理，用于选择、检测或维护代理，包含方法 __init__、set_current_index、current_state、current_display_name、_trim_failures、record_current_success、record_current_failure、available_count、cooldown_count、has_available_proxy。",
+      "tags": [
+        "类",
+        "代理"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 类，约 106 行，包含 15 个方法。"
+    },
+    {
+      "id": "function:util/proxy/ProxyTester.py:test_proxy_connectivity",
+      "type": "function",
+      "name": "test_proxy_connectivity",
+      "filePath": "util/proxy/ProxyTester.py",
+      "lineRange": [
+        208,
+        211
+      ],
+      "summary": "`test_proxy_connectivity(proxy_string, timeout)` 位于代理管理，负责选择、检测或维护代理；内部主要调用 ProxyTester、test_proxy_list、format_test_results。",
+      "tags": [
+        "函数",
+        "代理"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 4 行，直接调用约 3 次。"
+    },
+    {
+      "id": "class:util/proxy/ProxyTester.py:ProxyTester",
+      "type": "class",
+      "name": "ProxyTester",
+      "filePath": "util/proxy/ProxyTester.py",
+      "lineRange": [
+        10,
+        205
+      ],
+      "summary": "`ProxyTester` 位于代理管理，用于选择、检测或维护代理，包含方法 __init__、test_single_proxy、_get_ip_info、_validate_proxy_format、test_proxy_list、format_test_results。",
+      "tags": [
+        "类",
+        "代理"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 类，约 196 行，包含 6 个方法。"
+    },
+    {
+      "id": "class:util/request/BiliRequest.py:BiliRequest",
+      "type": "class",
+      "name": "BiliRequest",
+      "filePath": "util/request/BiliRequest.py",
+      "lineRange": [
+        22,
+        278
+      ],
+      "summary": "`BiliRequest` 位于请求与 Cookie 管理，用于封装接口请求，包含方法 __init__、_rotate_proxy、_invalidate_h2_client、get_user_agent、snapshot_proxy_state、restore_proxy_state、clear_request_count、set_100001_handler、handle_100001、get。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 类，约 257 行，包含 28 个方法。"
+    },
+    {
+      "id": "function:util/request/BrowerState.py:random_hex",
+      "type": "function",
+      "name": "random_hex",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        109,
+        114
+      ],
+      "summary": "`random_hex(length)`：生成 length 位 hex 字符串。。位于请求与 Cookie 管理，调用 token_hex。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 6 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:util/request/BrowerState.py:build_chrome_user_agent",
+      "type": "function",
+      "name": "build_chrome_user_agent",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        117,
+        149
+      ],
+      "summary": "`build_chrome_user_agent(os_name, chrome_major)`：构造一个常见桌面 Chrome UA。。位于请求与 Cookie 管理，调用 choice、randint。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 33 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:util/request/BrowerState.py:extract_app_version_from_ua",
+      "type": "function",
+      "name": "extract_app_version_from_ua",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        152,
+        159
+      ],
+      "summary": "`extract_app_version_from_ua(user_agent)`：navigator.appVersion 常见表现：UA 去掉开头的 Mozilla/。位于请求与 Cookie 管理，调用 startswith、len。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 8 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:util/request/BrowerState.py:generate_browser_window_state",
+      "type": "function",
+      "name": "generate_browser_window_state",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        167,
+        267
+      ],
+      "summary": "`generate_browser_window_state(screen_width, screen_height, maximized, scroll, os_name)`：生成一组自洽的浏览器窗口尺寸参数。。位于请求与 Cookie 管理，调用 max、choice。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 5 个，约 101 行，直接调用约 23 次。"
+    },
+    {
+      "id": "function:util/request/BrowerState.py:generate_browser_display_state",
+      "type": "function",
+      "name": "generate_browser_display_state",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        275,
+        300
+      ],
+      "summary": "`generate_browser_display_state(screen_width, screen_height, device_pixel_ratio)`：对应：。位于请求与 Cookie 管理，调用 choice。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 3 个，约 26 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:util/request/BrowerState.py:generate_browser_navigator_state",
+      "type": "function",
+      "name": "generate_browser_navigator_state",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        308,
+        366
+      ],
+      "summary": "`generate_browser_navigator_state(os_name, locale, user_agent)`：对应常见 navigator 字段。。位于请求与 Cookie 管理，调用 choice、build_chrome_user_agent、extract_app_version_from_ua、split。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 3 个，约 59 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:util/request/BrowerState.py:generate_browser_locale_state",
+      "type": "function",
+      "name": "generate_browser_locale_state",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        374,
+        418
+      ],
+      "summary": "`generate_browser_locale_state(locale, timezone)`：对应：。位于请求与 Cookie 管理，调用 get。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 2 个，约 45 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:util/request/BrowerState.py:generate_browser_location_state",
+      "type": "function",
+      "name": "generate_browser_location_state",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        426,
+        483
+      ],
+      "summary": "`generate_browser_location_state(href, history_length)`：对应：。位于请求与 Cookie 管理，调用 urlparse、str、choice、randint、len。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 2 个，约 58 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:util/request/BrowerState.py:generate_browser_webgl_state",
+      "type": "function",
+      "name": "generate_browser_webgl_state",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        491,
+        559
+      ],
+      "summary": "`generate_browser_webgl_state(os_name, gpu_profile)`：生成 WebGL 相关字段。。位于请求与 Cookie 管理，调用 choice。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 2 个，约 69 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:util/request/BrowerState.py:generate_browser_canvas_state",
+      "type": "function",
+      "name": "generate_browser_canvas_state",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        567,
+        590
+      ],
+      "summary": "`generate_browser_canvas_state(x64hash128, data_url_hash)`：Canvas 指纹字段。。位于请求与 Cookie 管理，调用 random_hex。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 24 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:util/request/BrowerState.py:generate_browser_storage_state",
+      "type": "function",
+      "name": "generate_browser_storage_state",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        598,
+        614
+      ],
+      "summary": "`generate_browser_storage_state(local_storage, session_storage, cookies)`：localStorage / sessionStorage / cookies。。位于请求与 Cookie 管理，调用 dict。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 3 个，约 17 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:util/request/BrowerState.py:generate_browser_fingerprint_state",
+      "type": "function",
+      "name": "generate_browser_fingerprint_state",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        622,
+        704
+      ],
+      "summary": "`generate_browser_fingerprint_state(os_name, locale, timezone, screen_width, screen_height, maximized, scroll, href, history_length, user_agent, device_pixel_ratio, gpu_profile, canvas_hash, local_storage, session_storage, cookies)`：生成完整浏览器指纹状态。。位于请求与 Cookie 管理，调用 generate_browser_window_state、generate_browser_display_state、generate_browser_navigator_state、generate_browser_locale_state、generate_browser_location_state、generate_browser_webgl_state、generate_browser_canvas_state、generate_browser_storage_state。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 16 个，约 83 行，直接调用约 8 次。"
+    },
+    {
+      "id": "function:util/request/BrowerState.py:finalize_device_id",
+      "type": "function",
+      "name": "finalize_device_id",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        707,
+        762
+      ],
+      "summary": "`finalize_device_id(raw_device_id)` 位于请求与 Cookie 管理，负责处理 finalize device id 相关逻辑；内部主要调用 calculate_position_or_value、format、isinstance、TypeError、len、ValueError。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 56 行，直接调用约 13 次。"
+    },
+    {
+      "id": "function:util/request/BrowerState.py:_cookie_dict_to_header",
+      "type": "function",
+      "name": "_cookie_dict_to_header",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        765,
+        768
+      ],
+      "summary": "`_cookie_dict_to_header(cookies)` 位于请求与 Cookie 管理，负责处理登录认证或 Cookie 状态；内部主要调用 join、items。",
+      "tags": [
+        "函数",
+        "请求",
+        "认证"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 4 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:util/request/BrowerState.py:_build_sec_ch_ua",
+      "type": "function",
+      "name": "_build_sec_ch_ua",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        771,
+        788
+      ],
+      "summary": "`_build_sec_ch_ua(user_agent)`：根据 UA 粗略生成 sec-ch-ua。。位于请求与 Cookie 管理，调用 split。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 18 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:util/request/BrowerState.py:_build_sec_ch_ua_platform",
+      "type": "function",
+      "name": "_build_sec_ch_ua_platform",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        791,
+        798
+      ],
+      "summary": "`_build_sec_ch_ua_platform(platform)` 位于请求与 Cookie 管理，负责处理 build sec ch ua platform 相关逻辑；内部主要调用 startswith。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 8 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:util/request/BrowerState.py:build_headers_from_browser_state",
+      "type": "function",
+      "name": "build_headers_from_browser_state",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        801,
+        879
+      ],
+      "summary": "`build_headers_from_browser_state(state, base_headers, referer, content_type)`：根据 BrowserFingerprintState 构造请求 headers。。位于请求与 Cookie 管理，调用 dict、get、_cookie_dict_to_header。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 4 个，约 79 行，直接调用约 18 次。"
+    },
+    {
+      "id": "class:util/request/BrowerState.py:BrowserWindowState",
+      "type": "class",
+      "name": "BrowserWindowState",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        14,
+        26
+      ],
+      "summary": "`BrowserWindowState` 位于请求与 Cookie 管理，继承 TypedDict，用于处理 Browser Window State 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 13 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/request/BrowerState.py:BrowserDisplayState",
+      "type": "class",
+      "name": "BrowserDisplayState",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        29,
+        32
+      ],
+      "summary": "`BrowserDisplayState` 位于请求与 Cookie 管理，继承 TypedDict，用于处理 Browser Display State 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 4 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/request/BrowerState.py:BrowserNavigatorState",
+      "type": "class",
+      "name": "BrowserNavigatorState",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        35,
+        51
+      ],
+      "summary": "`BrowserNavigatorState` 位于请求与 Cookie 管理，继承 TypedDict，用于处理 Browser Navigator State 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 17 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/request/BrowerState.py:BrowserLocaleState",
+      "type": "class",
+      "name": "BrowserLocaleState",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        54,
+        57
+      ],
+      "summary": "`BrowserLocaleState` 位于请求与 Cookie 管理，继承 TypedDict，用于处理 Browser Locale State 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 4 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/request/BrowerState.py:BrowserLocationState",
+      "type": "class",
+      "name": "BrowserLocationState",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        60,
+        71
+      ],
+      "summary": "`BrowserLocationState` 位于请求与 Cookie 管理，继承 TypedDict，用于处理 Browser Location State 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 12 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/request/BrowerState.py:BrowserWebGLState",
+      "type": "class",
+      "name": "BrowserWebGLState",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        74,
+        78
+      ],
+      "summary": "`BrowserWebGLState` 位于请求与 Cookie 管理，继承 TypedDict，用于处理 Browser Web GLState 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 5 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/request/BrowerState.py:BrowserCanvasState",
+      "type": "class",
+      "name": "BrowserCanvasState",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        81,
+        84
+      ],
+      "summary": "`BrowserCanvasState` 位于请求与 Cookie 管理，继承 TypedDict，用于处理 Browser Canvas State 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 4 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/request/BrowerState.py:BrowserStorageState",
+      "type": "class",
+      "name": "BrowserStorageState",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        87,
+        90
+      ],
+      "summary": "`BrowserStorageState` 位于请求与 Cookie 管理，继承 TypedDict，用于处理 Browser Storage State 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 4 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/request/BrowerState.py:BrowserFingerprintState",
+      "type": "class",
+      "name": "BrowserFingerprintState",
+      "filePath": "util/request/BrowerState.py",
+      "lineRange": [
+        93,
+        101
+      ],
+      "summary": "`BrowserFingerprintState` 位于请求与 Cookie 管理，继承 TypedDict，用于处理 Browser Fingerprint State 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 9 行，包含 0 个方法。"
+    },
+    {
+      "id": "function:util/request/CookieManager.py:parse_cookie_list",
+      "type": "function",
+      "name": "parse_cookie_list",
+      "filePath": "util/request/CookieManager.py",
+      "lineRange": [
+        22,
+        46
+      ],
+      "summary": "`parse_cookie_list(cookie_str)` 位于请求与 Cookie 管理，负责规范化输入值；内部主要调用 split、append、strip。",
+      "tags": [
+        "函数",
+        "请求",
+        "规范化"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 25 行，直接调用约 11 次。"
+    },
+    {
+      "id": "class:util/request/CookieManager.py:Account",
+      "type": "class",
+      "name": "Account",
+      "filePath": "util/request/CookieManager.py",
+      "lineRange": [
+        10,
+        19
+      ],
+      "summary": "`Account`：B站账号信息。位于请求与 Cookie 管理，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 10 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/request/CookieManager.py:CookieManager",
+      "type": "class",
+      "name": "CookieManager",
+      "filePath": "util/request/CookieManager.py",
+      "lineRange": [
+        49,
+        202
+      ],
+      "summary": "`CookieManager`：管理 cookies.json，包含多账号和配置。位于请求与 Cookie 管理，包含方法 __init__、get_cookies、have_cookies、get_cookies_str、get_cookies_value、get_config_value、set_config_value、get_accounts、add_account、remove_account。",
+      "tags": [
+        "类",
+        "请求",
+        "认证"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 类，约 154 行，包含 13 个方法。"
+    },
+    {
+      "id": "class:util/request/exceptions/connection.py:BiliConnectionError",
+      "type": "class",
+      "name": "BiliConnectionError",
+      "filePath": "util/request/exceptions/connection.py",
+      "lineRange": [
+        1,
+        4
+      ],
+      "summary": "`BiliConnectionError` 位于请求与 Cookie 管理，继承 RuntimeError，用于处理 Bili Connection Error 相关逻辑，包含方法 __init__。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 4 行，包含 1 个方法。"
+    },
+    {
+      "id": "class:util/request/exceptions/rate_limit.py:BiliRateLimitError",
+      "type": "class",
+      "name": "BiliRateLimitError",
+      "filePath": "util/request/exceptions/rate_limit.py",
+      "lineRange": [
+        1,
+        4
+      ],
+      "summary": "`BiliRateLimitError` 位于请求与 Cookie 管理，继承 RuntimeError，用于处理 Bili Rate Limit Error 相关逻辑，包含方法 __init__。",
+      "tags": [
+        "类",
+        "请求"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 4 行，包含 1 个方法。"
+    },
+    {
+      "id": "function:cptoken/__init__.py:generate_ctoken",
+      "type": "function",
+      "name": "generate_ctoken",
+      "filePath": "cptoken/__init__.py",
+      "lineRange": [
+        14,
+        78
+      ],
+      "summary": "`generate_ctoken()` 位于项目通用模块，负责处理 generate ctoken 相关逻辑；内部主要调用 generate_prepare_ctoken。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 2 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:cptoken/__init__.py:generate_browser_window_state",
+      "type": "function",
+      "name": "generate_browser_window_state",
+      "filePath": "cptoken/__init__.py",
+      "lineRange": [
+        151,
+        227
+      ],
+      "summary": "`generate_browser_window_state(screen_width, screen_height, maximized, scroll)` 位于项目通用模块，负责处理 generate browser window state 相关逻辑；内部主要调用 choice、max、randint。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 4 个，约 77 行，直接调用约 21 次。"
+    },
+    {
+      "id": "function:cptoken/__init__.py:init_ctoken_state",
+      "type": "function",
+      "name": "init_ctoken_state",
+      "filePath": "cptoken/__init__.py",
+      "lineRange": [
+        281,
+        331
+      ],
+      "summary": "`init_ctoken_state(browser_window_state, history_length, user_agent_length, href_length, device_pixel_ratio, ticket_collection_t)` 位于项目通用模块，负责处理 init ctoken state 相关逻辑；内部主要调用 randint、CTokenRuntimeState、info、generate_browser_window_state、to_dict、int、round、derive_d。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 6 个，约 51 行，直接调用约 21 次。"
+    },
+    {
+      "id": "function:cptoken/__init__.py:sim_ctoken_state",
+      "type": "function",
+      "name": "sim_ctoken_state",
+      "filePath": "cptoken/__init__.py",
+      "lineRange": [
+        334,
+        366
+      ],
+      "summary": "`sim_ctoken_state(before_state, now_ms)` 位于项目通用模块，负责处理 sim ctoken state 相关逻辑；内部主要调用 snapshot、choice、CTokenSnapshot、int、choices、max、time。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 2 个，约 33 行，直接调用约 9 次。"
+    },
+    {
+      "id": "class:cptoken/__init__.py:CTokenSnapshot",
+      "type": "class",
+      "name": "CTokenSnapshot",
+      "filePath": "cptoken/__init__.py",
+      "lineRange": [
+        82,
+        133
+      ],
+      "summary": "`CTokenSnapshot` 位于项目通用模块，用于处理 CToken Snapshot 相关逻辑，包含方法 to_dict、kwargs、generate_ctoken、generate_prepare_ctoken、generate_create_ctoken。",
+      "tags": [
+        "类"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 类，约 52 行，包含 5 个方法。"
+    },
+    {
+      "id": "class:cptoken/__init__.py:BrowserWindowState",
+      "type": "class",
+      "name": "BrowserWindowState",
+      "filePath": "cptoken/__init__.py",
+      "lineRange": [
+        136,
+        148
+      ],
+      "summary": "`BrowserWindowState` 位于项目通用模块，继承 TypedDict，用于处理 Browser Window State 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 13 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:cptoken/__init__.py:CTokenRuntimeState",
+      "type": "class",
+      "name": "CTokenRuntimeState",
+      "filePath": "cptoken/__init__.py",
+      "lineRange": [
+        231,
+        278
+      ],
+      "summary": "`CTokenRuntimeState` 位于项目通用模块，用于启动或执行任务，包含方法 snapshot、kwargs。",
+      "tags": [
+        "类",
+        "执行"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 类，约 48 行，包含 2 个方法。"
+    },
+    {
+      "id": "function:task/buy.py:_extract_prepare_token",
+      "type": "function",
+      "name": "_extract_prepare_token",
+      "filePath": "task/buy.py",
+      "lineRange": [
+        191,
+        201
+      ],
+      "summary": "`_extract_prepare_token(result)` 位于核心购票任务，负责处理 extract prepare token 相关逻辑；内部主要调用 get、strip、isinstance、str。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 11 行，直接调用约 6 次。"
+    },
+    {
+      "id": "function:task/buy.py:_format_reprepare_reason",
+      "type": "function",
+      "name": "_format_reprepare_reason",
+      "filePath": "task/buy.py",
+      "lineRange": [
+        204,
+        205
+      ],
+      "summary": "`_format_reprepare_reason(reason)` 位于核心购票任务，负责格式化展示内容；内部主要调用 无明显外部调用。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 2 行，直接调用约 0 次。"
+    },
+    {
+      "id": "function:task/buy.py:buy_stream",
+      "type": "function",
+      "name": "buy_stream",
+      "filePath": "task/buy.py",
+      "lineRange": [
+        208,
+        902
+      ],
+      "summary": "`buy_stream(config)` 位于核心购票任务，负责推进购票、订单或支付流程；内部主要调用 BuyStreamState、loads、pop、deepcopy、dumps、mask_proxy_string、info。",
+      "tags": [
+        "函数",
+        "购票",
+        "支付"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 1 个，约 695 行，直接调用约 236 次。"
+    },
+    {
+      "id": "function:task/buy.py:buy_new_terminal",
+      "type": "function",
+      "name": "buy_new_terminal",
+      "filePath": "task/buy.py",
+      "lineRange": [
+        905,
+        915
+      ],
+      "summary": "`buy_new_terminal(log_file_path, log_level, log_retention_days)` 位于核心购票任务，负责推进购票、订单或支付流程；内部主要调用 start_new_terminal。",
+      "tags": [
+        "函数",
+        "购票",
+        "支付"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 3 个，约 12 行，直接调用约 1 次。"
+    },
+    {
+      "id": "class:task/buy.py:Buy",
+      "type": "class",
+      "name": "Buy",
+      "filePath": "task/buy.py",
+      "lineRange": [
+        63,
+        188
+      ],
+      "summary": "`Buy` 位于核心购票任务，用于推进购票、订单或支付流程，包含方法 _resolved_tickets_info、resolved_config、stream、start_worker、to_cli_args、run、buy、start_new_terminal、buy_new_terminal。",
+      "tags": [
+        "类",
+        "购票",
+        "支付"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 类，约 126 行，包含 9 个方法。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:get_qrcode_url",
+      "type": "function",
+      "name": "get_qrcode_url",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        27,
+        32
+      ],
+      "summary": "`get_qrcode_url(_request, order_id)` 位于核心购票任务，负责封装接口请求；内部主要调用 json、ValueError、get。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 6 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:get_order_detail_url",
+      "type": "function",
+      "name": "get_order_detail_url",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        35,
+        36
+      ],
+      "summary": "`get_order_detail_url(order_id)` 位于核心购票任务，负责封装接口请求；内部主要调用 无明显外部调用。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 2 行，直接调用约 0 次。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:build_payment_result",
+      "type": "function",
+      "name": "build_payment_result",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        39,
+        50
+      ],
+      "summary": "`build_payment_result(_request, order_id)` 位于核心购票任务，负责推进购票、订单或支付流程；内部主要调用 get_order_detail_url、get_qrcode_url。",
+      "tags": [
+        "函数",
+        "购票",
+        "支付"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 12 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:format_countdown",
+      "type": "function",
+      "name": "format_countdown",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        53,
+        60
+      ],
+      "summary": "`format_countdown(seconds)` 位于核心购票任务，负责格式化展示内容；内部主要调用 max、divmod、int。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 8 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:next_countdown_report_at",
+      "type": "function",
+      "name": "next_countdown_report_at",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        63,
+        72
+      ],
+      "summary": "`next_countdown_report_at(countdown_seconds)` 位于核心购票任务，负责处理 next countdown report at 相关逻辑；内部主要调用 无明显外部调用。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 10 行，直接调用约 0 次。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:wait_until_start",
+      "type": "function",
+      "name": "wait_until_start",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        75,
+        164
+      ],
+      "summary": "`wait_until_start(time_start, warmup)` 位于核心购票任务，负责启动或执行任务；内部主要调用 get_timeoffset、compute_bili_time_check、hasattr、float、ValueError、timestamp、countdown_now。",
+      "tags": [
+        "函数",
+        "购票",
+        "执行"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 2 个，约 90 行，直接调用约 24 次。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:build_token_payload",
+      "type": "function",
+      "name": "build_token_payload",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        167,
+        188
+      ],
+      "summary": "`build_token_payload(tickets_info)` 位于核心购票任务，负责读取并解析数据；内部主要调用 int、get。",
+      "tags": [
+        "函数",
+        "购票",
+        "读取"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 22 行，直接调用约 8 次。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:build_order_token",
+      "type": "function",
+      "name": "build_order_token",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        191,
+        198
+      ],
+      "summary": "`build_order_token(tickets_info)` 位于核心购票任务，负责推进购票、订单或支付流程；内部主要调用 generate_token、int、get。",
+      "tags": [
+        "函数",
+        "购票",
+        "支付"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 8 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:normalize_prepare_ptoken",
+      "type": "function",
+      "name": "normalize_prepare_ptoken",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        201,
+        204
+      ],
+      "summary": "`normalize_prepare_ptoken(value)` 位于核心购票任务，负责规范化输入值；内部主要调用 replace、str。",
+      "tags": [
+        "函数",
+        "购票",
+        "规范化"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 4 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:create_order_terminal_rule",
+      "type": "function",
+      "name": "create_order_terminal_rule",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        224,
+        225
+      ],
+      "summary": "`create_order_terminal_rule(err)` 位于核心购票任务，负责推进购票、订单或支付流程；内部主要调用 get。",
+      "tags": [
+        "函数",
+        "购票",
+        "支付"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 2 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:is_create_success",
+      "type": "function",
+      "name": "is_create_success",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        228,
+        230
+      ],
+      "summary": "`is_create_success(ret, err)` 位于核心购票任务，负责处理 is create success 相关逻辑；内部主要调用 str、get。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 3 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:extract_order_id",
+      "type": "function",
+      "name": "extract_order_id",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        233,
+        240
+      ],
+      "summary": "`extract_order_id(ret)` 位于核心购票任务，负责推进购票、订单或支付流程；内部主要调用 get、isinstance。",
+      "tags": [
+        "函数",
+        "购票",
+        "支付"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 8 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:extract_response_message",
+      "type": "function",
+      "name": "extract_response_message",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        243,
+        244
+      ],
+      "summary": "`extract_response_message(ret)` 位于核心购票任务，负责处理 extract response message 相关逻辑；内部主要调用 strip、str、get。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 2 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:append_response_message",
+      "type": "function",
+      "name": "append_response_message",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        247,
+        248
+      ],
+      "summary": "`append_response_message(err, base, ret)` 位于核心购票任务，负责处理 append response message 相关逻辑；内部主要调用 append_response_message。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 3 个，约 2 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:format_retry_reason",
+      "type": "function",
+      "name": "format_retry_reason",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        251,
+        259
+      ],
+      "summary": "`format_retry_reason(outcome)` 位于核心购票任务，负责格式化展示内容；内部主要调用 get_message_or_unknown、append_response_message。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 9 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:summarize_non_json_response",
+      "type": "function",
+      "name": "summarize_non_json_response",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        262,
+        271
+      ],
+      "summary": "`summarize_non_json_response(prefix, diagnostic)` 位于核心购票任务，负责处理 summarize non json response 相关逻辑；内部主要调用 split、startswith。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 10 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:build_proxy_exhausted_message",
+      "type": "function",
+      "name": "build_proxy_exhausted_message",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        274,
+        279
+      ],
+      "summary": "`build_proxy_exhausted_message(_request, delay_seconds)` 位于核心购票任务，负责选择、检测或维护代理；内部主要调用 proxy_pool_status。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 6 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:notify_proxy_exhausted",
+      "type": "function",
+      "name": "notify_proxy_exhausted",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        282,
+        296
+      ],
+      "summary": "`notify_proxy_exhausted(notifier_config, _request, delay_seconds)` 位于核心购票任务，负责选择、检测或维护代理；内部主要调用 create_from_config、start_all、build_proxy_exhausted_message。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 3 个，约 15 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:handle_proxy_failure",
+      "type": "function",
+      "name": "handle_proxy_failure",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        299,
+        343
+      ],
+      "summary": "`handle_proxy_failure(_request, reason, proxy_backoff, notifier_config, replenish_proxy_pool)` 位于核心购票任务，负责选择、检测或维护代理；内部主要调用 current_proxy_display、mark_current_proxy_failure、switch_proxy、has_available_proxy、next_delay_seconds、should_notify、reset、replenish_proxy_pool。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 5 个，约 45 行，直接调用约 11 次。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:format_status_result",
+      "type": "function",
+      "name": "format_status_result",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        346,
+        354
+      ],
+      "summary": "`format_status_result(prefix, ret)` 位于核心购票任务，负责格式化展示内容；内部主要调用 int、get_message、extract_response_message、get、append_response_message。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 9 行，直接调用约 6 次。"
+    },
+    {
+      "id": "function:task/buy_helpers.py:prepare_create_request",
+      "type": "function",
+      "name": "prepare_create_request",
+      "filePath": "task/buy_helpers.py",
+      "lineRange": [
+        357,
+        391
+      ],
+      "summary": "`prepare_create_request(tickets_info, order_token, is_hot_project, request_result, ticket_state)` 位于核心购票任务，负责封装接口请求；内部主要调用 dict、current_time_ms、pop、sim_ctoken_state、generate_create_ctoken。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 5 个，约 35 行，直接调用约 11 次。"
+    },
+    {
+      "id": "class:task/buy_types.py:BuyStreamState",
+      "type": "class",
+      "name": "BuyStreamState",
+      "filePath": "task/buy_types.py",
+      "lineRange": [
+        12,
+        26
+      ],
+      "summary": "`BuyStreamState` 位于核心购票任务，用于推进购票、订单或支付流程，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "购票",
+        "支付"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 15 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:task/buy_types.py:BuyStreamEvent",
+      "type": "class",
+      "name": "BuyStreamEvent",
+      "filePath": "task/buy_types.py",
+      "lineRange": [
+        30,
+        34
+      ],
+      "summary": "`BuyStreamEvent` 位于核心购票任务，用于推进购票、订单或支付流程，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "购票",
+        "支付"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 5 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:task/buy_types.py:BuyStreamUpdate",
+      "type": "class",
+      "name": "BuyStreamUpdate",
+      "filePath": "task/buy_types.py",
+      "lineRange": [
+        38,
+        109
+      ],
+      "summary": "`BuyStreamUpdate` 位于核心购票任务，用于推进购票、订单或支付流程，包含方法 apply_to、to_dict。",
+      "tags": [
+        "类",
+        "购票",
+        "支付"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 类，约 72 行，包含 2 个方法。"
+    },
+    {
+      "id": "class:task/buy_types.py:RetryOutcome",
+      "type": "class",
+      "name": "RetryOutcome",
+      "filePath": "task/buy_types.py",
+      "lineRange": [
+        113,
+        124
+      ],
+      "summary": "`RetryOutcome` 位于核心购票任务，用于处理 Retry Outcome 相关逻辑，包含方法 set_response、set_exception。",
+      "tags": [
+        "类",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 12 行，包含 2 个方法。"
+    },
+    {
+      "id": "class:task/buy_types.py:CreateOrderTerminalRule",
+      "type": "class",
+      "name": "CreateOrderTerminalRule",
+      "filePath": "task/buy_types.py",
+      "lineRange": [
+        128,
+        131
+      ],
+      "summary": "`CreateOrderTerminalRule` 位于核心购票任务，用于推进购票、订单或支付流程，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "购票",
+        "支付"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 4 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:task/buy_types.py:LatestValueWorker",
+      "type": "class",
+      "name": "LatestValueWorker",
+      "filePath": "task/buy_types.py",
+      "lineRange": [
+        137,
+        200
+      ],
+      "summary": "`LatestValueWorker` 位于核心购票任务，用于验证对应业务行为，包含方法 __init__、start、_publish、_run、is_alive、done、latest_value、get_value、raise_if_failed、join。",
+      "tags": [
+        "类",
+        "购票"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 类，约 64 行，包含 10 个方法。"
+    },
+    {
+      "id": "class:task/buy_types.py:BuyStreamWorker",
+      "type": "class",
+      "name": "BuyStreamWorker",
+      "filePath": "task/buy_types.py",
+      "lineRange": [
+        203,
+        233
+      ],
+      "summary": "`BuyStreamWorker` 位于核心购票任务，用于推进购票、订单或支付流程，包含方法 __init__、latest_event、get_event、iter_events、start_buy_stream_worker。",
+      "tags": [
+        "类",
+        "购票",
+        "支付"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 31 行，包含 5 个方法。"
+    },
+    {
+      "id": "function:tests/test_buy_prepare_token.py:test_extract_prepare_token_returns_none_when_missing",
+      "type": "function",
+      "name": "test_extract_prepare_token_returns_none_when_missing",
+      "filePath": "tests/test_buy_prepare_token.py",
+      "lineRange": [
+        4,
+        10
+      ],
+      "summary": "`test_extract_prepare_token_returns_none_when_missing()` 位于自动化测试，负责验证对应业务行为；内部主要调用 _extract_prepare_token。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 7 行，直接调用约 6 次。"
+    },
+    {
+      "id": "function:tests/test_buy_prepare_token.py:test_extract_prepare_token_returns_string_when_present",
+      "type": "function",
+      "name": "test_extract_prepare_token_returns_string_when_present",
+      "filePath": "tests/test_buy_prepare_token.py",
+      "lineRange": [
+        13,
+        15
+      ],
+      "summary": "`test_extract_prepare_token_returns_string_when_present()` 位于自动化测试，负责验证对应业务行为；内部主要调用 _extract_prepare_token。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 3 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:tests/test_buy_reprepare_reason.py:test_format_reprepare_reason_includes_cause",
+      "type": "function",
+      "name": "test_format_reprepare_reason_includes_cause",
+      "filePath": "tests/test_buy_reprepare_reason.py",
+      "lineRange": [
+        4,
+        5
+      ],
+      "summary": "`test_format_reprepare_reason_includes_cause()` 位于自动化测试，负责格式化展示内容；内部主要调用 _format_reprepare_reason。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 2 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tests/test_proxy_api_provider.py:_proxy_url",
+      "type": "function",
+      "name": "_proxy_url",
+      "filePath": "tests/test_proxy_api_provider.py",
+      "lineRange": [
+        10,
+        11
+      ],
+      "summary": "`_proxy_url(scheme, username, password, host, port)` 位于自动化测试，负责选择、检测或维护代理；内部主要调用 无明显外部调用。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 5 个，约 2 行，直接调用约 0 次。"
+    },
+    {
+      "id": "function:tests/test_proxy_api_provider.py:test_build_proxy_api_url_overrides_required_params",
+      "type": "function",
+      "name": "test_build_proxy_api_url_overrides_required_params",
+      "filePath": "tests/test_proxy_api_provider.py",
+      "lineRange": [
+        14,
+        23
+      ],
+      "summary": "`test_build_proxy_api_url_overrides_required_params()` 位于自动化测试，负责封装接口请求；内部主要调用 build_proxy_api_url。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 10 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tests/test_proxy_api_provider.py:test_parse_youdaili_success_response_as_http_proxy",
+      "type": "function",
+      "name": "test_parse_youdaili_success_response_as_http_proxy",
+      "filePath": "tests/test_proxy_api_provider.py",
+      "lineRange": [
+        26,
+        43
+      ],
+      "summary": "`test_parse_youdaili_success_response_as_http_proxy()` 位于自动化测试，负责规范化输入值；内部主要调用 parse_proxy_api_response。",
+      "tags": [
+        "函数",
+        "测试",
+        "规范化"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 18 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tests/test_proxy_api_provider.py:test_parse_youdaili_success_response_as_socks_proxy",
+      "type": "function",
+      "name": "test_parse_youdaili_success_response_as_socks_proxy",
+      "filePath": "tests/test_proxy_api_provider.py",
+      "lineRange": [
+        46,
+        62
+      ],
+      "summary": "`test_parse_youdaili_success_response_as_socks_proxy()` 位于自动化测试，负责规范化输入值；内部主要调用 parse_proxy_api_response。",
+      "tags": [
+        "函数",
+        "测试",
+        "规范化"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 17 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tests/test_proxy_api_provider.py:test_parse_proxy_api_keeps_auth_from_standard_url",
+      "type": "function",
+      "name": "test_parse_proxy_api_keeps_auth_from_standard_url",
+      "filePath": "tests/test_proxy_api_provider.py",
+      "lineRange": [
+        65,
+        72
+      ],
+      "summary": "`test_parse_proxy_api_keeps_auth_from_standard_url()` 位于自动化测试，负责规范化输入值；内部主要调用 _proxy_url、parse_proxy_api_response。",
+      "tags": [
+        "函数",
+        "测试",
+        "规范化"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 8 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:tests/test_proxy_api_provider.py:test_parse_proxy_api_keeps_auth_from_host_port_user_pass",
+      "type": "function",
+      "name": "test_parse_proxy_api_keeps_auth_from_host_port_user_pass",
+      "filePath": "tests/test_proxy_api_provider.py",
+      "lineRange": [
+        75,
+        85
+      ],
+      "summary": "`test_parse_proxy_api_keeps_auth_from_host_port_user_pass()` 位于自动化测试，负责规范化输入值；内部主要调用 parse_proxy_api_response、_proxy_url。",
+      "tags": [
+        "函数",
+        "测试",
+        "规范化"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 11 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:tests/test_proxy_api_provider.py:test_parse_proxy_api_keeps_auth_from_object_fields",
+      "type": "function",
+      "name": "test_parse_proxy_api_keeps_auth_from_object_fields",
+      "filePath": "tests/test_proxy_api_provider.py",
+      "lineRange": [
+        88,
+        104
+      ],
+      "summary": "`test_parse_proxy_api_keeps_auth_from_object_fields()` 位于自动化测试，负责规范化输入值；内部主要调用 parse_proxy_api_response、_proxy_url。",
+      "tags": [
+        "函数",
+        "测试",
+        "规范化"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 17 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:tests/test_proxy_api_provider.py:test_parse_proxy_api_merges_auth_fields_with_proxy_field",
+      "type": "function",
+      "name": "test_parse_proxy_api_merges_auth_fields_with_proxy_field",
+      "filePath": "tests/test_proxy_api_provider.py",
+      "lineRange": [
+        107,
+        122
+      ],
+      "summary": "`test_parse_proxy_api_merges_auth_fields_with_proxy_field()` 位于自动化测试，负责规范化输入值；内部主要调用 parse_proxy_api_response、_proxy_url。",
+      "tags": [
+        "函数",
+        "测试",
+        "规范化"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 16 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:tests/test_proxy_api_provider.py:test_parse_proxy_api_keeps_auth_for_socks5_url",
+      "type": "function",
+      "name": "test_parse_proxy_api_keeps_auth_for_socks5_url",
+      "filePath": "tests/test_proxy_api_provider.py",
+      "lineRange": [
+        125,
+        132
+      ],
+      "summary": "`test_parse_proxy_api_keeps_auth_for_socks5_url()` 位于自动化测试，负责规范化输入值；内部主要调用 _proxy_url、parse_proxy_api_response。",
+      "tags": [
+        "函数",
+        "测试",
+        "规范化"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 8 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:tests/test_proxy_api_provider.py:test_parse_youdaili_failure_response_raises",
+      "type": "function",
+      "name": "test_parse_youdaili_failure_response_raises",
+      "filePath": "tests/test_proxy_api_provider.py",
+      "lineRange": [
+        135,
+        143
+      ],
+      "summary": "`test_parse_youdaili_failure_response_raises()` 位于自动化测试，负责规范化输入值；内部主要调用 raises、parse_proxy_api_response。",
+      "tags": [
+        "函数",
+        "测试",
+        "规范化"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 9 行，直接调用约 2 次。"
+    },
+    {
+      "id": "class:util/ErrorCodes.py:ErrorCodes",
+      "type": "class",
+      "name": "ErrorCodes",
+      "filePath": "util/ErrorCodes.py",
+      "lineRange": [
+        1,
+        55
+      ],
+      "summary": "`ErrorCodes` 位于项目通用模块，用于处理 Error Codes 相关逻辑，包含方法 get_message、get_message_or_unknown、should_show_response_msg、append_response_message、format_attempt_result。",
+      "tags": [
+        "类"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 类，约 55 行，包含 5 个方法。"
+    },
+    {
+      "id": "function:util/proxy/ProxyApiProvider.py:normalize_proxy_api_protocol",
+      "type": "function",
+      "name": "normalize_proxy_api_protocol",
+      "filePath": "util/proxy/ProxyApiProvider.py",
+      "lineRange": [
+        21,
+        25
+      ],
+      "summary": "`normalize_proxy_api_protocol(protocol)` 位于代理管理，负责规范化输入值；内部主要调用 lower、strip、str。",
+      "tags": [
+        "函数",
+        "代理",
+        "规范化"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 5 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:util/proxy/ProxyApiProvider.py:build_proxy_api_url",
+      "type": "function",
+      "name": "build_proxy_api_url",
+      "filePath": "util/proxy/ProxyApiProvider.py",
+      "lineRange": [
+        28,
+        46
+      ],
+      "summary": "`build_proxy_api_url(api_url, count, protocol)` 位于代理管理，负责封装接口请求；内部主要调用 strip、urlsplit、dict、str、normalize_proxy_api_protocol、urlunsplit、ProxyApiError、parse_qsl。",
+      "tags": [
+        "函数",
+        "代理"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 3 个，约 19 行，直接调用约 12 次。"
+    },
+    {
+      "id": "function:util/proxy/ProxyApiProvider.py:_iter_proxy_items",
+      "type": "function",
+      "name": "_iter_proxy_items",
+      "filePath": "util/proxy/ProxyApiProvider.py",
+      "lineRange": [
+        49,
+        68
+      ],
+      "summary": "`_iter_proxy_items(payload)` 位于代理管理，负责选择、检测或维护代理；内部主要调用 isinstance、get、any。",
+      "tags": [
+        "函数",
+        "代理"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 20 行，直接调用约 10 次。"
+    },
+    {
+      "id": "function:util/proxy/ProxyApiProvider.py:_normalize_proxy_scheme",
+      "type": "function",
+      "name": "_normalize_proxy_scheme",
+      "filePath": "util/proxy/ProxyApiProvider.py",
+      "lineRange": [
+        71,
+        79
+      ],
+      "summary": "`_normalize_proxy_scheme(scheme, fallback_protocol)` 位于代理管理，负责规范化输入值；内部主要调用 lower、normalize_proxy_api_protocol、strip、str。",
+      "tags": [
+        "函数",
+        "代理",
+        "规范化"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 9 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:util/proxy/ProxyApiProvider.py:_format_proxy_url",
+      "type": "function",
+      "name": "_format_proxy_url",
+      "filePath": "util/proxy/ProxyApiProvider.py",
+      "lineRange": [
+        82,
+        101
+      ],
+      "summary": "`_format_proxy_url(scheme, host, port, username, password)` 位于代理管理，负责选择、检测或维护代理；内部主要调用 strip、str、quote。",
+      "tags": [
+        "函数",
+        "代理"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 5 个，约 20 行，直接调用约 11 次。"
+    },
+    {
+      "id": "function:util/proxy/ProxyApiProvider.py:_get_any_key",
+      "type": "function",
+      "name": "_get_any_key",
+      "filePath": "util/proxy/ProxyApiProvider.py",
+      "lineRange": [
+        104,
+        113
+      ],
+      "summary": "`_get_any_key(item, *keys)` 位于代理管理，负责封装接口请求；内部主要调用 lower、get、items、str。",
+      "tags": [
+        "函数",
+        "代理"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 10 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:util/proxy/ProxyApiProvider.py:_extract_proxy_parts",
+      "type": "function",
+      "name": "_extract_proxy_parts",
+      "filePath": "util/proxy/ProxyApiProvider.py",
+      "lineRange": [
+        116,
+        211
+      ],
+      "summary": "`_extract_proxy_parts(item, protocol)` 位于代理管理，负责选择、检测或维护代理；内部主要调用 isinstance、strip、urlsplit、normalize_proxy_api_protocol、match、split、rsplit、_get_any_key。",
+      "tags": [
+        "函数",
+        "代理"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 2 个，约 96 行，直接调用约 53 次。"
+    },
+    {
+      "id": "function:util/proxy/ProxyApiProvider.py:parse_proxy_api_response",
+      "type": "function",
+      "name": "parse_proxy_api_response",
+      "filePath": "util/proxy/ProxyApiProvider.py",
+      "lineRange": [
+        214,
+        245
+      ],
+      "summary": "`parse_proxy_api_response(payload, protocol)` 位于代理管理，负责规范化输入值；内部主要调用 get、set、_iter_proxy_items、ProxyApiError、_extract_proxy_parts、_format_proxy_url。",
+      "tags": [
+        "函数",
+        "代理",
+        "规范化"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 2 个，约 32 行，直接调用约 16 次。"
+    },
+    {
+      "id": "function:util/proxy/ProxyApiProvider.py:fetch_proxy_api",
+      "type": "function",
+      "name": "fetch_proxy_api",
+      "filePath": "util/proxy/ProxyApiProvider.py",
+      "lineRange": [
+        248,
+        266
+      ],
+      "summary": "`fetch_proxy_api(api_url, count, protocol, timeout)` 位于代理管理，负责封装接口请求；内部主要调用 build_proxy_api_url、request、raise_for_status、json、ProxyApiResult、isinstance、ProxyApiError、parse_proxy_api_response。",
+      "tags": [
+        "函数",
+        "代理"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 4 个，约 19 行，直接调用约 8 次。"
+    },
+    {
+      "id": "class:util/proxy/ProxyApiProvider.py:ProxyApiError",
+      "type": "class",
+      "name": "ProxyApiError",
+      "filePath": "util/proxy/ProxyApiProvider.py",
+      "lineRange": [
+        11,
+        12
+      ],
+      "summary": "`ProxyApiError` 位于代理管理，继承 RuntimeError，用于封装接口请求，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "代理"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 2 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/proxy/ProxyApiProvider.py:ProxyApiResult",
+      "type": "class",
+      "name": "ProxyApiResult",
+      "filePath": "util/proxy/ProxyApiProvider.py",
+      "lineRange": [
+        16,
+        18
+      ],
+      "summary": "`ProxyApiResult` 位于代理管理，用于封装接口请求，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "代理"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 3 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/proxy/ProxyBackoff.py:ProxyBackoff",
+      "type": "class",
+      "name": "ProxyBackoff",
+      "filePath": "util/proxy/ProxyBackoff.py",
+      "lineRange": [
+        4,
+        31
+      ],
+      "summary": "`ProxyBackoff` 位于代理管理，用于选择、检测或维护代理，包含方法 __init__、next_delay_seconds、reset、should_notify。",
+      "tags": [
+        "类",
+        "代理"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 28 行，包含 4 个方法。"
+    },
+    {
+      "id": "function:util/request/TokenUtil.py:generate_token",
+      "type": "function",
+      "name": "generate_token",
+      "filePath": "util/request/TokenUtil.py",
+      "lineRange": [
+        13,
+        47
+      ],
+      "summary": "`generate_token(project_id, screen_id, order_type, count, sku_id, ts)`：生成 Token。。位于请求与 Cookie 管理，调用 bytes、to_bytes、decode。",
+      "tags": [
+        "函数",
+        "请求"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 6 个，约 35 行，直接调用约 19 次。"
+    },
+    {
+      "id": "function:tab/go.py:withTimeString",
+      "type": "function",
+      "name": "withTimeString",
+      "filePath": "tab/go.py",
+      "lineRange": [
+        38,
+        41
+      ],
+      "summary": "`withTimeString(string)` 位于Gradio 界面标签页，负责处理 with Time String 相关逻辑；内部主要调用 strftime、now。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 4 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:tab/go.py:_build_task_log_path",
+      "type": "function",
+      "name": "_build_task_log_path",
+      "filePath": "tab/go.py",
+      "lineRange": [
+        44,
+        50
+      ],
+      "summary": "`_build_task_log_path(filename)` 位于Gradio 界面标签页，负责处理 build task log path 相关逻辑；内部主要调用 join、splitext、strip、basename、isalnum、uuid4。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 7 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:tab/go.py:_build_task_proxy_list",
+      "type": "function",
+      "name": "_build_task_proxy_list",
+      "filePath": "tab/go.py",
+      "lineRange": [
+        53,
+        60
+      ],
+      "summary": "`_build_task_proxy_list(proxy_string, include_direct)` 位于Gradio 界面标签页，负责选择、检测或维护代理；内部主要调用 parse_proxy_list、lower。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 8 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:tab/go.py:_parse_sale_start",
+      "type": "function",
+      "name": "_parse_sale_start",
+      "filePath": "tab/go.py",
+      "lineRange": [
+        63,
+        72
+      ],
+      "summary": "`_parse_sale_start(value)` 位于Gradio 界面标签页，负责规范化输入值；内部主要调用 isinstance、fromtimestamp、strip、replace、strptime。",
+      "tags": [
+        "函数",
+        "界面",
+        "规范化"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 10 行，直接调用约 6 次。"
+    },
+    {
+      "id": "function:tab/go.py:_preview_value",
+      "type": "function",
+      "name": "_preview_value",
+      "filePath": "tab/go.py",
+      "lineRange": [
+        75,
+        80
+      ],
+      "summary": "`_preview_value(value)` 位于Gradio 界面标签页，负责处理 preview value 相关逻辑；内部主要调用 isinstance、str、join。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 6 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:tab/go.py:_format_price_cents",
+      "type": "function",
+      "name": "_format_price_cents",
+      "filePath": "tab/go.py",
+      "lineRange": [
+        83,
+        88
+      ],
+      "summary": "`_format_price_cents(value)` 位于Gradio 界面标签页，负责格式化展示内容；内部主要调用 int、_preview_value。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 6 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:tab/go.py:_format_buyer_identity",
+      "type": "function",
+      "name": "_format_buyer_identity",
+      "filePath": "tab/go.py",
+      "lineRange": [
+        91,
+        109
+      ],
+      "summary": "`_format_buyer_identity(buyer_info)` 位于Gradio 界面标签页，负责推进购票、订单或支付流程；内部主要调用 _preview_value、get、append、join、isinstance。",
+      "tags": [
+        "函数",
+        "界面",
+        "支付"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 19 行，直接调用约 8 次。"
+    },
+    {
+      "id": "function:tab/go.py:_render_ticket_preview",
+      "type": "function",
+      "name": "_render_ticket_preview",
+      "filePath": "tab/go.py",
+      "lineRange": [
+        112,
+        136
+      ],
+      "summary": "`_render_ticket_preview(config)` 位于Gradio 界面标签页，负责推进购票、订单或支付流程；内部主要调用 join、_preview_value、_format_price_cents、escape、get。",
+      "tags": [
+        "函数",
+        "界面",
+        "支付"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 25 行，直接调用约 15 次。"
+    },
+    {
+      "id": "function:tab/go.py:_get_session_upload_files",
+      "type": "function",
+      "name": "_get_session_upload_files",
+      "filePath": "tab/go.py",
+      "lineRange": [
+        140,
+        141
+      ],
+      "summary": "`_get_session_upload_files()` 位于Gradio 界面标签页，负责读取并解析数据；内部主要调用 runtime_state_reader。",
+      "tags": [
+        "函数",
+        "界面",
+        "读取"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 2 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tab/go.py:_build_session_ticket_preview",
+      "type": "function",
+      "name": "_build_session_ticket_preview",
+      "filePath": "tab/go.py",
+      "lineRange": [
+        144,
+        155
+      ],
+      "summary": "`_build_session_ticket_preview()` 位于Gradio 界面标签页，负责推进购票、订单或支付流程；内部主要调用 _get_session_upload_files、_render_ticket_preview、open、load、escape、str。",
+      "tags": [
+        "函数",
+        "界面",
+        "支付"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 0 个，约 12 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:tab/go.py:go_start_tab",
+      "type": "function",
+      "name": "go_start_tab",
+      "filePath": "tab/go.py",
+      "lineRange": [
+        158,
+        539
+      ],
+      "summary": "`go_start_tab()` 位于Gradio 界面标签页，负责启动或执行任务；内部主要调用 runtime_state_writer、upload、change、clear、select、Textbox。",
+      "tags": [
+        "函数",
+        "界面",
+        "执行"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 0 个，约 382 行，直接调用约 140 次。"
+    },
+    {
+      "id": "function:tab/log.py:_status_class",
+      "type": "function",
+      "name": "_status_class",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        51,
+        58
+      ],
+      "summary": "`_status_class(status)` 位于Gradio 界面标签页，负责处理 status class 相关逻辑；内部主要调用 get。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 8 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tab/log.py:_refresh_token",
+      "type": "function",
+      "name": "_refresh_token",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        61,
+        62
+      ],
+      "summary": "`_refresh_token()` 位于Gradio 界面标签页，负责处理 refresh token 相关逻辑；内部主要调用 time_ns。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 2 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tab/log.py:build_main_log_card",
+      "type": "function",
+      "name": "build_main_log_card",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        65,
+        66
+      ],
+      "summary": "`build_main_log_card()` 位于Gradio 界面标签页，负责处理 build main log card 相关逻辑；内部主要调用 无明显外部调用。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 2 行，直接调用约 0 次。"
+    },
+    {
+      "id": "function:tab/log.py:_render_log_path",
+      "type": "function",
+      "name": "_render_log_path",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        69,
+        77
+      ],
+      "summary": "`_render_log_path(path)` 位于Gradio 界面标签页，负责格式化展示内容；内部主要调用 format、escape。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 9 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:tab/log.py:_render_log_view_action",
+      "type": "function",
+      "name": "_render_log_view_action",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        80,
+        83
+      ],
+      "summary": "`_render_log_view_action(path)` 位于Gradio 界面标签页，负责格式化展示内容；内部主要调用 format、escape、build_log_view_url。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 4 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:tab/log.py:_list_log_files",
+      "type": "function",
+      "name": "_list_log_files",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        86,
+        95
+      ],
+      "summary": "`_list_log_files()` 位于Gradio 界面标签页，负责处理 list log files 相关逻辑；内部主要调用 sorted、join、listdir、isfile、getmtime。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 10 行，直接调用约 6 次。"
+    },
+    {
+      "id": "function:tab/log.py:_find_task_entry_by_log_file",
+      "type": "function",
+      "name": "_find_task_entry_by_log_file",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        98,
+        103
+      ],
+      "summary": "`_find_task_entry_by_log_file(log_file)` 位于Gradio 界面标签页，负责处理 find task entry by log file 相关逻辑；内部主要调用 abspath、visible_task_entries。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 6 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:tab/log.py:clear_log_files",
+      "type": "function",
+      "name": "clear_log_files",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        106,
+        152
+      ],
+      "summary": "`clear_log_files()` 位于Gradio 界面标签页，负责处理 clear log files 相关逻辑；内部主要调用 _list_log_files、refresh_log_panel、Info、_find_task_entry_by_log_file、remove_task_logs_by_paths、append。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 0 个，约 47 行，直接调用约 22 次。"
+    },
+    {
+      "id": "function:tab/log.py:is_task_running",
+      "type": "function",
+      "name": "is_task_running",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        155,
+        199
+      ],
+      "summary": "`is_task_running(pid)` 位于Gradio 界面标签页，负责启动或执行任务；内部主要调用 format、exists、_is_posix_zombie_process、OpenProcess、kill、c_ulong、CloseHandle、GetExitCodeProcess。",
+      "tags": [
+        "函数",
+        "界面",
+        "执行"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 45 行，直接调用约 13 次。"
+    },
+    {
+      "id": "function:tab/log.py:_is_posix_zombie_process",
+      "type": "function",
+      "name": "_is_posix_zombie_process",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        202,
+        218
+      ],
+      "summary": "`_is_posix_zombie_process(pid)` 位于Gradio 界面标签页，负责处理 is posix zombie process 相关逻辑；内部主要调用 splitlines、startswith、run、strip、str。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 17 行，直接调用约 6 次。"
+    },
+    {
+      "id": "function:tab/log.py:_send_posix_signal",
+      "type": "function",
+      "name": "_send_posix_signal",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        221,
+        243
+      ],
+      "summary": "`_send_posix_signal(pid, sig)` 位于Gradio 界面标签页，负责发送通知或推送消息；内部主要调用 getpgid、killpg、kill、sender。",
+      "tags": [
+        "函数",
+        "界面",
+        "推送"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 23 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:tab/log.py:terminate_task",
+      "type": "function",
+      "name": "terminate_task",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        246,
+        301
+      ],
+      "summary": "`terminate_task(pid)` 位于Gradio 界面标签页，负责停止任务或清理进程；内部主要调用 _send_posix_signal、is_task_running、time、sleep、run。",
+      "tags": [
+        "函数",
+        "界面",
+        "停止"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 56 行，直接调用约 15 次。"
+    },
+    {
+      "id": "function:tab/log.py:sync_task_statuses",
+      "type": "function",
+      "name": "sync_task_statuses",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        304,
+        326
+      ],
+      "summary": "`sync_task_statuses()` 位于Gradio 界面标签页，负责处理 sync task statuses 相关逻辑；内部主要调用 get_task_logs、extract_payment_qr_url、log_contains_marker、is_task_running、update_task_log_status。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 0 个，约 23 行，直接调用约 10 次。"
+    },
+    {
+      "id": "function:tab/log.py:visible_task_entries",
+      "type": "function",
+      "name": "visible_task_entries",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        329,
+        330
+      ],
+      "summary": "`visible_task_entries()` 位于Gradio 界面标签页，负责处理 visible task entries 相关逻辑；内部主要调用 sync_task_statuses。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 2 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tab/log.py:log_contains_marker",
+      "type": "function",
+      "name": "log_contains_marker",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        333,
+        342
+      ],
+      "summary": "`log_contains_marker(log_file, marker)` 位于Gradio 界面标签页，负责处理 log contains marker 相关逻辑；内部主要调用 open、seek、tell、decode、max、read。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 2 个，约 10 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:tab/log.py:extract_payment_qr_url",
+      "type": "function",
+      "name": "extract_payment_qr_url",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        345,
+        359
+      ],
+      "summary": "`extract_payment_qr_url(log_file)` 位于Gradio 界面标签页，负责推进购票、订单或支付流程；内部主要调用 reversed、splitlines、open、seek、tell、decode、strip。",
+      "tags": [
+        "函数",
+        "界面",
+        "支付"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 15 行，直接调用约 11 次。"
+    },
+    {
+      "id": "function:tab/log.py:refresh_task_panel",
+      "type": "function",
+      "name": "refresh_task_panel",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        362,
+        363
+      ],
+      "summary": "`refresh_task_panel()` 位于Gradio 界面标签页，负责处理 refresh task panel 相关逻辑；内部主要调用 _refresh_token、update、bool、visible_task_entries。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 2 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:tab/log.py:refresh_task_panel_with_payments",
+      "type": "function",
+      "name": "refresh_task_panel_with_payments",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        366,
+        373
+      ],
+      "summary": "`refresh_task_panel_with_payments()` 位于Gradio 界面标签页，负责推进购票、订单或支付流程；内部主要调用 visible_task_entries、_refresh_token、update、dumps、bool。",
+      "tags": [
+        "函数",
+        "界面",
+        "支付"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 8 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:tab/log.py:refresh_log_panel",
+      "type": "function",
+      "name": "refresh_log_panel",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        376,
+        377
+      ],
+      "summary": "`refresh_log_panel()` 位于Gradio 界面标签页，负责处理 refresh log panel 相关逻辑；内部主要调用 _refresh_token、update。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 2 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:tab/log.py:stop_task",
+      "type": "function",
+      "name": "stop_task",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        380,
+        390
+      ],
+      "summary": "`stop_task(pid)` 位于Gradio 界面标签页，负责停止任务或清理进程；内部主要调用 get_task_log、terminate_task、update_task_log_status、refresh_task_panel、append_stop_log、Warning、Info。",
+      "tags": [
+        "函数",
+        "界面",
+        "停止"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 11 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:tab/log.py:stop_all_running_tasks",
+      "type": "function",
+      "name": "stop_all_running_tasks",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        393,
+        429
+      ],
+      "summary": "`stop_all_running_tasks()` 位于Gradio 界面标签页，负责启动或执行任务；内部主要调用 refresh_task_panel、Info、terminate_task、update_task_log_status、Warning、visible_task_entries、append_stop_log。",
+      "tags": [
+        "函数",
+        "界面",
+        "执行"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 0 个，约 37 行，直接调用约 12 次。"
+    },
+    {
+      "id": "function:tab/log.py:remove_task",
+      "type": "function",
+      "name": "remove_task",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        432,
+        445
+      ],
+      "summary": "`remove_task(pid)` 位于Gradio 界面标签页，负责处理 remove task 相关逻辑；内部主要调用 get_task_log、remove_task_log、Info、refresh_task_panel、Warning、terminate_task、append_stop_log。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 14 行，直接调用约 8 次。"
+    },
+    {
+      "id": "function:tab/log.py:append_stop_log",
+      "type": "function",
+      "name": "append_stop_log",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        448,
+        457
+      ],
+      "summary": "`append_stop_log(log_file, title, message)` 位于Gradio 界面标签页，负责停止任务或清理进程；内部主要调用 strftime、now、open、write、format。",
+      "tags": [
+        "函数",
+        "界面",
+        "停止"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 3 个，约 10 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:tab/log.py:read_task_log_locations",
+      "type": "function",
+      "name": "read_task_log_locations",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        460,
+        494
+      ],
+      "summary": "`read_task_log_locations()` 位于Gradio 界面标签页，负责读取并解析数据；内部主要调用 visible_task_entries、append、join、build_main_log_card、strftime、_status_class。",
+      "tags": [
+        "函数",
+        "界面",
+        "读取"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 0 个，约 35 行，直接调用约 16 次。"
+    },
+    {
+      "id": "function:tab/log.py:render_task_manager_panel",
+      "type": "function",
+      "name": "render_task_manager_panel",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        497,
+        585
+      ],
+      "summary": "`render_task_manager_panel(task_panel)` 位于Gradio 界面标签页，负责格式化展示内容；内部主要调用 State、Textbox、Timer、render、click、tick、change、_refresh_token。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 1 个，约 89 行，直接调用约 35 次。"
+    },
+    {
+      "id": "function:tab/log.py:log_tab",
+      "type": "function",
+      "name": "log_tab",
+      "filePath": "tab/log.py",
+      "lineRange": [
+        588,
+        681
+      ],
+      "summary": "`log_tab()` 位于Gradio 界面标签页，负责处理 log tab 相关逻辑；内部主要调用 State、_refresh_token、Column、render、click、Row、HTML。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 0 个，约 94 行，直接调用约 30 次。"
+    },
+    {
+      "id": "function:tests/test_go_ticket_preview.py:test_ticket_preview_appends_buyer_document_type",
+      "type": "function",
+      "name": "test_ticket_preview_appends_buyer_document_type",
+      "filePath": "tests/test_go_ticket_preview.py",
+      "lineRange": [
+        4,
+        15
+      ],
+      "summary": "`test_ticket_preview_appends_buyer_document_type()` 位于自动化测试，负责推进购票、订单或支付流程；内部主要调用 _render_ticket_preview。",
+      "tags": [
+        "函数",
+        "测试",
+        "支付"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 12 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tests/test_task_log_controls.py:test_is_task_running_treats_posix_zombie_as_stopped",
+      "type": "function",
+      "name": "test_is_task_running_treats_posix_zombie_as_stopped",
+      "filePath": "tests/test_task_log_controls.py",
+      "lineRange": [
+        7,
+        20
+      ],
+      "summary": "`test_is_task_running_treats_posix_zombie_as_stopped(monkeypatch)` 位于自动化测试，负责启动或执行任务；内部主要调用 setattr、AssertionError、is_task_running、PsResult。",
+      "tags": [
+        "函数",
+        "测试",
+        "执行"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 14 行，直接调用约 6 次。"
+    },
+    {
+      "id": "function:tests/test_task_log_controls.py:test_terminate_task_falls_back_to_process_signal_when_group_denied",
+      "type": "function",
+      "name": "test_terminate_task_falls_back_to_process_signal_when_group_denied",
+      "filePath": "tests/test_task_log_controls.py",
+      "lineRange": [
+        23,
+        41
+      ],
+      "summary": "`test_terminate_task_falls_back_to_process_signal_when_group_denied(monkeypatch)` 位于自动化测试，负责停止任务或清理进程；内部主要调用 iter、setattr、terminate_task、next、throw。",
+      "tags": [
+        "函数",
+        "测试",
+        "停止"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 19 行，直接调用约 10 次。"
+    },
+    {
+      "id": "function:tests/test_task_log_controls.py:test_terminate_task_returns_message_when_signal_permission_denied",
+      "type": "function",
+      "name": "test_terminate_task_returns_message_when_signal_permission_denied",
+      "filePath": "tests/test_task_log_controls.py",
+      "lineRange": [
+        44,
+        58
+      ],
+      "summary": "`test_terminate_task_returns_message_when_signal_permission_denied(monkeypatch)` 位于自动化测试，负责停止任务或清理进程；内部主要调用 setattr、terminate_task、throw、PermissionError。",
+      "tags": [
+        "函数",
+        "测试",
+        "停止"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 15 行，直接调用约 9 次。"
+    },
+    {
+      "id": "function:tests/test_task_log_controls.py:test_stop_all_running_tasks_stops_only_active_pid_entries",
+      "type": "function",
+      "name": "test_stop_all_running_tasks_stops_only_active_pid_entries",
+      "filePath": "tests/test_task_log_controls.py",
+      "lineRange": [
+        61,
+        126
+      ],
+      "summary": "`test_stop_all_running_tasks_stops_only_active_pid_entries(monkeypatch, tmp_path)` 位于自动化测试，负责启动或执行任务；内部主要调用 write_text、TaskLogEntry、setattr。",
+      "tags": [
+        "函数",
+        "测试",
+        "执行"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 2 个，约 66 行，直接调用约 18 次。"
+    },
+    {
+      "id": "function:tests/test_time_util.py:test_current_time_ms_applies_local_minus_reference_offset",
+      "type": "function",
+      "name": "test_current_time_ms_applies_local_minus_reference_offset",
+      "filePath": "tests/test_time_util.py",
+      "lineRange": [
+        14,
+        16
+      ],
+      "summary": "`test_current_time_ms_applies_local_minus_reference_offset()` 位于自动化测试，负责验证对应业务行为；内部主要调用 current_time_ms。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 3 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:tests/test_time_util.py:test_time_service_now_uses_calibrated_reference_time",
+      "type": "function",
+      "name": "test_time_service_now_uses_calibrated_reference_time",
+      "filePath": "tests/test_time_util.py",
+      "lineRange": [
+        19,
+        25
+      ],
+      "summary": "`test_time_service_now_uses_calibrated_reference_time(monkeypatch)` 位于自动化测试，负责验证对应业务行为；内部主要调用 setattr、TimeUtil、set_timeoffset、now、approx、current_time_ms。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 7 行，直接调用约 6 次。"
+    },
+    {
+      "id": "function:tests/test_time_util.py:test_countdown_now_prefers_bili_date_check",
+      "type": "function",
+      "name": "test_countdown_now_prefers_bili_date_check",
+      "filePath": "tests/test_time_util.py",
+      "lineRange": [
+        28,
+        41
+      ],
+      "summary": "`test_countdown_now_prefers_bili_date_check(monkeypatch)` 位于自动化测试，负责校验状态或参数；内部主要调用 setattr、TimeUtil、set_timeoffset、BiliTimeCheck、countdown_now、approx、countdown_time_source。",
+      "tags": [
+        "函数",
+        "测试",
+        "校验"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 14 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:tests/test_time_util.py:test_compute_ntp_sample_uses_low_delay_median",
+      "type": "function",
+      "name": "test_compute_ntp_sample_uses_low_delay_median",
+      "filePath": "tests/test_time_util.py",
+      "lineRange": [
+        44,
+        68
+      ],
+      "summary": "`test_compute_ntp_sample_uses_low_delay_median()` 位于自动化测试，负责验证对应业务行为；内部主要调用 TimeUtil、Client、compute_ntp_sample、approx、Response。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 0 个，约 25 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:tests/test_time_util.py:test_compute_ntp_sample_returns_fast_primary_without_backup_calls",
+      "type": "function",
+      "name": "test_compute_ntp_sample_returns_fast_primary_without_backup_calls",
+      "filePath": "tests/test_time_util.py",
+      "lineRange": [
+        71,
+        93
+      ],
+      "summary": "`test_compute_ntp_sample_returns_fast_primary_without_backup_calls()` 位于自动化测试，负责验证对应业务行为；内部主要调用 TimeUtil、Client、compute_ntp_sample、approx、append、Response。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 23 行，直接调用约 6 次。"
+    },
+    {
+      "id": "function:tests/test_time_util.py:test_compute_bili_time_check_parses_http_date",
+      "type": "function",
+      "name": "test_compute_bili_time_check_parses_http_date",
+      "filePath": "tests/test_time_util.py",
+      "lineRange": [
+        96,
+        122
+      ],
+      "summary": "`test_compute_bili_time_check_parses_http_date(monkeypatch)` 位于自动化测试，负责规范化输入值；内部主要调用 iter、setattr、TimeUtil、compute_bili_time_check、timestamp、approx。",
+      "tags": [
+        "函数",
+        "测试",
+        "规范化"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 27 行，直接调用约 12 次。"
+    },
+    {
+      "id": "function:util/TimeUtil.py:current_time_ms",
+      "type": "function",
+      "name": "current_time_ms",
+      "filePath": "util/TimeUtil.py",
+      "lineRange": [
+        19,
+        28
+      ],
+      "summary": "`current_time_ms()`：Return calibrated reference wall time in milliseconds.。位于项目通用模块，调用 current_time_ms。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 3 行，直接调用约 1 次。"
+    },
+    {
+      "id": "class:util/TimeUtil.py:TimeSyncSample",
+      "type": "class",
+      "name": "TimeSyncSample",
+      "filePath": "util/TimeUtil.py",
+      "lineRange": [
+        32,
+        35
+      ],
+      "summary": "`TimeSyncSample` 位于项目通用模块，用于处理 Time Sync Sample 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 4 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/TimeUtil.py:BiliTimeCheck",
+      "type": "class",
+      "name": "BiliTimeCheck",
+      "filePath": "util/TimeUtil.py",
+      "lineRange": [
+        39,
+        49
+      ],
+      "summary": "`BiliTimeCheck` 位于项目通用模块，用于校验状态或参数，包含方法 uncertainty_seconds。",
+      "tags": [
+        "类",
+        "校验"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 11 行，包含 1 个方法。"
+    },
+    {
+      "id": "class:util/TimeUtil.py:TimeUtil",
+      "type": "class",
+      "name": "TimeUtil",
+      "filePath": "util/TimeUtil.py",
+      "lineRange": [
+        52,
+        258
+      ],
+      "summary": "`TimeUtil` 位于项目通用模块，用于处理 Time Util 相关逻辑，包含方法 __init__、compute_timeoffset、compute_ntp_sample、compute_bili_time_check、set_timeoffset、get_timeoffset、sync_time、now、countdown_now、countdown_time_source。",
+      "tags": [
+        "类"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 类，约 207 行，包含 11 个方法。"
+    },
+    {
+      "id": "function:util/__init__.py:get_application_path",
+      "type": "function",
+      "name": "get_application_path",
+      "filePath": "util/__init__.py",
+      "lineRange": [
+        16,
+        28
+      ],
+      "summary": "`get_application_path()` 位于项目通用模块，负责封装接口请求；内部主要调用 getattr、dirname、abspath。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 0 个，约 13 行，直接调用约 9 次。"
+    },
+    {
+      "id": "function:util/__init__.py:get_exec_path",
+      "type": "function",
+      "name": "get_exec_path",
+      "filePath": "util/__init__.py",
+      "lineRange": [
+        31,
+        37
+      ],
+      "summary": "`get_exec_path()` 位于项目通用模块，负责封装接口请求；内部主要调用 endswith、dirname、len、realpath、abspath。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 0 个，约 7 行，直接调用约 7 次。"
+    },
+    {
+      "id": "function:util/__init__.py:get_application_tmp_path",
+      "type": "function",
+      "name": "get_application_tmp_path",
+      "filePath": "util/__init__.py",
+      "lineRange": [
+        43,
+        45
+      ],
+      "summary": "`get_application_tmp_path()` 位于项目通用模块，负责封装接口请求；内部主要调用 makedirs、join。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 3 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:util/__init__.py:set_main_request",
+      "type": "function",
+      "name": "set_main_request",
+      "filePath": "util/__init__.py",
+      "lineRange": [
+        83,
+        85
+      ],
+      "summary": "`set_main_request(request)` 位于项目通用模块，负责封装接口请求；内部主要调用 无明显外部调用。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 3 行，直接调用约 0 次。"
+    },
+    {
+      "id": "function:util/__init__.py:runtime_state_reader",
+      "type": "function",
+      "name": "runtime_state_reader",
+      "filePath": "util/__init__.py",
+      "lineRange": [
+        218,
+        237
+      ],
+      "summary": "`runtime_state_reader(key, kind, default, limit)` 位于项目通用模块，负责读取并解析数据；内部主要调用 wraps、func、state_get、state_get_path_list。",
+      "tags": [
+        "函数",
+        "读取"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 4 个，约 20 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:util/__init__.py:runtime_state_writer",
+      "type": "function",
+      "name": "runtime_state_writer",
+      "filePath": "util/__init__.py",
+      "lineRange": [
+        240,
+        267
+      ],
+      "summary": "`runtime_state_writer(key, kind, arg_index, limit, value_getter)` 位于项目通用模块，负责写入或持久化数据；内部主要调用 wraps、func、value_getter、state_set_path_list、state_set、len。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 5 个，约 28 行，直接调用约 6 次。"
+    },
+    {
+      "id": "class:util/__init__.py:TaskLogEntry",
+      "type": "class",
+      "name": "TaskLogEntry",
+      "filePath": "util/__init__.py",
+      "lineRange": [
+        96,
+        104
+      ],
+      "summary": "`TaskLogEntry` 位于项目通用模块，用于处理 Task Log Entry 相关逻辑，包含方法 无显式方法。",
+      "tags": [
+        "类"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 9 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:util/__init__.py:RuntimeStateStore",
+      "type": "class",
+      "name": "RuntimeStateStore",
+      "filePath": "util/__init__.py",
+      "lineRange": [
+        108,
+        138
+      ],
+      "summary": "`RuntimeStateStore` 位于项目通用模块，用于启动或执行任务，包含方法 set、get、delete、set_path_list、get_path_list。",
+      "tags": [
+        "类",
+        "执行"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 31 行，包含 5 个方法。"
+    },
+    {
+      "id": "class:util/__init__.py:GlobalStatus",
+      "type": "class",
+      "name": "GlobalStatus",
+      "filePath": "util/__init__.py",
+      "lineRange": [
+        142,
+        212
+      ],
+      "summary": "`GlobalStatus` 位于项目通用模块，用于处理 Global Status 相关逻辑，包含方法 state_set、state_get、state_delete、state_set_path_list、state_get_path_list、set_uploaded_config_files、get_uploaded_config_files、register_task_log、get_task_logs、get_task_log。",
+      "tags": [
+        "类"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 类，约 71 行，包含 13 个方法。"
+    },
+    {
+      "id": "function:util/log/LogConfig.py:loguru_config",
+      "type": "function",
+      "name": "loguru_config",
+      "filePath": "util/log/LogConfig.py",
+      "lineRange": [
+        6,
+        54
+      ],
+      "summary": "`loguru_config(log_dir, log_file_name, file_colorize, enable_console, file_level, console_level, retention_days)`：配置 Loguru 日志系统。。位于日志与终端输出，调用 remove、upper、add、join、int。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 7 个，约 49 行，直接调用约 13 次。"
+    },
+    {
+      "id": "function:util/log/LogWeb.py:build_log_view_url",
+      "type": "function",
+      "name": "build_log_view_url",
+      "filePath": "util/log/LogWeb.py",
+      "lineRange": [
+        17,
+        19
+      ],
+      "summary": "`build_log_view_url(path)` 位于日志与终端输出，负责处理 build log view url 相关逻辑；内部主要调用 basename、quote。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 3 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:util/log/LogWeb.py:_resolve_log_path",
+      "type": "function",
+      "name": "_resolve_log_path",
+      "filePath": "util/log/LogWeb.py",
+      "lineRange": [
+        22,
+        44
+      ],
+      "summary": "`_resolve_log_path(raw_path, log_name)` 位于日志与终端输出，负责处理 resolve log path 相关逻辑；内部主要调用 resolve、basename、HTTPException、Path、strip。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 2 个，约 23 行，直接调用约 14 次。"
+    },
+    {
+      "id": "function:util/log/LogWeb.py:_read_log_text",
+      "type": "function",
+      "name": "_read_log_text",
+      "filePath": "util/log/LogWeb.py",
+      "lineRange": [
+        47,
+        49
+      ],
+      "summary": "`_read_log_text(path)` 位于日志与终端输出，负责读取并解析数据；内部主要调用 open、read。",
+      "tags": [
+        "函数",
+        "读取"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 3 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:util/log/LogWeb.py:attach_log_routes",
+      "type": "function",
+      "name": "attach_log_routes",
+      "filePath": "util/log/LogWeb.py",
+      "lineRange": [
+        52,
+        209
+      ],
+      "summary": "`attach_log_routes(app)` 位于日志与终端输出，负责处理 attach log routes 相关逻辑；内部主要调用 getattr、get、Query、_resolve_log_path、escape。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 1 个，约 158 行，直接调用约 30 次。"
+    },
+    {
+      "id": "function:util/log/LogWeb.py:build_log_stream_url",
+      "type": "function",
+      "name": "build_log_stream_url",
+      "filePath": "util/log/LogWeb.py",
+      "lineRange": [
+        212,
+        214
+      ],
+      "summary": "`build_log_stream_url(path)` 位于日志与终端输出，负责处理 build log stream url 相关逻辑；内部主要调用 basename、quote。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 3 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:util/log/LogWeb.py:_sse",
+      "type": "function",
+      "name": "_sse",
+      "filePath": "util/log/LogWeb.py",
+      "lineRange": [
+        217,
+        219
+      ],
+      "summary": "`_sse(event, data)` 位于日志与终端输出，负责处理 sse 相关逻辑；内部主要调用 replace、chr。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 3 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:util/notifer/RandomMessages.py:_load_messages",
+      "type": "function",
+      "name": "_load_messages",
+      "filePath": "util/notifer/RandomMessages.py",
+      "lineRange": [
+        10,
+        16
+      ],
+      "summary": "`_load_messages()` 位于通知渠道，负责读取并解析数据；内部主要调用 join、get_application_path、open、load。",
+      "tags": [
+        "函数",
+        "通知",
+        "读取"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 7 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:util/notifer/RandomMessages.py:get_random_fail_message",
+      "type": "function",
+      "name": "get_random_fail_message",
+      "filePath": "util/notifer/RandomMessages.py",
+      "lineRange": [
+        22,
+        23
+      ],
+      "summary": "`get_random_fail_message()` 位于通知渠道，负责封装接口请求；内部主要调用 choice。",
+      "tags": [
+        "函数",
+        "通知"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 2 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:app_cmd/buy.py:buy_cmd",
+      "type": "function",
+      "name": "buy_cmd",
+      "filePath": "app_cmd/buy.py",
+      "lineRange": [
+        11,
+        259
+      ],
+      "summary": "`buy_cmd(args)` 位于命令行购票流程，负责推进购票、订单或支付流程；内部主要调用 apply_log_env、load_tickets_info、basename、resolve_log_file_name、loguru_config、install_console_close_handler、start_parent_watchdog、info。",
+      "tags": [
+        "函数",
+        "购票",
+        "支付"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 1 个，约 249 行，直接调用约 82 次。"
+    },
+    {
+      "id": "function:app_cmd/cli_args.py:_env_bool",
+      "type": "function",
+      "name": "_env_bool",
+      "filePath": "app_cmd/cli_args.py",
+      "lineRange": [
+        9,
+        13
+      ],
+      "summary": "`_env_bool(key, default)` 位于命令行购票流程，负责处理 env bool 相关逻辑；内部主要调用 get、lower、strip、str。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 5 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:app_cmd/cli_args.py:_env_optional_int",
+      "type": "function",
+      "name": "_env_optional_int",
+      "filePath": "app_cmd/cli_args.py",
+      "lineRange": [
+        16,
+        21
+      ],
+      "summary": "`_env_optional_int(*keys)` 位于命令行购票流程，负责处理 env optional int 相关逻辑；内部主要调用 get、int。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 6 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:app_cmd/cli_args.py:_env_optional_str",
+      "type": "function",
+      "name": "_env_optional_str",
+      "filePath": "app_cmd/cli_args.py",
+      "lineRange": [
+        24,
+        29
+      ],
+      "summary": "`_env_optional_str(*keys)` 位于命令行购票流程，负责处理 env optional str 相关逻辑；内部主要调用 get。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 6 行，直接调用约 1 次。"
+    },
+    {
+      "id": "class:app_cmd/cli_args.py:TickerCliArgs",
+      "type": "class",
+      "name": "TickerCliArgs",
+      "filePath": "app_cmd/cli_args.py",
+      "lineRange": [
+        33,
+        46
+      ],
+      "summary": "`TickerCliArgs`：Web UI launch options.。位于命令行购票流程，包含方法 无显式方法。",
+      "tags": [
+        "类",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 14 行，包含 0 个方法。"
+    },
+    {
+      "id": "function:app_cmd/ticker.py:exit_app_ui",
+      "type": "function",
+      "name": "exit_app_ui",
+      "filePath": "app_cmd/ticker.py",
+      "lineRange": [
+        14,
+        17
+      ],
+      "summary": "`exit_app_ui()` 位于命令行购票流程，负责处理 exit app ui 相关逻辑；内部主要调用 info、start、Info、Timer、_exit。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 4 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:app_cmd/ticker.py:shutdown_app_process",
+      "type": "function",
+      "name": "shutdown_app_process",
+      "filePath": "app_cmd/ticker.py",
+      "lineRange": [
+        20,
+        21
+      ],
+      "summary": "`shutdown_app_process(delay_seconds)` 位于命令行购票流程，负责处理 shutdown app process 相关逻辑；内部主要调用 start、Timer、_exit。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 2 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:app_cmd/ticker.py:ticker_cmd",
+      "type": "function",
+      "name": "ticker_cmd",
+      "filePath": "app_cmd/ticker.py",
+      "lineRange": [
+        24,
+        265
+      ],
+      "summary": "`ticker_cmd(args)` 位于命令行购票流程，负责处理 ticker cmd 相关逻辑；内部主要调用 loguru_config、join、exists、get_app_version、get、launch。",
+      "tags": [
+        "函数",
+        "购票"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 1 个，约 242 行，直接调用约 50 次。"
+    },
+    {
+      "id": "function:app_update.py:normalize_version",
+      "type": "function",
+      "name": "normalize_version",
+      "filePath": "app_update.py",
+      "lineRange": [
+        53,
+        60
+      ],
+      "summary": "`normalize_version(value)` 位于项目通用模块，负责规范化输入值；内部主要调用 strip、startswith、Version、lower、UpdateError。",
+      "tags": [
+        "函数",
+        "规范化"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 8 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:app_update.py:select_update",
+      "type": "function",
+      "name": "select_update",
+      "filePath": "app_update.py",
+      "lineRange": [
+        63,
+        106
+      ],
+      "summary": "`select_update(releases, current_version, channel)` 位于项目通用模块，负责处理 select update 相关逻辑；内部主要调用 normalize_version、max、tuple、ReleaseInfo、UpdateError、get、bool。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Python 函数，参数 3 个，约 44 行，直接调用约 35 次。"
+    },
+    {
+      "id": "function:app_update.py:fetch_update",
+      "type": "function",
+      "name": "fetch_update",
+      "filePath": "app_update.py",
+      "lineRange": [
+        109,
+        129
+      ],
+      "summary": "`fetch_update(current_version, channel, session)` 位于项目通用模块，负责封装接口请求；内部主要调用 get、raise_for_status、json、select_update、Session、isinstance、UpdateError。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 3 个，约 21 行，直接调用约 7 次。"
+    },
+    {
+      "id": "class:app_update.py:UpdateError",
+      "type": "class",
+      "name": "UpdateError",
+      "filePath": "app_update.py",
+      "lineRange": [
+        19,
+        20
+      ],
+      "summary": "`UpdateError`：Raised when an update cannot be discovered or downloaded safely.。位于项目通用模块，继承 RuntimeError，包含方法 无显式方法。",
+      "tags": [
+        "类"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 2 行，包含 0 个方法。"
+    },
+    {
+      "id": "class:app_update.py:ReleaseInfo",
+      "type": "class",
+      "name": "ReleaseInfo",
+      "filePath": "app_update.py",
+      "lineRange": [
+        24,
+        50
+      ],
+      "summary": "`ReleaseInfo` 位于项目通用模块，用于处理 Release Info 相关逻辑，包含方法 to_dict、from_dict。",
+      "tags": [
+        "类"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 类，约 27 行，包含 2 个方法。"
+    },
+    {
+      "id": "function:app_version.py:_read_pyproject_version",
+      "type": "function",
+      "name": "_read_pyproject_version",
+      "filePath": "app_version.py",
+      "lineRange": [
+        12,
+        26
+      ],
+      "summary": "`_read_pyproject_version()` 位于项目通用模块，负责读取并解析数据；内部主要调用 FileNotFoundError、with_name、getattr、cwd、is_file、str、resolve。",
+      "tags": [
+        "函数",
+        "读取"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 0 个，约 15 行，直接调用约 15 次。"
+    },
+    {
+      "id": "function:app_version.py:get_app_version",
+      "type": "function",
+      "name": "get_app_version",
+      "filePath": "app_version.py",
+      "lineRange": [
+        29,
+        34
+      ],
+      "summary": "`get_app_version()`：Return the installed package version, falling back to pyproject.toml.。位于项目通用模块，调用 version、_read_pyproject_version。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 6 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:main.py:_normalize_argv",
+      "type": "function",
+      "name": "_normalize_argv",
+      "filePath": "main.py",
+      "lineRange": [
+        30,
+        43
+      ],
+      "summary": "`_normalize_argv(argv)` 位于项目通用模块，负责规范化输入值；内部主要调用 无明显外部调用。",
+      "tags": [
+        "函数",
+        "规范化"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 14 行，直接调用约 0 次。"
+    },
+    {
+      "id": "function:main.py:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "main.py",
+      "lineRange": [
+        46,
+        51
+      ],
+      "summary": "`main()` 位于项目通用模块，负责处理 main 相关逻辑；内部主要调用 cli、isinstance、ticker_cmd、buy_cmd、_normalize_argv。",
+      "tags": [
+        "函数"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 6 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:tab/update.py:_saved_channel",
+      "type": "function",
+      "name": "_saved_channel",
+      "filePath": "tab/update.py",
+      "lineRange": [
+        20,
+        21
+      ],
+      "summary": "`_saved_channel()` 位于Gradio 界面标签页，负责写入或持久化数据；内部主要调用 str、get。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 2 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:tab/update.py:_format_update",
+      "type": "function",
+      "name": "_format_update",
+      "filePath": "tab/update.py",
+      "lineRange": [
+        24,
+        41
+      ],
+      "summary": "`_format_update(release, channel)` 位于Gradio 界面标签页，负责格式化展示内容；内部主要调用 escape、get_app_version。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 2 个，约 18 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:tab/update.py:_update_script_name",
+      "type": "function",
+      "name": "_update_script_name",
+      "filePath": "tab/update.py",
+      "lineRange": [
+        44,
+        45
+      ],
+      "summary": "`_update_script_name()` 位于Gradio 界面标签页，负责处理 update script name 相关逻辑；内部主要调用 无明显外部调用。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 2 行，直接调用约 0 次。"
+    },
+    {
+      "id": "function:tab/update.py:_runtime_mode",
+      "type": "function",
+      "name": "_runtime_mode",
+      "filePath": "tab/update.py",
+      "lineRange": [
+        48,
+        55
+      ],
+      "summary": "`_runtime_mode()` 位于Gradio 界面标签页，负责启动或执行任务；内部主要调用 getattr、exists、endswith、Path。",
+      "tags": [
+        "函数",
+        "界面",
+        "执行"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 8 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:tab/update.py:_source_update_hint",
+      "type": "function",
+      "name": "_source_update_hint",
+      "filePath": "tab/update.py",
+      "lineRange": [
+        58,
+        64
+      ],
+      "summary": "`_source_update_hint()` 位于Gradio 界面标签页，负责处理 source update hint 相关逻辑；内部主要调用 escape。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 7 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tab/update.py:_pip_update_hint",
+      "type": "function",
+      "name": "_pip_update_hint",
+      "filePath": "tab/update.py",
+      "lineRange": [
+        67,
+        71
+      ],
+      "summary": "`_pip_update_hint(channel)` 位于Gradio 界面标签页，负责处理 pip update hint 相关逻辑；内部主要调用 escape。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 5 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tab/update.py:_bundled_update_hint",
+      "type": "function",
+      "name": "_bundled_update_hint",
+      "filePath": "tab/update.py",
+      "lineRange": [
+        74,
+        86
+      ],
+      "summary": "`_bundled_update_hint()` 位于Gradio 界面标签页，负责处理 bundled update hint 相关逻辑；内部主要调用 _update_script_name、escape、lower、join、system。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 13 行，直接调用约 5 次。"
+    },
+    {
+      "id": "function:tab/update.py:_update_hint",
+      "type": "function",
+      "name": "_update_hint",
+      "filePath": "tab/update.py",
+      "lineRange": [
+        89,
+        95
+      ],
+      "summary": "`_update_hint(channel)` 位于Gradio 界面标签页，负责处理 update hint 相关逻辑；内部主要调用 _runtime_mode、_pip_update_hint、_bundled_update_hint、_source_update_hint。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 1 个，约 7 行，直接调用约 4 次。"
+    },
+    {
+      "id": "function:tab/update.py:_check_updates",
+      "type": "function",
+      "name": "_check_updates",
+      "filePath": "tab/update.py",
+      "lineRange": [
+        98,
+        116
+      ],
+      "summary": "`_check_updates(channel)` 位于Gradio 界面标签页，负责校验状态或参数；内部主要调用 insert、_saved_channel、fetch_update、_format_update、update、get_app_version、to_dict。",
+      "tags": [
+        "函数",
+        "界面",
+        "校验"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 19 行，直接调用约 12 次。"
+    },
+    {
+      "id": "function:tab/update.py:load_update_check",
+      "type": "function",
+      "name": "load_update_check",
+      "filePath": "tab/update.py",
+      "lineRange": [
+        119,
+        120
+      ],
+      "summary": "`load_update_check()` 位于Gradio 界面标签页，负责读取并解析数据；内部主要调用 _check_updates、_saved_channel。",
+      "tags": [
+        "函数",
+        "界面",
+        "读取"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 2 行，直接调用约 2 次。"
+    },
+    {
+      "id": "function:tab/update.py:run_stable_update_check",
+      "type": "function",
+      "name": "run_stable_update_check",
+      "filePath": "tab/update.py",
+      "lineRange": [
+        123,
+        124
+      ],
+      "summary": "`run_stable_update_check()` 位于Gradio 界面标签页，负责校验状态或参数；内部主要调用 _check_updates。",
+      "tags": [
+        "函数",
+        "界面",
+        "校验"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 2 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tab/update.py:show_update_loading",
+      "type": "function",
+      "name": "show_update_loading",
+      "filePath": "tab/update.py",
+      "lineRange": [
+        127,
+        132
+      ],
+      "summary": "`show_update_loading()` 位于Gradio 界面标签页，负责读取并解析数据；内部主要调用 update。",
+      "tags": [
+        "函数",
+        "界面",
+        "读取"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 6 行，直接调用约 1 次。"
+    },
+    {
+      "id": "function:tab/update.py:update_tab",
+      "type": "function",
+      "name": "update_tab",
+      "filePath": "tab/update.py",
+      "lineRange": [
+        135,
+        155
+      ],
+      "summary": "`update_tab(demo)` 位于Gradio 界面标签页，负责处理 update tab 相关逻辑；内部主要调用 HTML、State、Markdown、load、then、Row、Button、_update_hint。",
+      "tags": [
+        "函数",
+        "界面"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Python 函数，参数 1 个，约 21 行，直接调用约 10 次。"
+    },
+    {
+      "id": "function:tests/test_app_update.py:_release",
+      "type": "function",
+      "name": "_release",
+      "filePath": "tests/test_app_update.py",
+      "lineRange": [
+        8,
+        18
+      ],
+      "summary": "`_release(tag, prerelease, draft, assets)` 位于自动化测试，负责处理 release 相关逻辑；内部主要调用 无明显外部调用。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 4 个，约 11 行，直接调用约 0 次。"
+    },
+    {
+      "id": "function:tests/test_app_update.py:test_stable_channel_skips_prereleases",
+      "type": "function",
+      "name": "test_stable_channel_skips_prereleases",
+      "filePath": "tests/test_app_update.py",
+      "lineRange": [
+        21,
+        25
+      ],
+      "summary": "`test_stable_channel_skips_prereleases()` 位于自动化测试，负责验证对应业务行为；内部主要调用 select_update、_release。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 5 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:tests/test_app_update.py:test_prerelease_channel_selects_newest_version",
+      "type": "function",
+      "name": "test_prerelease_channel_selects_newest_version",
+      "filePath": "tests/test_app_update.py",
+      "lineRange": [
+        28,
+        32
+      ],
+      "summary": "`test_prerelease_channel_selects_newest_version()` 位于自动化测试，负责验证对应业务行为；内部主要调用 select_update、_release。",
+      "tags": [
+        "函数",
+        "测试"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Python 函数，参数 0 个，约 5 行，直接调用约 3 次。"
+    },
+    {
+      "id": "function:install.sh:resolve_url",
+      "type": "function",
+      "name": "resolve_url",
+      "filePath": "install.sh",
+      "lineRange": [
+        51,
+        65
+      ],
+      "summary": "resolve_url 封装 install.sh 中的一段可复用业务逻辑。",
+      "tags": [
+        "脚本",
+        "函数",
+        "函数"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.sh:http_get",
+      "type": "function",
+      "name": "http_get",
+      "filePath": "install.sh",
+      "lineRange": [
+        70,
+        149
+      ],
+      "summary": "http_get 封装 install.sh 中的一段可复用业务逻辑。",
+      "tags": [
+        "脚本",
+        "函数",
+        "函数"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:install.sh:request_version_info",
+      "type": "function",
+      "name": "request_version_info",
+      "filePath": "install.sh",
+      "lineRange": [
+        151,
+        171
+      ],
+      "summary": "request_version_info 封装 install.sh 中的一段可复用业务逻辑。",
+      "tags": [
+        "脚本",
+        "函数",
+        "函数"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.sh:parse_version_info",
+      "type": "function",
+      "name": "parse_version_info",
+      "filePath": "install.sh",
+      "lineRange": [
+        173,
+        281
+      ],
+      "summary": "parse_version_info 封装 install.sh 中的一段可复用业务逻辑。",
+      "tags": [
+        "脚本",
+        "函数",
+        "函数"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:install.sh:validate_version_info",
+      "type": "function",
+      "name": "validate_version_info",
+      "filePath": "install.sh",
+      "lineRange": [
+        283,
+        328
+      ],
+      "summary": "validate_version_info 封装 install.sh 中的一段可复用业务逻辑。",
+      "tags": [
+        "脚本",
+        "函数",
+        "函数"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.sh:is_valid_zip",
+      "type": "function",
+      "name": "is_valid_zip",
+      "filePath": "install.sh",
+      "lineRange": [
+        330,
+        349
+      ],
+      "summary": "is_valid_zip 封装 install.sh 中的一段可复用业务逻辑。",
+      "tags": [
+        "脚本",
+        "函数",
+        "函数"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.sh:print_invalid_download",
+      "type": "function",
+      "name": "print_invalid_download",
+      "filePath": "install.sh",
+      "lineRange": [
+        351,
+        379
+      ],
+      "summary": "print_invalid_download 封装 install.sh 中的一段可复用业务逻辑。",
+      "tags": [
+        "脚本",
+        "函数",
+        "函数"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.sh:download_release_asset",
+      "type": "function",
+      "name": "download_release_asset",
+      "filePath": "install.sh",
+      "lineRange": [
+        381,
+        420
+      ],
+      "summary": "download_release_asset 封装 install.sh 中的一段可复用业务逻辑。",
+      "tags": [
+        "脚本",
+        "函数",
+        "函数"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.sh:get_file_size",
+      "type": "function",
+      "name": "get_file_size",
+      "filePath": "install.sh",
+      "lineRange": [
+        422,
+        433
+      ],
+      "summary": "get_file_size 封装 install.sh 中的一段可复用业务逻辑。",
+      "tags": [
+        "脚本",
+        "函数",
+        "函数"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.sh:calculate_sha256",
+      "type": "function",
+      "name": "calculate_sha256",
+      "filePath": "install.sh",
+      "lineRange": [
+        435,
+        458
+      ],
+      "summary": "calculate_sha256 封装 install.sh 中的一段可复用业务逻辑。",
+      "tags": [
+        "脚本",
+        "函数",
+        "函数"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.sh:verify_download",
+      "type": "function",
+      "name": "verify_download",
+      "filePath": "install.sh",
+      "lineRange": [
+        460,
+        494
+      ],
+      "summary": "verify_download 封装 install.sh 中的一段可复用业务逻辑。",
+      "tags": [
+        "脚本",
+        "函数",
+        "函数"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.sh:append_path_block",
+      "type": "function",
+      "name": "append_path_block",
+      "filePath": "install.sh",
+      "lineRange": [
+        496,
+        515
+      ],
+      "summary": "append_path_block 封装 install.sh 中的一段可复用业务逻辑。",
+      "tags": [
+        "脚本",
+        "函数",
+        "函数"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.sh:find_package_binary",
+      "type": "function",
+      "name": "find_package_binary",
+      "filePath": "install.sh",
+      "lineRange": [
+        522,
+        531
+      ],
+      "summary": "find_package_binary 封装 install.sh 中的一段可复用业务逻辑。",
+      "tags": [
+        "脚本",
+        "函数",
+        "函数"
+      ],
+      "complexity": "simple"
+    }
+  ],
+  "edges": [
+    {
+      "source": "file:__init__.py",
+      "target": "file:interface/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:interface/__init__.py",
+      "target": "file:interface/auth.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:interface/__init__.py",
+      "target": "file:interface/config.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:interface/__init__.py",
+      "target": "file:interface/execution.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:interface/__init__.py",
+      "target": "file:interface/project.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:interface/__init__.py",
+      "target": "file:interface/search.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:interface/__init__.py",
+      "target": "file:interface/types.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:interface/auth.py",
+      "target": "function:interface/auth.py:get_login_state",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/auth.py",
+      "target": "function:interface/auth.py:get_login_state",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/auth.py",
+      "target": "function:interface/auth.py:start_qr_login",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/auth.py",
+      "target": "function:interface/auth.py:start_qr_login",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/auth.py",
+      "target": "function:interface/auth.py:poll_qr_login",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/auth.py",
+      "target": "function:interface/auth.py:poll_qr_login",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/auth.py",
+      "target": "function:interface/auth.py:login_with_cookies",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/auth.py",
+      "target": "function:interface/auth.py:login_with_cookies",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_load_json_file",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_load_json_file",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_read_tinydb_value",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_read_tinydb_value",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_cookie_store_path",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_cookie_store_path",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_coerce_cookie_store",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_coerce_cookie_store",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_resolve_cookie_list",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_resolve_cookie_list",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_cookies_to_header",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_cookies_to_header",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_fetch_username_silently",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_fetch_username_silently",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_deepcopy_dict",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_deepcopy_dict",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_load_config",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_load_config",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_extract_project_id",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_extract_project_id",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_format_sale_status",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_format_sale_status",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_make_request",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/common.py",
+      "target": "function:interface/common.py:_make_request",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/auth.py",
+      "target": "file:interface/common.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:interface/common.py:_read_tinydb_value",
+      "target": "function:interface/common.py:_load_json_file",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/common.py:_cookie_store_path",
+      "target": "function:interface/common.py:_read_tinydb_value",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/common.py:_resolve_cookie_list",
+      "target": "function:interface/common.py:_coerce_cookie_store",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/common.py:_resolve_cookie_list",
+      "target": "function:interface/common.py:_cookie_store_path",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/common.py:_resolve_cookie_list",
+      "target": "function:interface/common.py:_load_json_file",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/common.py:_fetch_username_silently",
+      "target": "function:interface/common.py:_cookies_to_header",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/common.py:_load_config",
+      "target": "function:interface/common.py:_deepcopy_dict",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/common.py:_load_config",
+      "target": "function:interface/common.py:_load_json_file",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/common.py:_make_request",
+      "target": "function:interface/common.py:_cookie_store_path",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:normalize_time_start",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:normalize_time_start",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:normalize_interval",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:normalize_interval",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:normalize_non_negative_interval",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:normalize_non_negative_interval",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:normalize_positive_int",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:normalize_positive_int",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:load_ticket_config",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:load_ticket_config",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:save_ticket_config",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:save_ticket_config",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:_normalize_buyer_info",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:_normalize_buyer_info",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:generate_ticket_config",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:generate_ticket_config",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:build_runtime_options",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:build_runtime_options",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:build_ticket_config_from_selection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:build_ticket_config_from_selection",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:validate_config",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "function:interface/config.py:validate_config",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "class:interface/config.py:RuntimeOptions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "class:interface/config.py:RuntimeOptions",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "file:interface/common.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "file:interface/types.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:interface/config.py:generate_ticket_config",
+      "target": "function:interface/config.py:_normalize_buyer_info",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/config.py:build_runtime_options",
+      "target": "function:interface/config.py:normalize_interval",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/config.py:build_runtime_options",
+      "target": "function:interface/config.py:normalize_non_negative_interval",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/config.py:build_runtime_options",
+      "target": "function:interface/config.py:normalize_positive_int",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/config.py:build_runtime_options",
+      "target": "function:interface/config.py:normalize_time_start",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/config.py:build_ticket_config_from_selection",
+      "target": "function:interface/config.py:generate_ticket_config",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/config.py:validate_config",
+      "target": "function:interface/config.py:generate_ticket_config",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/config.py",
+      "target": "file:tests/test_local_fanout_proxy_strategy.py",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_collect_payment_fields_from_event",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_collect_payment_fields_from_event",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_package_root",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_package_root",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_managed_runs_root",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_managed_runs_root",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_dump_json",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_dump_json",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_load_json",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_load_json",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_read_text_tail",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_read_text_tail",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_heartbeat_timeout_seconds",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_heartbeat_timeout_seconds",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_update_managed_status",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_update_managed_status",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_pid_is_running",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_pid_is_running",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_terminate_pid",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_terminate_pid",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_build_managed_failure_result",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_build_managed_failure_result",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_mark_managed_run_failed",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_mark_managed_run_failed",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_reconcile_managed_run",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_reconcile_managed_run",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_append_log",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_append_log",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_update_task",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_update_task",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_run_buy_task",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:_run_buy_task",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:start_buy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:start_buy",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:task_status",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:task_status",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:run_buy_sync",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:run_buy_sync",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:start_managed_buy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:start_managed_buy",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:managed_task_status",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:managed_task_status",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:cancel_managed_buy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:cancel_managed_buy",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:delete_managed_buy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "function:interface/execution.py:delete_managed_buy",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "file:interface/config.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "file:interface/types.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:interface/execution.py:_managed_runs_root",
+      "target": "function:interface/execution.py:_package_root",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:_update_managed_status",
+      "target": "function:interface/execution.py:_load_json",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:_update_managed_status",
+      "target": "function:interface/execution.py:_dump_json",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:_build_managed_failure_result",
+      "target": "function:interface/execution.py:_read_text_tail",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:_mark_managed_run_failed",
+      "target": "function:interface/execution.py:_update_managed_status",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:_mark_managed_run_failed",
+      "target": "function:interface/execution.py:_build_managed_failure_result",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:_mark_managed_run_failed",
+      "target": "function:interface/execution.py:_dump_json",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:_reconcile_managed_run",
+      "target": "function:interface/execution.py:_pid_is_running",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:_reconcile_managed_run",
+      "target": "function:interface/execution.py:_heartbeat_timeout_seconds",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:_reconcile_managed_run",
+      "target": "function:interface/execution.py:_mark_managed_run_failed",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:_reconcile_managed_run",
+      "target": "function:interface/execution.py:_load_json",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:_reconcile_managed_run",
+      "target": "function:interface/execution.py:_update_managed_status",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:_reconcile_managed_run",
+      "target": "function:interface/execution.py:_read_text_tail",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:_run_buy_task",
+      "target": "function:interface/execution.py:_update_task",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:_run_buy_task",
+      "target": "function:interface/execution.py:_append_log",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:_run_buy_task",
+      "target": "function:interface/execution.py:_collect_payment_fields_from_event",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:run_buy_sync",
+      "target": "function:interface/execution.py:_collect_payment_fields_from_event",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:start_managed_buy",
+      "target": "function:interface/execution.py:_managed_runs_root",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:start_managed_buy",
+      "target": "function:interface/execution.py:_dump_json",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:start_managed_buy",
+      "target": "function:interface/execution.py:_package_root",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:start_managed_buy",
+      "target": "function:interface/execution.py:_mark_managed_run_failed",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:managed_task_status",
+      "target": "function:interface/execution.py:_managed_runs_root",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:managed_task_status",
+      "target": "function:interface/execution.py:_reconcile_managed_run",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:managed_task_status",
+      "target": "function:interface/execution.py:_load_json",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:cancel_managed_buy",
+      "target": "function:interface/execution.py:_managed_runs_root",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:cancel_managed_buy",
+      "target": "function:interface/execution.py:_load_json",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:cancel_managed_buy",
+      "target": "function:interface/execution.py:_pid_is_running",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:cancel_managed_buy",
+      "target": "function:interface/execution.py:_terminate_pid",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:cancel_managed_buy",
+      "target": "function:interface/execution.py:_update_managed_status",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:cancel_managed_buy",
+      "target": "function:interface/execution.py:_dump_json",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:delete_managed_buy",
+      "target": "function:interface/execution.py:_managed_runs_root",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:delete_managed_buy",
+      "target": "function:interface/execution.py:_load_json",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:delete_managed_buy",
+      "target": "function:interface/execution.py:_pid_is_running",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/execution.py:delete_managed_buy",
+      "target": "function:interface/execution.py:cancel_managed_buy",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/execution.py",
+      "target": "file:tests/test_payment_result_fields.py",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:_normalize_new_project_payload",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:_normalize_new_project_payload",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:_fetch_project_payload_new",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:_fetch_project_payload_new",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:_fetch_project_payload_old",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:_fetch_project_payload_old",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:fetch_project_payload",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:fetch_project_payload",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:_build_ticket_option",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:_build_ticket_option",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:_merge_link_goods",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:_merge_link_goods",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:_fetch_ticket_options",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:_fetch_ticket_options",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:fetch_project_detail",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:fetch_project_detail",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:fetch_ticket_options",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:fetch_ticket_options",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:fetch_buyers",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:fetch_buyers",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:fetch_addresses",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:fetch_addresses",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:fetch_purchase_context",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "function:interface/project.py:fetch_purchase_context",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/search.py",
+      "target": "function:interface/search.py:search_tickets",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/search.py",
+      "target": "function:interface/search.py:search_tickets",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/search.py",
+      "target": "function:interface/search.py:format_ticket_search_results_text",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/search.py",
+      "target": "function:interface/search.py:format_ticket_search_results_text",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/project.py",
+      "target": "file:interface/common.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:interface/search.py",
+      "target": "file:interface/auth.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:interface/search.py",
+      "target": "file:interface/common.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:interface/project.py:_fetch_project_payload_new",
+      "target": "function:interface/project.py:_normalize_new_project_payload",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/project.py:fetch_project_payload",
+      "target": "function:interface/project.py:_fetch_project_payload_new",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/project.py:fetch_project_payload",
+      "target": "function:interface/project.py:_fetch_project_payload_old",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/project.py:_fetch_ticket_options",
+      "target": "function:interface/project.py:_merge_link_goods",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/project.py:_fetch_ticket_options",
+      "target": "function:interface/project.py:_build_ticket_option",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/project.py:fetch_project_detail",
+      "target": "function:interface/project.py:fetch_project_payload",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/project.py:fetch_ticket_options",
+      "target": "function:interface/project.py:fetch_project_payload",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/project.py:fetch_ticket_options",
+      "target": "function:interface/project.py:_fetch_ticket_options",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/project.py:fetch_buyers",
+      "target": "function:interface/project.py:fetch_project_payload",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/project.py:fetch_purchase_context",
+      "target": "function:interface/project.py:fetch_project_payload",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/project.py:fetch_purchase_context",
+      "target": "function:interface/project.py:_fetch_ticket_options",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/types.py",
+      "target": "class:interface/types.py:ValidationResult",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/types.py",
+      "target": "class:interface/types.py:ValidationResult",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/types.py",
+      "target": "class:interface/types.py:BuyTaskRecord",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/types.py",
+      "target": "class:interface/types.py:BuyTaskRecord",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/__init__.py",
+      "target": "file:tests/test_settings_ticket_selection.py",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_format_account_choice",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_format_account_choice",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_find_uid_from_choice",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_find_uid_from_choice",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_resolve_default_account_choice",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_resolve_default_account_choice",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_read_positive_int",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_read_positive_int",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_iter_project_dates",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_iter_project_dates",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_fetch_screens_by_date",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_fetch_screens_by_date",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_normalize_date_string",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_normalize_date_string",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_screen_matches_date",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_screen_matches_date",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_fetch_screens_by_date_with_fallback",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_fetch_screens_by_date_with_fallback",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_merge_screens",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_merge_screens",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:filename_filter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:filename_filter",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_format_price",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_format_price",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_render_ticket_info_html",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_render_ticket_info_html",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_empty_ticket_info_updates",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_empty_ticket_info_updates",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_has_invalid_index",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_has_invalid_index",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_get_active_account_uid",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_get_active_account_uid",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_reset_ticket_context",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_reset_ticket_context",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_format_ticket_option",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_format_ticket_option",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_resolve_project_input",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:_resolve_project_input",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:on_submit_ticket_id",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:on_submit_ticket_id",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:extract_id_from_url",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:extract_id_from_url",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:on_submit_all",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:on_submit_all",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:upload_file",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:upload_file",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:login_tab",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:login_tab",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:setting_tab",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "function:tab/settings.py:setting_tab",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "function:tests/test_local_fanout_proxy_strategy.py:test_task_proxy_list_includes_direct_when_enabled",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "function:tests/test_local_fanout_proxy_strategy.py:test_task_proxy_list_includes_direct_when_enabled",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "function:tests/test_local_fanout_proxy_strategy.py:test_task_proxy_list_excludes_direct_when_disabled",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "function:tests/test_local_fanout_proxy_strategy.py:test_task_proxy_list_excludes_direct_when_disabled",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "function:tests/test_local_fanout_proxy_strategy.py:test_task_proxy_list_can_require_configured_proxy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "function:tests/test_local_fanout_proxy_strategy.py:test_task_proxy_list_can_require_configured_proxy",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "function:tests/test_local_fanout_proxy_strategy.py:test_runtime_strategy_flows_into_buy_config",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "function:tests/test_local_fanout_proxy_strategy.py:test_runtime_strategy_flows_into_buy_config",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "function:tests/test_local_fanout_proxy_strategy.py:test_h2_client_constructor_uses_abstract_client_interface",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "function:tests/test_local_fanout_proxy_strategy.py:test_h2_client_constructor_uses_abstract_client_interface",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "function:tests/test_local_fanout_proxy_strategy.py:test_replace_proxy_pool_updates_h2_client_options",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "function:tests/test_local_fanout_proxy_strategy.py:test_replace_proxy_pool_updates_h2_client_options",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "function:tests/test_local_fanout_proxy_strategy.py:test_proxy_pool_fanout_builds_one_create_connection_per_proxy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "function:tests/test_local_fanout_proxy_strategy.py:test_proxy_pool_fanout_builds_one_create_connection_per_proxy",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "function:tests/test_local_fanout_proxy_strategy.py:test_proxy_pool_fanout_repeats_until_one_proxy_succeeds",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "function:tests/test_local_fanout_proxy_strategy.py:test_proxy_pool_fanout_repeats_until_one_proxy_succeeds",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "class:tests/test_local_fanout_proxy_strategy.py:FakeCookies",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "class:tests/test_local_fanout_proxy_strategy.py:FakeCookies",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "class:tests/test_local_fanout_proxy_strategy.py:FakeH2Client",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "class:tests/test_local_fanout_proxy_strategy.py:FakeH2Client",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "class:tests/test_local_fanout_proxy_strategy.py:FakeH2Connection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "class:tests/test_local_fanout_proxy_strategy.py:FakeH2Connection",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "file:interface/common.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "file:interface/project.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "file:util/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "file:util/request/BiliRequest.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "file:util/request/CookieManager.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "file:app_cmd/config/BuyConfig.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "file:interface/config.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "file:tab/go.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "file:util/h2client/h2connection.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "file:util/h2client/ja_h2_client.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_local_fanout_proxy_strategy.py",
+      "target": "file:util/request/BiliRequest.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:tab/settings.py:_resolve_default_account_choice",
+      "target": "function:tab/settings.py:_find_uid_from_choice",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:_screen_matches_date",
+      "target": "function:tab/settings.py:_normalize_date_string",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:_fetch_screens_by_date_with_fallback",
+      "target": "function:tab/settings.py:_fetch_screens_by_date",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:_fetch_screens_by_date_with_fallback",
+      "target": "function:tab/settings.py:_screen_matches_date",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:_merge_screens",
+      "target": "function:tab/settings.py:_read_positive_int",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:_format_ticket_option",
+      "target": "function:tab/settings.py:_format_price",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:_resolve_project_input",
+      "target": "function:tab/settings.py:extract_id_from_url",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:on_submit_ticket_id",
+      "target": "function:tab/settings.py:_reset_ticket_context",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:on_submit_ticket_id",
+      "target": "function:tab/settings.py:_resolve_project_input",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:on_submit_ticket_id",
+      "target": "function:tab/settings.py:_iter_project_dates",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:on_submit_ticket_id",
+      "target": "function:tab/settings.py:_fetch_screens_by_date_with_fallback",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:on_submit_ticket_id",
+      "target": "function:tab/settings.py:_merge_screens",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:on_submit_ticket_id",
+      "target": "function:tab/settings.py:_format_ticket_option",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:on_submit_ticket_id",
+      "target": "function:tab/settings.py:_get_active_account_uid",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:on_submit_ticket_id",
+      "target": "function:tab/settings.py:_render_ticket_info_html",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:on_submit_ticket_id",
+      "target": "function:tab/settings.py:_empty_ticket_info_updates",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:on_submit_all",
+      "target": "function:tab/settings.py:_get_active_account_uid",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:on_submit_all",
+      "target": "function:tab/settings.py:_has_invalid_index",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:on_submit_all",
+      "target": "function:tab/settings.py:_resolve_project_input",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:on_submit_all",
+      "target": "function:tab/settings.py:filename_filter",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:upload_file",
+      "target": "function:tab/settings.py:_reset_ticket_context",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:upload_file",
+      "target": "function:tab/settings.py:_format_account_choice",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "file:tests/test_login_account_defaults.py",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:tab/settings.py",
+      "target": "file:tests/test_settings_ticket_selection.py",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:tests/test_login_account_defaults.py",
+      "target": "function:tests/test_login_account_defaults.py:test_resolve_default_account_choice_prefers_active_uid",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_login_account_defaults.py",
+      "target": "function:tests/test_login_account_defaults.py:test_resolve_default_account_choice_prefers_active_uid",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_login_account_defaults.py",
+      "target": "function:tests/test_login_account_defaults.py:test_resolve_default_account_choice_falls_back_to_first_choice",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_login_account_defaults.py",
+      "target": "function:tests/test_login_account_defaults.py:test_resolve_default_account_choice_falls_back_to_first_choice",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_payment_result_fields.py",
+      "target": "function:tests/test_payment_result_fields.py:test_build_payment_result_contains_order_and_code_urls",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_payment_result_fields.py",
+      "target": "function:tests/test_payment_result_fields.py:test_build_payment_result_contains_order_and_code_urls",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_payment_result_fields.py",
+      "target": "function:tests/test_payment_result_fields.py:test_collect_payment_fields_from_event_reads_new_fields",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_payment_result_fields.py",
+      "target": "function:tests/test_payment_result_fields.py:test_collect_payment_fields_from_event_reads_new_fields",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_payment_result_fields.py",
+      "target": "class:tests/test_payment_result_fields.py:_DummyRequest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_payment_result_fields.py",
+      "target": "class:tests/test_payment_result_fields.py:_DummyRequest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_login_account_defaults.py",
+      "target": "file:tab/settings.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_payment_result_fields.py",
+      "target": "file:interface/execution.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_payment_result_fields.py",
+      "target": "file:task/buy_helpers.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_payment_result_fields.py",
+      "target": "file:task/buy_types.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_settings_ticket_selection.py",
+      "target": "function:tests/test_settings_ticket_selection.py:_project_payload",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_settings_ticket_selection.py",
+      "target": "function:tests/test_settings_ticket_selection.py:_project_payload",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_settings_ticket_selection.py",
+      "target": "function:tests/test_settings_ticket_selection.py:test_submit_ticket_id_resets_stale_selection_values",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_settings_ticket_selection.py",
+      "target": "function:tests/test_settings_ticket_selection.py:test_submit_ticket_id_resets_stale_selection_values",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_settings_ticket_selection.py",
+      "target": "function:tests/test_settings_ticket_selection.py:test_has_invalid_index_detects_stale_buyer_selection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_settings_ticket_selection.py",
+      "target": "function:tests/test_settings_ticket_selection.py:test_has_invalid_index_detects_stale_buyer_selection",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_settings_ticket_selection.py",
+      "target": "function:tests/test_settings_ticket_selection.py:test_submit_all_rejects_ticket_context_from_previous_account",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_settings_ticket_selection.py",
+      "target": "function:tests/test_settings_ticket_selection.py:test_submit_all_rejects_ticket_context_from_previous_account",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_settings_ticket_selection.py",
+      "target": "class:tests/test_settings_ticket_selection.py:_JsonResponse",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_settings_ticket_selection.py",
+      "target": "class:tests/test_settings_ticket_selection.py:_JsonResponse",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_settings_ticket_selection.py",
+      "target": "class:tests/test_settings_ticket_selection.py:_FakeRequest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_settings_ticket_selection.py",
+      "target": "class:tests/test_settings_ticket_selection.py:_FakeRequest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_settings_ticket_selection.py",
+      "target": "class:tests/test_settings_ticket_selection.py:_FakeCookieManager",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_settings_ticket_selection.py",
+      "target": "class:tests/test_settings_ticket_selection.py:_FakeCookieManager",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_settings_ticket_selection.py",
+      "target": "class:tests/test_settings_ticket_selection.py:_FakeAccountRequest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_settings_ticket_selection.py",
+      "target": "class:tests/test_settings_ticket_selection.py:_FakeAccountRequest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_settings_ticket_selection.py",
+      "target": "file:tab/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_settings_ticket_selection.py",
+      "target": "file:tab/settings.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:tests/test_settings_ticket_selection.py:test_submit_ticket_id_resets_stale_selection_values",
+      "target": "function:tests/test_settings_ticket_selection.py:_project_payload",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "function:util/h2client/h2connection.py:format_authority",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "function:util/h2client/h2connection.py:format_authority",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "function:util/h2client/h2connection.py:verify_client_hello_ja",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "function:util/h2client/h2connection.py:verify_client_hello_ja",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "function:util/h2client/h2connection.py:assert_client_hello_ja",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "function:util/h2client/h2connection.py:assert_client_hello_ja",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "function:util/h2client/h2connection.py:_coerce_body",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "function:util/h2client/h2connection.py:_coerce_body",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "function:util/h2client/h2connection.py:_body_for_log",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "function:util/h2client/h2connection.py:_body_for_log",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "function:util/h2client/h2connection.py:_header_value",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "function:util/h2client/h2connection.py:_header_value",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "function:util/h2client/h2connection.py:_normalize_header_items",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "function:util/h2client/h2connection.py:_normalize_header_items",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "function:util/h2client/h2connection.py:_parse_request_target",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "function:util/h2client/h2connection.py:_parse_request_target",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "function:util/h2client/h2connection.py:build_request_headers",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "function:util/h2client/h2connection.py:build_request_headers",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "class:util/h2client/h2connection.py:H2Response",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "class:util/h2client/h2connection.py:H2Response",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "class:util/h2client/h2connection.py:RequestTarget",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "class:util/h2client/h2connection.py:RequestTarget",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "class:util/h2client/h2connection.py:JAMatch",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "class:util/h2client/h2connection.py:JAMatch",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "class:util/h2client/h2connection.py:H2ConnectionConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "class:util/h2client/h2connection.py:H2ConnectionConfig",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "class:util/h2client/h2connection.py:H2Connection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "class:util/h2client/h2connection.py:H2Connection",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/h2connection.py:assert_client_hello_ja",
+      "target": "function:util/h2client/h2connection.py:verify_client_hello_ja",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/h2connection.py:_parse_request_target",
+      "target": "function:util/h2client/h2connection.py:format_authority",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/h2connection.py:build_request_headers",
+      "target": "function:util/h2client/h2connection.py:_parse_request_target",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/h2connection.py:build_request_headers",
+      "target": "function:util/h2client/h2connection.py:_normalize_header_items",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/h2connection.py",
+      "target": "file:tests/test_local_fanout_proxy_strategy.py",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_normalize_proxy_list",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_normalize_proxy_list",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_dedupe_sources",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_dedupe_sources",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_append_params",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_append_params",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_json_body",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_json_body",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_form_body",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_form_body",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_header_mapping",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_header_mapping",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_set_default_header",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_set_default_header",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_timeout_seconds",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_timeout_seconds",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_content_length",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_content_length",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_response_errno",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_response_errno",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_is_create_success_response",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "function:util/h2client/ja_h2_client.py:_is_create_success_response",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "class:util/h2client/ja_h2_client.py:SourceAddress",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "class:util/h2client/ja_h2_client.py:SourceAddress",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "class:util/h2client/ja_h2_client.py:ConnectionSlot",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "class:util/h2client/ja_h2_client.py:ConnectionSlot",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "class:util/h2client/ja_h2_client.py:FanoutOutcome",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "class:util/h2client/ja_h2_client.py:FanoutOutcome",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "class:util/h2client/ja_h2_client.py:HealthcheckOutcome",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "class:util/h2client/ja_h2_client.py:HealthcheckOutcome",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "class:util/h2client/ja_h2_client.py:_SourcePoolJA3H2Client",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "class:util/h2client/ja_h2_client.py:_SourcePoolJA3H2Client",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "class:util/h2client/ja_h2_client.py:_CreateV2FanoutJA3H2Client",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "class:util/h2client/ja_h2_client.py:_CreateV2FanoutJA3H2Client",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "class:util/h2client/ja_h2_client.py:ProxyPoolCreateV2FanoutJA3H2Client",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "class:util/h2client/ja_h2_client.py:ProxyPoolCreateV2FanoutJA3H2Client",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/ja_h2_client.py:_is_create_success_response",
+      "target": "function:util/h2client/ja_h2_client.py:_response_errno",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/ja_h2_client.py",
+      "target": "file:tests/test_local_fanout_proxy_strategy.py",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:app_cmd/buy.py",
+      "target": "file:app_cmd/cli_args.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:app_cmd/buy.py",
+      "target": "file:tab/log.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:app_cmd/cli_args.py",
+      "target": "file:app_cmd/config/BuyConfig.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:app_cmd/config/BuyConfig.py",
+      "target": "file:app_cmd/config/ConfigBasic.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:app_cmd/config/BuyConfig.py",
+      "target": "file:app_cmd/config/NotifierConfig.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:app_cmd/config/BuyConfig.py",
+      "target": "file:util/Constant.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:app_cmd/config/NotifierConfig.py",
+      "target": "file:app_cmd/config/ConfigBasic.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:app_cmd/ticker.py",
+      "target": "file:app_cmd/cli_args.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:app_cmd/ticker.py",
+      "target": "file:app_version.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:app_cmd/ticker.py",
+      "target": "file:util/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:main.py",
+      "target": "file:app_cmd/buy.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:main.py",
+      "target": "file:app_cmd/cli_args.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:main.py",
+      "target": "file:app_cmd/ticker.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tab/config.py",
+      "target": "file:app_cmd/config/BuyConfig.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tab/config.py",
+      "target": "file:util/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tab/config.py",
+      "target": "file:util/Constant.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "file:app_cmd/config/BuyConfig.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "file:tab/log.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "file:task/buy.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "file:util/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "file:util/Constant.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "file:util/proxy/ProxyManager.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "file:util/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "file:util/log/LogWeb.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "file:app_update.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "file:app_version.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "file:util/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "file:util/Constant.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/__init__.py",
+      "target": "file:app_cmd/config/BuyConfig.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/__init__.py",
+      "target": "file:task/buy_types.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/__init__.py",
+      "target": "file:task/buy.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "file:app_cmd/config/NotifierConfig.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "file:cptoken/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "file:task/buy_types.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "file:util/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "file:util/Constant.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "file:util/ErrorCodes.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "file:util/notifer/Notifier.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "file:util/proxy/ProxyBackoff.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "file:util/request/BiliRequest.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "file:util/request/TokenUtil.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "file:app_cmd/config/BuyConfig.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "file:cptoken/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "file:interface/project.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "file:task/buy_helpers.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "file:task/buy_types.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "file:util/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "file:util/ErrorCodes.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "file:util/notifer/Notifier.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "file:util/notifer/RandomMessages.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "file:util/proxy/ProxyApiProvider.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "file:util/proxy/ProxyBackoff.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "file:util/proxy/ProxyManager.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "file:util/request/BiliRequest.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "file:util/request/exceptions/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_app_update.py",
+      "target": "file:app_update.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_bili_request_h2_recovery.py",
+      "target": "file:util/request/BiliRequest.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_bili_request_h2_recovery.py",
+      "target": "file:util/request/exceptions/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_bili_request_maintenance.py",
+      "target": "file:util/request/BiliRequest.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_bili_request_rate_limit.py",
+      "target": "file:util/request/BiliRequest.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_bili_request_rate_limit.py",
+      "target": "file:util/request/exceptions/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_buy_prepare_token.py",
+      "target": "file:task/buy.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_buy_refresh_count.py",
+      "target": "file:app_cmd/config/BuyConfig.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_buy_reprepare_reason.py",
+      "target": "file:task/buy.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_go_ticket_preview.py",
+      "target": "file:tab/go.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_notifier_join_all.py",
+      "target": "file:util/notifer/Notifier.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "file:util/proxy/ProxyApiProvider.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_task_log_controls.py",
+      "target": "file:tab/log.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_task_log_controls.py",
+      "target": "file:util/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:tests/test_time_util.py",
+      "target": "file:util/TimeUtil.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "file:util/ErrorCodes.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "file:util/log/LogConfig.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "file:util/request/BiliRequest.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "file:util/Storage/KVDatabase.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "file:util/TimeUtil.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/log/LogWeb.py",
+      "target": "file:util/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/log/LogWeb.py",
+      "target": "file:util/Constant.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/notifer/AudioUtil.py",
+      "target": "file:util/notifer/Notifier.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/notifer/BarkUtil.py",
+      "target": "file:util/notifer/Notifier.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/notifer/MeoWUtil.py",
+      "target": "file:util/Constant.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/notifer/MeoWUtil.py",
+      "target": "file:util/notifer/Notifier.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/notifer/Notifier.py",
+      "target": "file:app_cmd/config/NotifierConfig.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/notifer/NtfyUtil.py",
+      "target": "file:util/notifer/Notifier.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/notifer/RandomMessages.py",
+      "target": "file:util/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/notifer/ServerChanUtil.py",
+      "target": "file:util/notifer/Notifier.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/proxy/ProxyManager.py",
+      "target": "file:util/proxy/ProxyState.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/proxy/ProxyTester.py",
+      "target": "file:util/proxy/ProxyManager.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/proxy/PushPlusUtil.py",
+      "target": "file:util/notifer/Notifier.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/request/BiliRequest.py",
+      "target": "file:util/Constant.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/request/BiliRequest.py",
+      "target": "file:util/h2client/abstract_h2_client.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/request/BiliRequest.py",
+      "target": "file:util/proxy/ProxyManager.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/request/BiliRequest.py",
+      "target": "file:util/request/BrowerState.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/request/BiliRequest.py",
+      "target": "file:util/request/CookieManager.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/request/BiliRequest.py",
+      "target": "file:util/request/exceptions/__init__.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/request/CookieManager.py",
+      "target": "file:util/Storage/KVDatabase.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/request/exceptions/__init__.py",
+      "target": "file:util/request/exceptions/connection.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:util/request/exceptions/__init__.py",
+      "target": "file:util/request/exceptions/rate_limit.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "document:README.md",
+      "target": "file:main.py",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:README.md",
+      "target": "file:app_cmd/buy.py",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:pyproject.toml",
+      "target": "file:main.py",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:pyproject.toml",
+      "target": "file:app_cmd/buy.py",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "service:Dockerfile",
+      "target": "file:main.py",
+      "type": "deploys",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "service:Dockerfile",
+      "target": "file:app_cmd/buy.py",
+      "type": "deploys",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:assets/updater/update.sh",
+      "target": "function:assets/updater/update.sh:resolve_url",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:assets/updater/update.sh",
+      "target": "function:assets/updater/update.sh:http_get",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:assets/updater/update.sh",
+      "target": "function:assets/updater/update.sh:request_release_json",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:assets/updater/update.sh",
+      "target": "function:assets/updater/update.sh:find_package_binary",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/managed_runner.py",
+      "target": "function:interface/managed_runner.py:_load_json",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/managed_runner.py",
+      "target": "function:interface/managed_runner.py:_load_json",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/managed_runner.py",
+      "target": "function:interface/managed_runner.py:_dump_json",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/managed_runner.py",
+      "target": "function:interface/managed_runner.py:_dump_json",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/managed_runner.py",
+      "target": "function:interface/managed_runner.py:_append_log",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/managed_runner.py",
+      "target": "function:interface/managed_runner.py:_append_log",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/managed_runner.py",
+      "target": "function:interface/managed_runner.py:_heartbeat_loop",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/managed_runner.py",
+      "target": "function:interface/managed_runner.py:_heartbeat_loop",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:interface/managed_runner.py",
+      "target": "function:interface/managed_runner.py:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:interface/managed_runner.py",
+      "target": "function:interface/managed_runner.py:main",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/problems.py",
+      "target": "function:tab/problems.py:problems_tab",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/problems.py",
+      "target": "function:tab/problems.py:problems_tab",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_buy_time_sync.py",
+      "target": "function:tests/test_buy_time_sync.py:test_prepare_create_request_uses_calibrated_timestamp",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_buy_time_sync.py",
+      "target": "function:tests/test_buy_time_sync.py:test_prepare_create_request_uses_calibrated_timestamp",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_buy_time_sync.py",
+      "target": "class:tests/test_buy_time_sync.py:_FakeTicketState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_buy_time_sync.py",
+      "target": "class:tests/test_buy_time_sync.py:_FakeTicketState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_buy_time_sync.py",
+      "target": "class:tests/test_buy_time_sync.py:_FakeCreateState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_buy_time_sync.py",
+      "target": "class:tests/test_buy_time_sync.py:_FakeCreateState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_buy_time_sync.py",
+      "target": "class:tests/test_buy_time_sync.py:_FakeTimeService",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_buy_time_sync.py",
+      "target": "class:tests/test_buy_time_sync.py:_FakeTimeService",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:u8",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:u8",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:u16",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:u16",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:u24",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:u24",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:vec_u8",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:vec_u8",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:vec_u16",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:vec_u16",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:tls_ext",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:tls_ext",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:build_extension_body",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:build_extension_body",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:build_extensions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:build_extensions",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:build_client_hello",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:build_client_hello",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:md5_hex",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:md5_hex",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:sha256_12",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:sha256_12",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:tls_version_for_ja4",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:tls_version_for_ja4",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:is_domain_name",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:is_domain_name",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:parse_client_hello_record",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:parse_client_hello_record",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:fingerprints_from_client_hello",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:fingerprints_from_client_hello",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:read_targets_from_file",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:read_targets_from_file",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:hash_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:hash_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:hmac_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:hmac_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:hkdf_extract",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:hkdf_extract",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:hkdf_expand",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:hkdf_expand",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:hkdf_expand_label",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:hkdf_expand_label",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:derive_secret",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:derive_secret",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:xor_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:xor_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:recvall",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:recvall",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:read_tls_record",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:read_tls_record",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:raise_for_alert",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:raise_for_alert",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:parse_server_hello",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:parse_server_hello",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:parse_encrypted_extensions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:parse_encrypted_extensions",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:pop_first_handshake_message",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:pop_first_handshake_message",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:connect_tcp",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:connect_tcp",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:connect_tcp_via_proxy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:connect_tcp_via_proxy",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:send_client_hello_only",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:send_client_hello_only",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:print_fingerprint_report",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:print_fingerprint_report",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:parse_args",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:parse_args",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "function:util/h2client/client_ja.py:main",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "class:util/h2client/client_ja.py:ClientHelloProfile",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "class:util/h2client/client_ja.py:ClientHelloProfile",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "class:util/h2client/client_ja.py:BuiltClientHello",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "class:util/h2client/client_ja.py:BuiltClientHello",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "class:util/h2client/client_ja.py:Fingerprints",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "class:util/h2client/client_ja.py:Fingerprints",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "class:util/h2client/client_ja.py:CipherSuiteSpec",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "class:util/h2client/client_ja.py:CipherSuiteSpec",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "class:util/h2client/client_ja.py:TLSAlert",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "class:util/h2client/client_ja.py:TLSAlert",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "class:util/h2client/client_ja.py:HandshakeBuffer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "class:util/h2client/client_ja.py:HandshakeBuffer",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "class:util/h2client/client_ja.py:TrafficCipher",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "class:util/h2client/client_ja.py:TrafficCipher",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "class:util/h2client/client_ja.py:ServerHello",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "class:util/h2client/client_ja.py:ServerHello",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "class:util/h2client/client_ja.py:TLSHandshakeResult",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "class:util/h2client/client_ja.py:TLSHandshakeResult",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "class:util/h2client/client_ja.py:TLS13Connection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/client_ja.py",
+      "target": "class:util/h2client/client_ja.py:TLS13Connection",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/local_sources.py",
+      "target": "function:util/h2client/local_sources.py:_is_usable_source_ip",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/local_sources.py",
+      "target": "function:util/h2client/local_sources.py:_is_usable_source_ip",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/local_sources.py",
+      "target": "function:util/h2client/local_sources.py:_source_address",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/local_sources.py",
+      "target": "function:util/h2client/local_sources.py:_source_address",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/local_sources.py",
+      "target": "function:util/h2client/local_sources.py:_dedupe_sources",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/local_sources.py",
+      "target": "function:util/h2client/local_sources.py:_dedupe_sources",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/local_sources.py",
+      "target": "function:util/h2client/local_sources.py:_discover_sources_with_powershell",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/local_sources.py",
+      "target": "function:util/h2client/local_sources.py:_discover_sources_with_powershell",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/local_sources.py",
+      "target": "function:util/h2client/local_sources.py:_discover_sources_with_socket",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/local_sources.py",
+      "target": "function:util/h2client/local_sources.py:_discover_sources_with_socket",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/local_sources.py",
+      "target": "function:util/h2client/local_sources.py:discover_interface_source_ips",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/local_sources.py",
+      "target": "function:util/h2client/local_sources.py:discover_interface_source_ips",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "function:util/log/TerminalRenderer.py:_extract_message_meta",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "function:util/log/TerminalRenderer.py:_extract_message_meta",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "function:util/log/TerminalRenderer.py:_make_log_item",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "function:util/log/TerminalRenderer.py:_make_log_item",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "function:util/log/TerminalRenderer.py:_can_merge_log_item",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "function:util/log/TerminalRenderer.py:_can_merge_log_item",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "function:util/log/TerminalRenderer.py:_merge_log_item",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "function:util/log/TerminalRenderer.py:_merge_log_item",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "function:util/log/TerminalRenderer.py:create_terminal_renderer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "function:util/log/TerminalRenderer.py:create_terminal_renderer",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "function:util/log/TerminalRenderer.py:render_message_stream",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "function:util/log/TerminalRenderer.py:render_message_stream",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "class:util/log/TerminalRenderer.py:TerminalRenderContext",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "class:util/log/TerminalRenderer.py:TerminalRenderContext",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "class:util/log/TerminalRenderer.py:TerminalViewState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "class:util/log/TerminalRenderer.py:TerminalViewState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "class:util/log/TerminalRenderer.py:LogItem",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "class:util/log/TerminalRenderer.py:LogItem",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "class:util/log/TerminalRenderer.py:BaseTerminalRenderer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "class:util/log/TerminalRenderer.py:BaseTerminalRenderer",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "class:util/log/TerminalRenderer.py:PlainTerminalRenderer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "class:util/log/TerminalRenderer.py:PlainTerminalRenderer",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "class:util/log/TerminalRenderer.py:TextualTerminalRenderer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/log/TerminalRenderer.py",
+      "target": "class:util/log/TerminalRenderer.py:TextualTerminalRenderer",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/Storage/CleanupUtil.py",
+      "target": "function:util/Storage/CleanupUtil.py:_trim_old_paths",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/Storage/CleanupUtil.py",
+      "target": "function:util/Storage/CleanupUtil.py:_trim_old_paths",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/Storage/CleanupUtil.py",
+      "target": "function:util/Storage/CleanupUtil.py:_remove_path",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/Storage/CleanupUtil.py",
+      "target": "function:util/Storage/CleanupUtil.py:_remove_path",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/Storage/CleanupUtil.py",
+      "target": "function:util/Storage/CleanupUtil.py:cleanup_runtime_artifacts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/Storage/CleanupUtil.py",
+      "target": "function:util/Storage/CleanupUtil.py:cleanup_runtime_artifacts",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_cmd/config/BuyConfig.py",
+      "target": "class:app_cmd/config/BuyConfig.py:BuyConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_cmd/config/BuyConfig.py",
+      "target": "class:app_cmd/config/BuyConfig.py:BuyConfig",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_cmd/config/ConfigBasic.py",
+      "target": "function:app_cmd/config/ConfigBasic.py:str_to_bool",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_cmd/config/ConfigBasic.py",
+      "target": "function:app_cmd/config/ConfigBasic.py:str_to_bool",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_cmd/config/ConfigBasic.py",
+      "target": "function:app_cmd/config/ConfigBasic.py:normalize_log_level",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_cmd/config/ConfigBasic.py",
+      "target": "function:app_cmd/config/ConfigBasic.py:normalize_log_level",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_cmd/config/ConfigBasic.py",
+      "target": "function:app_cmd/config/ConfigBasic.py:config_field",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_cmd/config/ConfigBasic.py",
+      "target": "function:app_cmd/config/ConfigBasic.py:config_field",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_cmd/config/ConfigBasic.py",
+      "target": "function:app_cmd/config/ConfigBasic.py:nested_config_field",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_cmd/config/ConfigBasic.py",
+      "target": "function:app_cmd/config/ConfigBasic.py:nested_config_field",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_cmd/config/ConfigBasic.py",
+      "target": "class:app_cmd/config/ConfigBasic.py:BasicConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_cmd/config/ConfigBasic.py",
+      "target": "class:app_cmd/config/ConfigBasic.py:BasicConfig",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_cmd/config/NotifierConfig.py",
+      "target": "class:app_cmd/config/NotifierConfig.py:NotifierConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_cmd/config/NotifierConfig.py",
+      "target": "class:app_cmd/config/NotifierConfig.py:NotifierConfig",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/config.py",
+      "target": "function:tab/config.py:go_settings_tab",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/config.py",
+      "target": "function:tab/config.py:go_settings_tab",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_buy_refresh_count.py",
+      "target": "function:tests/test_buy_refresh_count.py:_make_scheduler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_buy_refresh_count.py",
+      "target": "function:tests/test_buy_refresh_count.py:_make_scheduler",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_buy_refresh_count.py",
+      "target": "function:tests/test_buy_refresh_count.py:_config",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_buy_refresh_count.py",
+      "target": "function:tests/test_buy_refresh_count.py:_config",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_buy_refresh_count.py",
+      "target": "function:tests/test_buy_refresh_count.py:test_trigger_after_target_count_then_resets",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_buy_refresh_count.py",
+      "target": "function:tests/test_buy_refresh_count.py:test_trigger_after_target_count_then_resets",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_buy_refresh_count.py",
+      "target": "function:tests/test_buy_refresh_count.py:test_fetch_not_concurrent_with_create",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_buy_refresh_count.py",
+      "target": "function:tests/test_buy_refresh_count.py:test_fetch_not_concurrent_with_create",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_buy_refresh_count.py",
+      "target": "function:tests/test_buy_refresh_count.py:test_disabled_when_max_zero",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_buy_refresh_count.py",
+      "target": "function:tests/test_buy_refresh_count.py:test_disabled_when_max_zero",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_buy_refresh_count.py",
+      "target": "function:tests/test_buy_refresh_count.py:test_disabled_when_min_greater_than_max",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_buy_refresh_count.py",
+      "target": "function:tests/test_buy_refresh_count.py:test_disabled_when_min_greater_than_max",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_buy_refresh_count.py",
+      "target": "function:tests/test_buy_refresh_count.py:test_100001_resets_counter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_buy_refresh_count.py",
+      "target": "function:tests/test_buy_refresh_count.py:test_100001_resets_counter",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_buy_refresh_count.py",
+      "target": "function:tests/test_buy_refresh_count.py:test_default_config_values",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_buy_refresh_count.py",
+      "target": "function:tests/test_buy_refresh_count.py:test_default_config_values",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_notifier_join_all.py",
+      "target": "function:tests/test_notifier_join_all.py:_make_manager",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_notifier_join_all.py",
+      "target": "function:tests/test_notifier_join_all.py:_make_manager",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_notifier_join_all.py",
+      "target": "function:tests/test_notifier_join_all.py:test_join_all_waits_for_push_to_complete",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_notifier_join_all.py",
+      "target": "function:tests/test_notifier_join_all.py:test_join_all_waits_for_push_to_complete",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_notifier_join_all.py",
+      "target": "function:tests/test_notifier_join_all.py:test_join_all_blocks_until_thread_finishes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_notifier_join_all.py",
+      "target": "function:tests/test_notifier_join_all.py:test_join_all_blocks_until_thread_finishes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_notifier_join_all.py",
+      "target": "function:tests/test_notifier_join_all.py:test_join_all_timeout_does_not_block_forever",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_notifier_join_all.py",
+      "target": "function:tests/test_notifier_join_all.py:test_join_all_timeout_does_not_block_forever",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_notifier_join_all.py",
+      "target": "function:tests/test_notifier_join_all.py:test_join_all_no_notifiers_returns_immediately",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_notifier_join_all.py",
+      "target": "function:tests/test_notifier_join_all.py:test_join_all_no_notifiers_returns_immediately",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_notifier_join_all.py",
+      "target": "class:tests/test_notifier_join_all.py:_FakeNotifier",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_notifier_join_all.py",
+      "target": "class:tests/test_notifier_join_all.py:_FakeNotifier",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/notifer/AudioUtil.py",
+      "target": "class:util/notifer/AudioUtil.py:AudioNotifier",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/notifer/AudioUtil.py",
+      "target": "class:util/notifer/AudioUtil.py:AudioNotifier",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/notifer/BarkUtil.py",
+      "target": "class:util/notifer/BarkUtil.py:BarkNotifier",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/notifer/BarkUtil.py",
+      "target": "class:util/notifer/BarkUtil.py:BarkNotifier",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/notifer/MeoWUtil.py",
+      "target": "class:util/notifer/MeoWUtil.py:MeoWNotifier",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/notifer/MeoWUtil.py",
+      "target": "class:util/notifer/MeoWUtil.py:MeoWNotifier",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/notifer/Notifier.py",
+      "target": "class:util/notifer/Notifier.py:NotifierBase",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/notifer/Notifier.py",
+      "target": "class:util/notifer/Notifier.py:NotifierBase",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/notifer/Notifier.py",
+      "target": "class:util/notifer/Notifier.py:NotifierManager",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/notifer/Notifier.py",
+      "target": "class:util/notifer/Notifier.py:NotifierManager",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/notifer/NtfyUtil.py",
+      "target": "function:util/notifer/NtfyUtil.py:send_message",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/notifer/NtfyUtil.py",
+      "target": "function:util/notifer/NtfyUtil.py:send_message",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/notifer/NtfyUtil.py",
+      "target": "function:util/notifer/NtfyUtil.py:send_repeat_message",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/notifer/NtfyUtil.py",
+      "target": "function:util/notifer/NtfyUtil.py:send_repeat_message",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/notifer/NtfyUtil.py",
+      "target": "function:util/notifer/NtfyUtil.py:stop_notification",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/notifer/NtfyUtil.py",
+      "target": "function:util/notifer/NtfyUtil.py:stop_notification",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/notifer/NtfyUtil.py",
+      "target": "function:util/notifer/NtfyUtil.py:test_connection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/notifer/NtfyUtil.py",
+      "target": "function:util/notifer/NtfyUtil.py:test_connection",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/notifer/NtfyUtil.py",
+      "target": "class:util/notifer/NtfyUtil.py:RepeatedNotifier",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/notifer/NtfyUtil.py",
+      "target": "class:util/notifer/NtfyUtil.py:RepeatedNotifier",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/notifer/NtfyUtil.py",
+      "target": "class:util/notifer/NtfyUtil.py:NtfyNotifier",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/notifer/NtfyUtil.py",
+      "target": "class:util/notifer/NtfyUtil.py:NtfyNotifier",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/notifer/ServerChanUtil.py",
+      "target": "class:util/notifer/ServerChanUtil.py:ServerChanTurboNotifier",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/notifer/ServerChanUtil.py",
+      "target": "class:util/notifer/ServerChanUtil.py:ServerChanTurboNotifier",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/notifer/ServerChanUtil.py",
+      "target": "class:util/notifer/ServerChanUtil.py:ServerChan3Notifier",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/notifer/ServerChanUtil.py",
+      "target": "class:util/notifer/ServerChanUtil.py:ServerChan3Notifier",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/proxy/PushPlusUtil.py",
+      "target": "class:util/proxy/PushPlusUtil.py:PushPlusNotifier",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/proxy/PushPlusUtil.py",
+      "target": "class:util/proxy/PushPlusUtil.py:PushPlusNotifier",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_bili_request_h2_recovery.py",
+      "target": "function:tests/test_bili_request_h2_recovery.py:test_request_retries_once_after_h2_local_protocol_error",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_bili_request_h2_recovery.py",
+      "target": "function:tests/test_bili_request_h2_recovery.py:test_request_retries_once_after_h2_local_protocol_error",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_bili_request_h2_recovery.py",
+      "target": "function:tests/test_bili_request_h2_recovery.py:test_request_raises_connection_error_after_second_h2_local_protocol_error",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_bili_request_h2_recovery.py",
+      "target": "function:tests/test_bili_request_h2_recovery.py:test_request_raises_connection_error_after_second_h2_local_protocol_error",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_bili_request_h2_recovery.py",
+      "target": "function:tests/test_bili_request_h2_recovery.py:test_request_raises_connection_error_after_second_read_timeout",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_bili_request_h2_recovery.py",
+      "target": "function:tests/test_bili_request_h2_recovery.py:test_request_raises_connection_error_after_second_read_timeout",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_bili_request_maintenance.py",
+      "target": "function:tests/test_bili_request_maintenance.py:test_handle_100001_calls_registered_handler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_bili_request_maintenance.py",
+      "target": "function:tests/test_bili_request_maintenance.py:test_handle_100001_calls_registered_handler",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_bili_request_maintenance.py",
+      "target": "function:tests/test_bili_request_maintenance.py:test_handle_100001_ignores_other_errno",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_bili_request_maintenance.py",
+      "target": "function:tests/test_bili_request_maintenance.py:test_handle_100001_ignores_other_errno",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_bili_request_rate_limit.py",
+      "target": "function:tests/test_bili_request_rate_limit.py:test_request_raises_rate_limit_error",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_bili_request_rate_limit.py",
+      "target": "function:tests/test_bili_request_rate_limit.py:test_request_raises_rate_limit_error",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/Storage/KVDatabase.py",
+      "target": "function:util/Storage/KVDatabase.py:_ensure_valid_tinydb_file",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/Storage/KVDatabase.py",
+      "target": "function:util/Storage/KVDatabase.py:_ensure_valid_tinydb_file",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/Storage/KVDatabase.py",
+      "target": "class:util/Storage/KVDatabase.py:KVDatabase",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/Storage/KVDatabase.py",
+      "target": "class:util/Storage/KVDatabase.py:KVDatabase",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/abstract_h2_client.py",
+      "target": "class:util/h2client/abstract_h2_client.py:H2Headers",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/abstract_h2_client.py",
+      "target": "class:util/h2client/abstract_h2_client.py:H2Headers",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/abstract_h2_client.py",
+      "target": "class:util/h2client/abstract_h2_client.py:H2Cookies",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/abstract_h2_client.py",
+      "target": "class:util/h2client/abstract_h2_client.py:H2Cookies",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/abstract_h2_client.py",
+      "target": "class:util/h2client/abstract_h2_client.py:H2Response",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/abstract_h2_client.py",
+      "target": "class:util/h2client/abstract_h2_client.py:H2Response",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/h2client/abstract_h2_client.py",
+      "target": "class:util/h2client/abstract_h2_client.py:AbstractH2Client",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/h2client/abstract_h2_client.py",
+      "target": "class:util/h2client/abstract_h2_client.py:AbstractH2Client",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/proxy/ProxyManager.py",
+      "target": "class:util/proxy/ProxyManager.py:ProxyManager",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/proxy/ProxyManager.py",
+      "target": "class:util/proxy/ProxyManager.py:ProxyManager",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/proxy/ProxyState.py",
+      "target": "class:util/proxy/ProxyState.py:ProxyStateEntry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/proxy/ProxyState.py",
+      "target": "class:util/proxy/ProxyState.py:ProxyStateEntry",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/proxy/ProxyState.py",
+      "target": "class:util/proxy/ProxyState.py:ProxyStateRegistry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/proxy/ProxyState.py",
+      "target": "class:util/proxy/ProxyState.py:ProxyStateRegistry",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/proxy/ProxyTester.py",
+      "target": "function:util/proxy/ProxyTester.py:test_proxy_connectivity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/proxy/ProxyTester.py",
+      "target": "function:util/proxy/ProxyTester.py:test_proxy_connectivity",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/proxy/ProxyTester.py",
+      "target": "class:util/proxy/ProxyTester.py:ProxyTester",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/proxy/ProxyTester.py",
+      "target": "class:util/proxy/ProxyTester.py:ProxyTester",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BiliRequest.py",
+      "target": "class:util/request/BiliRequest.py:BiliRequest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BiliRequest.py",
+      "target": "class:util/request/BiliRequest.py:BiliRequest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:random_hex",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:random_hex",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:build_chrome_user_agent",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:build_chrome_user_agent",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:extract_app_version_from_ua",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:extract_app_version_from_ua",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:generate_browser_window_state",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:generate_browser_window_state",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:generate_browser_display_state",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:generate_browser_display_state",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:generate_browser_navigator_state",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:generate_browser_navigator_state",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:generate_browser_locale_state",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:generate_browser_locale_state",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:generate_browser_location_state",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:generate_browser_location_state",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:generate_browser_webgl_state",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:generate_browser_webgl_state",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:generate_browser_canvas_state",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:generate_browser_canvas_state",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:generate_browser_storage_state",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:generate_browser_storage_state",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:generate_browser_fingerprint_state",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:generate_browser_fingerprint_state",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:finalize_device_id",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:finalize_device_id",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:_cookie_dict_to_header",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:_cookie_dict_to_header",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:_build_sec_ch_ua",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:_build_sec_ch_ua",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:_build_sec_ch_ua_platform",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:_build_sec_ch_ua_platform",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:build_headers_from_browser_state",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "function:util/request/BrowerState.py:build_headers_from_browser_state",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "class:util/request/BrowerState.py:BrowserWindowState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "class:util/request/BrowerState.py:BrowserWindowState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "class:util/request/BrowerState.py:BrowserDisplayState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "class:util/request/BrowerState.py:BrowserDisplayState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "class:util/request/BrowerState.py:BrowserNavigatorState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "class:util/request/BrowerState.py:BrowserNavigatorState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "class:util/request/BrowerState.py:BrowserLocaleState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "class:util/request/BrowerState.py:BrowserLocaleState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "class:util/request/BrowerState.py:BrowserLocationState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "class:util/request/BrowerState.py:BrowserLocationState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "class:util/request/BrowerState.py:BrowserWebGLState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "class:util/request/BrowerState.py:BrowserWebGLState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "class:util/request/BrowerState.py:BrowserCanvasState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "class:util/request/BrowerState.py:BrowserCanvasState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "class:util/request/BrowerState.py:BrowserStorageState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "class:util/request/BrowerState.py:BrowserStorageState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "class:util/request/BrowerState.py:BrowserFingerprintState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/BrowerState.py",
+      "target": "class:util/request/BrowerState.py:BrowserFingerprintState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/CookieManager.py",
+      "target": "function:util/request/CookieManager.py:parse_cookie_list",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/CookieManager.py",
+      "target": "function:util/request/CookieManager.py:parse_cookie_list",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/CookieManager.py",
+      "target": "class:util/request/CookieManager.py:Account",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/CookieManager.py",
+      "target": "class:util/request/CookieManager.py:Account",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/CookieManager.py",
+      "target": "class:util/request/CookieManager.py:CookieManager",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/CookieManager.py",
+      "target": "class:util/request/CookieManager.py:CookieManager",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/exceptions/connection.py",
+      "target": "class:util/request/exceptions/connection.py:BiliConnectionError",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/exceptions/connection.py",
+      "target": "class:util/request/exceptions/connection.py:BiliConnectionError",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/exceptions/rate_limit.py",
+      "target": "class:util/request/exceptions/rate_limit.py:BiliRateLimitError",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/exceptions/rate_limit.py",
+      "target": "class:util/request/exceptions/rate_limit.py:BiliRateLimitError",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:cptoken/__init__.py",
+      "target": "function:cptoken/__init__.py:generate_ctoken",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:cptoken/__init__.py",
+      "target": "function:cptoken/__init__.py:generate_ctoken",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:cptoken/__init__.py",
+      "target": "function:cptoken/__init__.py:generate_browser_window_state",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:cptoken/__init__.py",
+      "target": "function:cptoken/__init__.py:generate_browser_window_state",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:cptoken/__init__.py",
+      "target": "function:cptoken/__init__.py:init_ctoken_state",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:cptoken/__init__.py",
+      "target": "function:cptoken/__init__.py:init_ctoken_state",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:cptoken/__init__.py",
+      "target": "function:cptoken/__init__.py:sim_ctoken_state",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:cptoken/__init__.py",
+      "target": "function:cptoken/__init__.py:sim_ctoken_state",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:cptoken/__init__.py",
+      "target": "class:cptoken/__init__.py:CTokenSnapshot",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:cptoken/__init__.py",
+      "target": "class:cptoken/__init__.py:CTokenSnapshot",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:cptoken/__init__.py",
+      "target": "class:cptoken/__init__.py:BrowserWindowState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:cptoken/__init__.py",
+      "target": "class:cptoken/__init__.py:BrowserWindowState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:cptoken/__init__.py",
+      "target": "class:cptoken/__init__.py:CTokenRuntimeState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:cptoken/__init__.py",
+      "target": "class:cptoken/__init__.py:CTokenRuntimeState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "function:task/buy.py:_extract_prepare_token",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "function:task/buy.py:_extract_prepare_token",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "function:task/buy.py:_format_reprepare_reason",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "function:task/buy.py:_format_reprepare_reason",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "function:task/buy.py:buy_stream",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "function:task/buy.py:buy_stream",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "function:task/buy.py:buy_new_terminal",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "function:task/buy.py:buy_new_terminal",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "class:task/buy.py:Buy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy.py",
+      "target": "class:task/buy.py:Buy",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:get_qrcode_url",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:get_qrcode_url",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:get_order_detail_url",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:get_order_detail_url",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:build_payment_result",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:build_payment_result",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:format_countdown",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:format_countdown",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:next_countdown_report_at",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:next_countdown_report_at",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:wait_until_start",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:wait_until_start",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:build_token_payload",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:build_token_payload",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:build_order_token",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:build_order_token",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:normalize_prepare_ptoken",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:normalize_prepare_ptoken",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:create_order_terminal_rule",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:create_order_terminal_rule",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:is_create_success",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:is_create_success",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:extract_order_id",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:extract_order_id",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:extract_response_message",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:extract_response_message",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:append_response_message",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:append_response_message",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:format_retry_reason",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:format_retry_reason",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:summarize_non_json_response",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:summarize_non_json_response",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:build_proxy_exhausted_message",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:build_proxy_exhausted_message",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:notify_proxy_exhausted",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:notify_proxy_exhausted",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:handle_proxy_failure",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:handle_proxy_failure",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:format_status_result",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:format_status_result",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:prepare_create_request",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_helpers.py",
+      "target": "function:task/buy_helpers.py:prepare_create_request",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_types.py",
+      "target": "class:task/buy_types.py:BuyStreamState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_types.py",
+      "target": "class:task/buy_types.py:BuyStreamState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_types.py",
+      "target": "class:task/buy_types.py:BuyStreamEvent",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_types.py",
+      "target": "class:task/buy_types.py:BuyStreamEvent",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_types.py",
+      "target": "class:task/buy_types.py:BuyStreamUpdate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_types.py",
+      "target": "class:task/buy_types.py:BuyStreamUpdate",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_types.py",
+      "target": "class:task/buy_types.py:RetryOutcome",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_types.py",
+      "target": "class:task/buy_types.py:RetryOutcome",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_types.py",
+      "target": "class:task/buy_types.py:CreateOrderTerminalRule",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_types.py",
+      "target": "class:task/buy_types.py:CreateOrderTerminalRule",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_types.py",
+      "target": "class:task/buy_types.py:LatestValueWorker",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_types.py",
+      "target": "class:task/buy_types.py:LatestValueWorker",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:task/buy_types.py",
+      "target": "class:task/buy_types.py:BuyStreamWorker",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:task/buy_types.py",
+      "target": "class:task/buy_types.py:BuyStreamWorker",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_buy_prepare_token.py",
+      "target": "function:tests/test_buy_prepare_token.py:test_extract_prepare_token_returns_none_when_missing",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_buy_prepare_token.py",
+      "target": "function:tests/test_buy_prepare_token.py:test_extract_prepare_token_returns_none_when_missing",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_buy_prepare_token.py",
+      "target": "function:tests/test_buy_prepare_token.py:test_extract_prepare_token_returns_string_when_present",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_buy_prepare_token.py",
+      "target": "function:tests/test_buy_prepare_token.py:test_extract_prepare_token_returns_string_when_present",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_buy_reprepare_reason.py",
+      "target": "function:tests/test_buy_reprepare_reason.py:test_format_reprepare_reason_includes_cause",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_buy_reprepare_reason.py",
+      "target": "function:tests/test_buy_reprepare_reason.py:test_format_reprepare_reason_includes_cause",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "function:tests/test_proxy_api_provider.py:_proxy_url",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "function:tests/test_proxy_api_provider.py:_proxy_url",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "function:tests/test_proxy_api_provider.py:test_build_proxy_api_url_overrides_required_params",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "function:tests/test_proxy_api_provider.py:test_build_proxy_api_url_overrides_required_params",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "function:tests/test_proxy_api_provider.py:test_parse_youdaili_success_response_as_http_proxy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "function:tests/test_proxy_api_provider.py:test_parse_youdaili_success_response_as_http_proxy",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "function:tests/test_proxy_api_provider.py:test_parse_youdaili_success_response_as_socks_proxy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "function:tests/test_proxy_api_provider.py:test_parse_youdaili_success_response_as_socks_proxy",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "function:tests/test_proxy_api_provider.py:test_parse_proxy_api_keeps_auth_from_standard_url",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "function:tests/test_proxy_api_provider.py:test_parse_proxy_api_keeps_auth_from_standard_url",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "function:tests/test_proxy_api_provider.py:test_parse_proxy_api_keeps_auth_from_host_port_user_pass",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "function:tests/test_proxy_api_provider.py:test_parse_proxy_api_keeps_auth_from_host_port_user_pass",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "function:tests/test_proxy_api_provider.py:test_parse_proxy_api_keeps_auth_from_object_fields",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "function:tests/test_proxy_api_provider.py:test_parse_proxy_api_keeps_auth_from_object_fields",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "function:tests/test_proxy_api_provider.py:test_parse_proxy_api_merges_auth_fields_with_proxy_field",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "function:tests/test_proxy_api_provider.py:test_parse_proxy_api_merges_auth_fields_with_proxy_field",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "function:tests/test_proxy_api_provider.py:test_parse_proxy_api_keeps_auth_for_socks5_url",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "function:tests/test_proxy_api_provider.py:test_parse_proxy_api_keeps_auth_for_socks5_url",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "function:tests/test_proxy_api_provider.py:test_parse_youdaili_failure_response_raises",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_proxy_api_provider.py",
+      "target": "function:tests/test_proxy_api_provider.py:test_parse_youdaili_failure_response_raises",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/ErrorCodes.py",
+      "target": "class:util/ErrorCodes.py:ErrorCodes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/ErrorCodes.py",
+      "target": "class:util/ErrorCodes.py:ErrorCodes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "function:util/proxy/ProxyApiProvider.py:normalize_proxy_api_protocol",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "function:util/proxy/ProxyApiProvider.py:normalize_proxy_api_protocol",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "function:util/proxy/ProxyApiProvider.py:build_proxy_api_url",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "function:util/proxy/ProxyApiProvider.py:build_proxy_api_url",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "function:util/proxy/ProxyApiProvider.py:_iter_proxy_items",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "function:util/proxy/ProxyApiProvider.py:_iter_proxy_items",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "function:util/proxy/ProxyApiProvider.py:_normalize_proxy_scheme",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "function:util/proxy/ProxyApiProvider.py:_normalize_proxy_scheme",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "function:util/proxy/ProxyApiProvider.py:_format_proxy_url",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "function:util/proxy/ProxyApiProvider.py:_format_proxy_url",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "function:util/proxy/ProxyApiProvider.py:_get_any_key",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "function:util/proxy/ProxyApiProvider.py:_get_any_key",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "function:util/proxy/ProxyApiProvider.py:_extract_proxy_parts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "function:util/proxy/ProxyApiProvider.py:_extract_proxy_parts",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "function:util/proxy/ProxyApiProvider.py:parse_proxy_api_response",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "function:util/proxy/ProxyApiProvider.py:parse_proxy_api_response",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "function:util/proxy/ProxyApiProvider.py:fetch_proxy_api",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "function:util/proxy/ProxyApiProvider.py:fetch_proxy_api",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "class:util/proxy/ProxyApiProvider.py:ProxyApiError",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "class:util/proxy/ProxyApiProvider.py:ProxyApiError",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "class:util/proxy/ProxyApiProvider.py:ProxyApiResult",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/proxy/ProxyApiProvider.py",
+      "target": "class:util/proxy/ProxyApiProvider.py:ProxyApiResult",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/proxy/ProxyBackoff.py",
+      "target": "class:util/proxy/ProxyBackoff.py:ProxyBackoff",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/proxy/ProxyBackoff.py",
+      "target": "class:util/proxy/ProxyBackoff.py:ProxyBackoff",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/request/TokenUtil.py",
+      "target": "function:util/request/TokenUtil.py:generate_token",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/request/TokenUtil.py",
+      "target": "function:util/request/TokenUtil.py:generate_token",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:withTimeString",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:withTimeString",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:_build_task_log_path",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:_build_task_log_path",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:_build_task_proxy_list",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:_build_task_proxy_list",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:_parse_sale_start",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:_parse_sale_start",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:_preview_value",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:_preview_value",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:_format_price_cents",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:_format_price_cents",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:_format_buyer_identity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:_format_buyer_identity",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:_render_ticket_preview",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:_render_ticket_preview",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:_get_session_upload_files",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:_get_session_upload_files",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:_build_session_ticket_preview",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:_build_session_ticket_preview",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:go_start_tab",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/go.py",
+      "target": "function:tab/go.py:go_start_tab",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:_status_class",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:_status_class",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:_refresh_token",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:_refresh_token",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:build_main_log_card",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:build_main_log_card",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:_render_log_path",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:_render_log_path",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:_render_log_view_action",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:_render_log_view_action",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:_list_log_files",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:_list_log_files",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:_find_task_entry_by_log_file",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:_find_task_entry_by_log_file",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:clear_log_files",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:clear_log_files",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:is_task_running",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:is_task_running",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:_is_posix_zombie_process",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:_is_posix_zombie_process",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:_send_posix_signal",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:_send_posix_signal",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:terminate_task",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:terminate_task",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:sync_task_statuses",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:sync_task_statuses",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:visible_task_entries",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:visible_task_entries",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:log_contains_marker",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:log_contains_marker",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:extract_payment_qr_url",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:extract_payment_qr_url",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:refresh_task_panel",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:refresh_task_panel",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:refresh_task_panel_with_payments",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:refresh_task_panel_with_payments",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:refresh_log_panel",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:refresh_log_panel",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:stop_task",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:stop_task",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:stop_all_running_tasks",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:stop_all_running_tasks",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:remove_task",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:remove_task",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:append_stop_log",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:append_stop_log",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:read_task_log_locations",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:read_task_log_locations",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:render_task_manager_panel",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:render_task_manager_panel",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:log_tab",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/log.py",
+      "target": "function:tab/log.py:log_tab",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_go_ticket_preview.py",
+      "target": "function:tests/test_go_ticket_preview.py:test_ticket_preview_appends_buyer_document_type",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_go_ticket_preview.py",
+      "target": "function:tests/test_go_ticket_preview.py:test_ticket_preview_appends_buyer_document_type",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_task_log_controls.py",
+      "target": "function:tests/test_task_log_controls.py:test_is_task_running_treats_posix_zombie_as_stopped",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_task_log_controls.py",
+      "target": "function:tests/test_task_log_controls.py:test_is_task_running_treats_posix_zombie_as_stopped",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_task_log_controls.py",
+      "target": "function:tests/test_task_log_controls.py:test_terminate_task_falls_back_to_process_signal_when_group_denied",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_task_log_controls.py",
+      "target": "function:tests/test_task_log_controls.py:test_terminate_task_falls_back_to_process_signal_when_group_denied",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_task_log_controls.py",
+      "target": "function:tests/test_task_log_controls.py:test_terminate_task_returns_message_when_signal_permission_denied",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_task_log_controls.py",
+      "target": "function:tests/test_task_log_controls.py:test_terminate_task_returns_message_when_signal_permission_denied",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_task_log_controls.py",
+      "target": "function:tests/test_task_log_controls.py:test_stop_all_running_tasks_stops_only_active_pid_entries",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_task_log_controls.py",
+      "target": "function:tests/test_task_log_controls.py:test_stop_all_running_tasks_stops_only_active_pid_entries",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_time_util.py",
+      "target": "function:tests/test_time_util.py:test_current_time_ms_applies_local_minus_reference_offset",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_time_util.py",
+      "target": "function:tests/test_time_util.py:test_current_time_ms_applies_local_minus_reference_offset",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_time_util.py",
+      "target": "function:tests/test_time_util.py:test_time_service_now_uses_calibrated_reference_time",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_time_util.py",
+      "target": "function:tests/test_time_util.py:test_time_service_now_uses_calibrated_reference_time",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_time_util.py",
+      "target": "function:tests/test_time_util.py:test_countdown_now_prefers_bili_date_check",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_time_util.py",
+      "target": "function:tests/test_time_util.py:test_countdown_now_prefers_bili_date_check",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_time_util.py",
+      "target": "function:tests/test_time_util.py:test_compute_ntp_sample_uses_low_delay_median",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_time_util.py",
+      "target": "function:tests/test_time_util.py:test_compute_ntp_sample_uses_low_delay_median",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_time_util.py",
+      "target": "function:tests/test_time_util.py:test_compute_ntp_sample_returns_fast_primary_without_backup_calls",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_time_util.py",
+      "target": "function:tests/test_time_util.py:test_compute_ntp_sample_returns_fast_primary_without_backup_calls",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_time_util.py",
+      "target": "function:tests/test_time_util.py:test_compute_bili_time_check_parses_http_date",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_time_util.py",
+      "target": "function:tests/test_time_util.py:test_compute_bili_time_check_parses_http_date",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/TimeUtil.py",
+      "target": "function:util/TimeUtil.py:current_time_ms",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/TimeUtil.py",
+      "target": "function:util/TimeUtil.py:current_time_ms",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/TimeUtil.py",
+      "target": "class:util/TimeUtil.py:TimeSyncSample",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/TimeUtil.py",
+      "target": "class:util/TimeUtil.py:TimeSyncSample",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/TimeUtil.py",
+      "target": "class:util/TimeUtil.py:BiliTimeCheck",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/TimeUtil.py",
+      "target": "class:util/TimeUtil.py:BiliTimeCheck",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/TimeUtil.py",
+      "target": "class:util/TimeUtil.py:TimeUtil",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/TimeUtil.py",
+      "target": "class:util/TimeUtil.py:TimeUtil",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "function:util/__init__.py:get_application_path",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "function:util/__init__.py:get_application_path",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "function:util/__init__.py:get_exec_path",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "function:util/__init__.py:get_exec_path",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "function:util/__init__.py:get_application_tmp_path",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "function:util/__init__.py:get_application_tmp_path",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "function:util/__init__.py:set_main_request",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "function:util/__init__.py:set_main_request",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "function:util/__init__.py:runtime_state_reader",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "function:util/__init__.py:runtime_state_reader",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "function:util/__init__.py:runtime_state_writer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "function:util/__init__.py:runtime_state_writer",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "class:util/__init__.py:TaskLogEntry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "class:util/__init__.py:TaskLogEntry",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "class:util/__init__.py:RuntimeStateStore",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "class:util/__init__.py:RuntimeStateStore",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "class:util/__init__.py:GlobalStatus",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/__init__.py",
+      "target": "class:util/__init__.py:GlobalStatus",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/log/LogConfig.py",
+      "target": "function:util/log/LogConfig.py:loguru_config",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/log/LogConfig.py",
+      "target": "function:util/log/LogConfig.py:loguru_config",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/log/LogWeb.py",
+      "target": "function:util/log/LogWeb.py:build_log_view_url",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/log/LogWeb.py",
+      "target": "function:util/log/LogWeb.py:build_log_view_url",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/log/LogWeb.py",
+      "target": "function:util/log/LogWeb.py:_resolve_log_path",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/log/LogWeb.py",
+      "target": "function:util/log/LogWeb.py:_resolve_log_path",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/log/LogWeb.py",
+      "target": "function:util/log/LogWeb.py:_read_log_text",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/log/LogWeb.py",
+      "target": "function:util/log/LogWeb.py:_read_log_text",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/log/LogWeb.py",
+      "target": "function:util/log/LogWeb.py:attach_log_routes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/log/LogWeb.py",
+      "target": "function:util/log/LogWeb.py:attach_log_routes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/log/LogWeb.py",
+      "target": "function:util/log/LogWeb.py:build_log_stream_url",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/log/LogWeb.py",
+      "target": "function:util/log/LogWeb.py:build_log_stream_url",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/log/LogWeb.py",
+      "target": "function:util/log/LogWeb.py:_sse",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/log/LogWeb.py",
+      "target": "function:util/log/LogWeb.py:_sse",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/notifer/RandomMessages.py",
+      "target": "function:util/notifer/RandomMessages.py:_load_messages",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/notifer/RandomMessages.py",
+      "target": "function:util/notifer/RandomMessages.py:_load_messages",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:util/notifer/RandomMessages.py",
+      "target": "function:util/notifer/RandomMessages.py:get_random_fail_message",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:util/notifer/RandomMessages.py",
+      "target": "function:util/notifer/RandomMessages.py:get_random_fail_message",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_cmd/buy.py",
+      "target": "function:app_cmd/buy.py:buy_cmd",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_cmd/buy.py",
+      "target": "function:app_cmd/buy.py:buy_cmd",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_cmd/cli_args.py",
+      "target": "function:app_cmd/cli_args.py:_env_bool",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_cmd/cli_args.py",
+      "target": "function:app_cmd/cli_args.py:_env_bool",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_cmd/cli_args.py",
+      "target": "function:app_cmd/cli_args.py:_env_optional_int",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_cmd/cli_args.py",
+      "target": "function:app_cmd/cli_args.py:_env_optional_int",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_cmd/cli_args.py",
+      "target": "function:app_cmd/cli_args.py:_env_optional_str",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_cmd/cli_args.py",
+      "target": "function:app_cmd/cli_args.py:_env_optional_str",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_cmd/cli_args.py",
+      "target": "class:app_cmd/cli_args.py:TickerCliArgs",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_cmd/cli_args.py",
+      "target": "class:app_cmd/cli_args.py:TickerCliArgs",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_cmd/ticker.py",
+      "target": "function:app_cmd/ticker.py:exit_app_ui",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_cmd/ticker.py",
+      "target": "function:app_cmd/ticker.py:exit_app_ui",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_cmd/ticker.py",
+      "target": "function:app_cmd/ticker.py:shutdown_app_process",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_cmd/ticker.py",
+      "target": "function:app_cmd/ticker.py:shutdown_app_process",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_cmd/ticker.py",
+      "target": "function:app_cmd/ticker.py:ticker_cmd",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_cmd/ticker.py",
+      "target": "function:app_cmd/ticker.py:ticker_cmd",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_update.py",
+      "target": "function:app_update.py:normalize_version",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_update.py",
+      "target": "function:app_update.py:normalize_version",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_update.py",
+      "target": "function:app_update.py:select_update",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_update.py",
+      "target": "function:app_update.py:select_update",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_update.py",
+      "target": "function:app_update.py:fetch_update",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_update.py",
+      "target": "function:app_update.py:fetch_update",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_update.py",
+      "target": "class:app_update.py:UpdateError",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_update.py",
+      "target": "class:app_update.py:UpdateError",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_update.py",
+      "target": "class:app_update.py:ReleaseInfo",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_update.py",
+      "target": "class:app_update.py:ReleaseInfo",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_version.py",
+      "target": "function:app_version.py:_read_pyproject_version",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_version.py",
+      "target": "function:app_version.py:_read_pyproject_version",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app_version.py",
+      "target": "function:app_version.py:get_app_version",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:app_version.py",
+      "target": "function:app_version.py:get_app_version",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:main.py",
+      "target": "function:main.py:_normalize_argv",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:main.py",
+      "target": "function:main.py:_normalize_argv",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:main.py",
+      "target": "function:main.py:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:main.py",
+      "target": "function:main.py:main",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:_saved_channel",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:_saved_channel",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:_format_update",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:_format_update",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:_update_script_name",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:_update_script_name",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:_runtime_mode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:_runtime_mode",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:_source_update_hint",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:_source_update_hint",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:_pip_update_hint",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:_pip_update_hint",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:_bundled_update_hint",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:_bundled_update_hint",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:_update_hint",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:_update_hint",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:_check_updates",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:_check_updates",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:load_update_check",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:load_update_check",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:run_stable_update_check",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:run_stable_update_check",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:show_update_loading",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:show_update_loading",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:update_tab",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tab/update.py",
+      "target": "function:tab/update.py:update_tab",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_app_update.py",
+      "target": "function:tests/test_app_update.py:_release",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_app_update.py",
+      "target": "function:tests/test_app_update.py:_release",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_app_update.py",
+      "target": "function:tests/test_app_update.py:test_stable_channel_skips_prereleases",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_app_update.py",
+      "target": "function:tests/test_app_update.py:test_stable_channel_skips_prereleases",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/test_app_update.py",
+      "target": "function:tests/test_app_update.py:test_prerelease_channel_selects_newest_version",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/test_app_update.py",
+      "target": "function:tests/test_app_update.py:test_prerelease_channel_selects_newest_version",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:resolve_url",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:http_get",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:request_version_info",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:parse_version_info",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:validate_version_info",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:is_valid_zip",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:print_invalid_download",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:download_release_asset",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:get_file_size",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:calculate_sha256",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:verify_download",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:append_path_block",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:find_package_binary",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "function:app_update.py:normalize_version",
+      "target": "class:app_update.py:UpdateError",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app_update.py:select_update",
+      "target": "function:app_update.py:normalize_version",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app_update.py:select_update",
+      "target": "class:app_update.py:ReleaseInfo",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app_update.py:select_update",
+      "target": "class:app_update.py:UpdateError",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app_update.py:fetch_update",
+      "target": "function:app_update.py:select_update",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app_update.py:fetch_update",
+      "target": "class:app_update.py:UpdateError",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app_version.py:get_app_version",
+      "target": "function:app_version.py:_read_pyproject_version",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:main.py:main",
+      "target": "function:main.py:_normalize_argv",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app_cmd/ticker.py:ticker_cmd",
+      "target": "function:app_cmd/ticker.py:shutdown_app_process",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:cptoken/__init__.py:init_ctoken_state",
+      "target": "class:cptoken/__init__.py:CTokenRuntimeState",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:cptoken/__init__.py:init_ctoken_state",
+      "target": "function:cptoken/__init__.py:generate_browser_window_state",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:cptoken/__init__.py:init_ctoken_state",
+      "target": "function:cptoken/__init__.py:to_dict",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:cptoken/__init__.py:init_ctoken_state",
+      "target": "function:cptoken/__init__.py:snapshot",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:cptoken/__init__.py:sim_ctoken_state",
+      "target": "function:cptoken/__init__.py:snapshot",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:cptoken/__init__.py:sim_ctoken_state",
+      "target": "class:cptoken/__init__.py:CTokenSnapshot",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:cptoken/__init__.py:generate_ctoken",
+      "target": "function:cptoken/__init__.py:generate_prepare_ctoken",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/config.py:build_runtime_options",
+      "target": "class:interface/config.py:RuntimeOptions",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/managed_runner.py:_heartbeat_loop",
+      "target": "function:interface/managed_runner.py:_dump_json",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/managed_runner.py:main",
+      "target": "function:interface/managed_runner.py:_load_json",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/managed_runner.py:main",
+      "target": "function:interface/managed_runner.py:_dump_json",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:interface/managed_runner.py:main",
+      "target": "function:interface/managed_runner.py:_append_log",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/go.py:_format_price_cents",
+      "target": "function:tab/go.py:_preview_value",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/go.py:_format_buyer_identity",
+      "target": "function:tab/go.py:_preview_value",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/go.py:_render_ticket_preview",
+      "target": "function:tab/go.py:_preview_value",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/go.py:_render_ticket_preview",
+      "target": "function:tab/go.py:_format_price_cents",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/go.py:_render_ticket_preview",
+      "target": "function:tab/go.py:_format_buyer_identity",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/go.py:_build_session_ticket_preview",
+      "target": "function:tab/go.py:_get_session_upload_files",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/go.py:_build_session_ticket_preview",
+      "target": "function:tab/go.py:_render_ticket_preview",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/go.py:go_start_tab",
+      "target": "function:tab/go.py:_build_task_log_path",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/go.py:go_start_tab",
+      "target": "function:tab/go.py:_build_task_proxy_list",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/go.py:go_start_tab",
+      "target": "function:tab/go.py:_render_ticket_preview",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/go.py:go_start_tab",
+      "target": "function:tab/go.py:_parse_sale_start",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:_find_task_entry_by_log_file",
+      "target": "function:tab/log.py:visible_task_entries",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:clear_log_files",
+      "target": "function:tab/log.py:_list_log_files",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:clear_log_files",
+      "target": "function:tab/log.py:refresh_log_panel",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:clear_log_files",
+      "target": "function:tab/log.py:_find_task_entry_by_log_file",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:is_task_running",
+      "target": "function:tab/log.py:_is_posix_zombie_process",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:terminate_task",
+      "target": "function:tab/log.py:_send_posix_signal",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:terminate_task",
+      "target": "function:tab/log.py:is_task_running",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:sync_task_statuses",
+      "target": "function:tab/log.py:extract_payment_qr_url",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:sync_task_statuses",
+      "target": "function:tab/log.py:log_contains_marker",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:sync_task_statuses",
+      "target": "function:tab/log.py:is_task_running",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:visible_task_entries",
+      "target": "function:tab/log.py:sync_task_statuses",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:refresh_task_panel",
+      "target": "function:tab/log.py:_refresh_token",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:refresh_task_panel",
+      "target": "function:tab/log.py:visible_task_entries",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:refresh_task_panel_with_payments",
+      "target": "function:tab/log.py:visible_task_entries",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:refresh_task_panel_with_payments",
+      "target": "function:tab/log.py:_refresh_token",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:refresh_log_panel",
+      "target": "function:tab/log.py:_refresh_token",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:stop_task",
+      "target": "function:tab/log.py:terminate_task",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:stop_task",
+      "target": "function:tab/log.py:refresh_task_panel",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:stop_task",
+      "target": "function:tab/log.py:append_stop_log",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:stop_all_running_tasks",
+      "target": "function:tab/log.py:refresh_task_panel",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:stop_all_running_tasks",
+      "target": "function:tab/log.py:terminate_task",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:stop_all_running_tasks",
+      "target": "function:tab/log.py:visible_task_entries",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:stop_all_running_tasks",
+      "target": "function:tab/log.py:append_stop_log",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:remove_task",
+      "target": "function:tab/log.py:refresh_task_panel",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:remove_task",
+      "target": "function:tab/log.py:terminate_task",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:remove_task",
+      "target": "function:tab/log.py:append_stop_log",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:read_task_log_locations",
+      "target": "function:tab/log.py:visible_task_entries",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:read_task_log_locations",
+      "target": "function:tab/log.py:build_main_log_card",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:read_task_log_locations",
+      "target": "function:tab/log.py:_status_class",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:read_task_log_locations",
+      "target": "function:tab/log.py:_render_log_path",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:read_task_log_locations",
+      "target": "function:tab/log.py:_render_log_view_action",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:render_task_manager_panel",
+      "target": "function:tab/log.py:_refresh_token",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:render_task_manager_panel",
+      "target": "function:tab/log.py:build_main_log_card",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:render_task_manager_panel",
+      "target": "function:tab/log.py:visible_task_entries",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:render_task_manager_panel",
+      "target": "function:tab/log.py:_status_class",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:render_task_manager_panel",
+      "target": "function:tab/log.py:_render_log_path",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:render_task_manager_panel",
+      "target": "function:tab/log.py:remove_task",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:render_task_manager_panel",
+      "target": "function:tab/log.py:stop_task",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:log_tab",
+      "target": "function:tab/log.py:_refresh_token",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:log_tab",
+      "target": "function:tab/log.py:_list_log_files",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:log_tab",
+      "target": "function:tab/log.py:_find_task_entry_by_log_file",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:log_tab",
+      "target": "function:tab/log.py:_status_class",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/log.py:log_tab",
+      "target": "function:tab/log.py:_render_log_path",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:login_tab",
+      "target": "function:tab/settings.py:_resolve_default_account_choice",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:login_tab",
+      "target": "function:tab/settings.py:_reset_ticket_context",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:login_tab",
+      "target": "function:tab/settings.py:_find_uid_from_choice",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:login_tab",
+      "target": "function:tab/settings.py:upload_file",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:login_tab",
+      "target": "function:tab/settings.py:_format_account_choice",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:setting_tab",
+      "target": "function:tab/settings.py:_fetch_screens_by_date_with_fallback",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:setting_tab",
+      "target": "function:tab/settings.py:_format_ticket_option",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/settings.py:setting_tab",
+      "target": "function:tab/settings.py:_render_ticket_info_html",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/update.py:_bundled_update_hint",
+      "target": "function:tab/update.py:_update_script_name",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/update.py:_update_hint",
+      "target": "function:tab/update.py:_runtime_mode",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/update.py:_update_hint",
+      "target": "function:tab/update.py:_pip_update_hint",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/update.py:_update_hint",
+      "target": "function:tab/update.py:_bundled_update_hint",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/update.py:_update_hint",
+      "target": "function:tab/update.py:_source_update_hint",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/update.py:_check_updates",
+      "target": "function:tab/update.py:_saved_channel",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/update.py:_check_updates",
+      "target": "function:tab/update.py:_format_update",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/update.py:_check_updates",
+      "target": "function:tab/update.py:_update_hint",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/update.py:load_update_check",
+      "target": "function:tab/update.py:_check_updates",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/update.py:load_update_check",
+      "target": "function:tab/update.py:_saved_channel",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/update.py:run_stable_update_check",
+      "target": "function:tab/update.py:_check_updates",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/update.py:update_tab",
+      "target": "function:tab/update.py:_update_hint",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tab/update.py:update_tab",
+      "target": "function:tab/update.py:_saved_channel",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:task/buy.py:buy_stream",
+      "target": "function:task/buy.py:_format_reprepare_reason",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:task/buy.py:buy_stream",
+      "target": "function:task/buy.py:_extract_prepare_token",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:task/buy.py:buy_new_terminal",
+      "target": "class:task/buy.py:Buy",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:task/buy.py:buy_new_terminal",
+      "target": "function:task/buy.py:start_new_terminal",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:task/buy_helpers.py:build_payment_result",
+      "target": "function:task/buy_helpers.py:get_order_detail_url",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:task/buy_helpers.py:build_payment_result",
+      "target": "function:task/buy_helpers.py:get_qrcode_url",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:task/buy_helpers.py:wait_until_start",
+      "target": "function:task/buy_helpers.py:format_countdown",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:task/buy_helpers.py:wait_until_start",
+      "target": "function:task/buy_helpers.py:next_countdown_report_at",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:task/buy_helpers.py:format_retry_reason",
+      "target": "function:task/buy_helpers.py:append_response_message",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:task/buy_helpers.py:notify_proxy_exhausted",
+      "target": "function:task/buy_helpers.py:build_proxy_exhausted_message",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:task/buy_helpers.py:handle_proxy_failure",
+      "target": "function:task/buy_helpers.py:notify_proxy_exhausted",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:task/buy_helpers.py:format_status_result",
+      "target": "function:task/buy_helpers.py:extract_response_message",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:task/buy_helpers.py:format_status_result",
+      "target": "function:task/buy_helpers.py:append_response_message",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:task/buy_helpers.py:prepare_create_request",
+      "target": "function:task/buy_helpers.py:normalize_prepare_ptoken",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_app_update.py:test_stable_channel_skips_prereleases",
+      "target": "function:tests/test_app_update.py:_release",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_app_update.py:test_prerelease_channel_selects_newest_version",
+      "target": "function:tests/test_app_update.py:_release",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_buy_refresh_count.py:test_trigger_after_target_count_then_resets",
+      "target": "function:tests/test_buy_refresh_count.py:_make_scheduler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_buy_refresh_count.py:test_trigger_after_target_count_then_resets",
+      "target": "function:tests/test_buy_refresh_count.py:_config",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_buy_refresh_count.py:test_fetch_not_concurrent_with_create",
+      "target": "function:tests/test_buy_refresh_count.py:_make_scheduler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_buy_refresh_count.py:test_fetch_not_concurrent_with_create",
+      "target": "function:tests/test_buy_refresh_count.py:_config",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_buy_refresh_count.py:test_disabled_when_max_zero",
+      "target": "function:tests/test_buy_refresh_count.py:_make_scheduler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_buy_refresh_count.py:test_disabled_when_max_zero",
+      "target": "function:tests/test_buy_refresh_count.py:_config",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_buy_refresh_count.py:test_disabled_when_min_greater_than_max",
+      "target": "function:tests/test_buy_refresh_count.py:_make_scheduler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_buy_refresh_count.py:test_disabled_when_min_greater_than_max",
+      "target": "function:tests/test_buy_refresh_count.py:_config",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_buy_refresh_count.py:test_100001_resets_counter",
+      "target": "function:tests/test_buy_refresh_count.py:_make_scheduler",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_buy_refresh_count.py:test_100001_resets_counter",
+      "target": "function:tests/test_buy_refresh_count.py:_config",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_buy_time_sync.py:test_prepare_create_request_uses_calibrated_timestamp",
+      "target": "class:tests/test_buy_time_sync.py:_FakeTimeService",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_buy_time_sync.py:test_prepare_create_request_uses_calibrated_timestamp",
+      "target": "class:tests/test_buy_time_sync.py:_FakeCreateState",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_buy_time_sync.py:test_prepare_create_request_uses_calibrated_timestamp",
+      "target": "class:tests/test_buy_time_sync.py:_FakeTicketState",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_local_fanout_proxy_strategy.py:test_proxy_pool_fanout_builds_one_create_connection_per_proxy",
+      "target": "function:tests/test_local_fanout_proxy_strategy.py:post",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_local_fanout_proxy_strategy.py:test_proxy_pool_fanout_repeats_until_one_proxy_succeeds",
+      "target": "function:tests/test_local_fanout_proxy_strategy.py:post",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_notifier_join_all.py:test_join_all_waits_for_push_to_complete",
+      "target": "class:tests/test_notifier_join_all.py:_FakeNotifier",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_notifier_join_all.py:test_join_all_waits_for_push_to_complete",
+      "target": "function:tests/test_notifier_join_all.py:_make_manager",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_notifier_join_all.py:test_join_all_blocks_until_thread_finishes",
+      "target": "class:tests/test_notifier_join_all.py:_FakeNotifier",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_notifier_join_all.py:test_join_all_blocks_until_thread_finishes",
+      "target": "function:tests/test_notifier_join_all.py:_make_manager",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_notifier_join_all.py:test_join_all_timeout_does_not_block_forever",
+      "target": "function:tests/test_notifier_join_all.py:_make_manager",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_notifier_join_all.py:test_join_all_timeout_does_not_block_forever",
+      "target": "function:tests/test_notifier_join_all.py:__init__",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_payment_result_fields.py:test_build_payment_result_contains_order_and_code_urls",
+      "target": "class:tests/test_payment_result_fields.py:_DummyRequest",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_proxy_api_provider.py:test_parse_proxy_api_keeps_auth_from_standard_url",
+      "target": "function:tests/test_proxy_api_provider.py:_proxy_url",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_proxy_api_provider.py:test_parse_proxy_api_keeps_auth_from_host_port_user_pass",
+      "target": "function:tests/test_proxy_api_provider.py:_proxy_url",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_proxy_api_provider.py:test_parse_proxy_api_keeps_auth_from_object_fields",
+      "target": "function:tests/test_proxy_api_provider.py:_proxy_url",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_proxy_api_provider.py:test_parse_proxy_api_merges_auth_fields_with_proxy_field",
+      "target": "function:tests/test_proxy_api_provider.py:_proxy_url",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_proxy_api_provider.py:test_parse_proxy_api_keeps_auth_for_socks5_url",
+      "target": "function:tests/test_proxy_api_provider.py:_proxy_url",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_settings_ticket_selection.py:test_submit_ticket_id_resets_stale_selection_values",
+      "target": "class:tests/test_settings_ticket_selection.py:_FakeRequest",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:tests/test_settings_ticket_selection.py:test_submit_all_rejects_ticket_context_from_previous_account",
+      "target": "class:tests/test_settings_ticket_selection.py:_FakeAccountRequest",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/__init__.py:runtime_state_reader",
+      "target": "function:util/__init__.py:state_get",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/__init__.py:runtime_state_reader",
+      "target": "function:util/__init__.py:state_get_path_list",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/__init__.py:runtime_state_writer",
+      "target": "function:util/__init__.py:state_set_path_list",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/__init__.py:runtime_state_writer",
+      "target": "function:util/__init__.py:state_set",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:vec_u8",
+      "target": "function:util/h2client/client_ja.py:u8",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:vec_u16",
+      "target": "function:util/h2client/client_ja.py:u16",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:tls_ext",
+      "target": "function:util/h2client/client_ja.py:u16",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:tls_ext",
+      "target": "function:util/h2client/client_ja.py:vec_u16",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:build_extension_body",
+      "target": "function:util/h2client/client_ja.py:vec_u16",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:build_extension_body",
+      "target": "function:util/h2client/client_ja.py:vec_u8",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:build_extension_body",
+      "target": "function:util/h2client/client_ja.py:u16",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:build_extensions",
+      "target": "function:util/h2client/client_ja.py:build_extension_body",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:build_extensions",
+      "target": "function:util/h2client/client_ja.py:tls_ext",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:build_client_hello",
+      "target": "class:util/h2client/client_ja.py:BuiltClientHello",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:build_client_hello",
+      "target": "function:util/h2client/client_ja.py:build_extensions",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:build_client_hello",
+      "target": "function:util/h2client/client_ja.py:vec_u16",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:build_client_hello",
+      "target": "function:util/h2client/client_ja.py:u24",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:build_client_hello",
+      "target": "function:util/h2client/client_ja.py:u16",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:build_client_hello",
+      "target": "function:util/h2client/client_ja.py:vec_u8",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:fingerprints_from_client_hello",
+      "target": "function:util/h2client/client_ja.py:parse_client_hello_record",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:fingerprints_from_client_hello",
+      "target": "class:util/h2client/client_ja.py:Fingerprints",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:fingerprints_from_client_hello",
+      "target": "function:util/h2client/client_ja.py:is_domain_name",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:fingerprints_from_client_hello",
+      "target": "function:util/h2client/client_ja.py:tls_version_for_ja4",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:fingerprints_from_client_hello",
+      "target": "function:util/h2client/client_ja.py:sha256_12",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:fingerprints_from_client_hello",
+      "target": "function:util/h2client/client_ja.py:md5_hex",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:hkdf_extract",
+      "target": "function:util/h2client/client_ja.py:hmac_bytes",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:hkdf_expand_label",
+      "target": "function:util/h2client/client_ja.py:hkdf_expand",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:hkdf_expand_label",
+      "target": "function:util/h2client/client_ja.py:vec_u8",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:hkdf_expand_label",
+      "target": "function:util/h2client/client_ja.py:u16",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:derive_secret",
+      "target": "function:util/h2client/client_ja.py:hkdf_expand_label",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:read_tls_record",
+      "target": "function:util/h2client/client_ja.py:recvall",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:raise_for_alert",
+      "target": "class:util/h2client/client_ja.py:TLSAlert",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:parse_server_hello",
+      "target": "class:util/h2client/client_ja.py:ServerHello",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:pop_first_handshake_message",
+      "target": "function:util/h2client/client_ja.py:read_tls_record",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:pop_first_handshake_message",
+      "target": "function:util/h2client/client_ja.py:feed",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:pop_first_handshake_message",
+      "target": "function:util/h2client/client_ja.py:pop_messages",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:pop_first_handshake_message",
+      "target": "function:util/h2client/client_ja.py:raise_for_alert",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "target": "class:util/h2client/client_ja.py:HandshakeBuffer",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "target": "function:util/h2client/client_ja.py:pop_first_handshake_message",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "target": "function:util/h2client/client_ja.py:parse_server_hello",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "target": "function:util/h2client/client_ja.py:hash_bytes",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "target": "function:util/h2client/client_ja.py:hkdf_extract",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "target": "function:util/h2client/client_ja.py:derive_secret",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "target": "class:util/h2client/client_ja.py:TrafficCipher",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "target": "function:util/h2client/client_ja.py:hkdf_expand_label",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "target": "function:util/h2client/client_ja.py:hmac_bytes",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "target": "class:util/h2client/client_ja.py:TLS13Connection",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "target": "function:util/h2client/client_ja.py:read_tls_record",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "target": "function:util/h2client/client_ja.py:decrypt_record",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "target": "function:util/h2client/client_ja.py:feed",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "target": "function:util/h2client/client_ja.py:pop_messages",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "target": "function:util/h2client/client_ja.py:encrypt_record",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "target": "function:util/h2client/client_ja.py:raise_for_alert",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "target": "function:util/h2client/client_ja.py:u24",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:open_tls13_connection",
+      "target": "function:util/h2client/client_ja.py:parse_encrypted_extensions",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "target": "class:util/h2client/client_ja.py:HandshakeBuffer",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "target": "function:util/h2client/client_ja.py:pop_first_handshake_message",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "target": "function:util/h2client/client_ja.py:parse_server_hello",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "target": "function:util/h2client/client_ja.py:hash_bytes",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "target": "function:util/h2client/client_ja.py:hkdf_extract",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "target": "function:util/h2client/client_ja.py:derive_secret",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "target": "class:util/h2client/client_ja.py:TrafficCipher",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "target": "function:util/h2client/client_ja.py:hkdf_expand_label",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "target": "function:util/h2client/client_ja.py:hmac_bytes",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "target": "class:util/h2client/client_ja.py:TLSHandshakeResult",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "target": "function:util/h2client/client_ja.py:read_tls_record",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "target": "function:util/h2client/client_ja.py:decrypt_record",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "target": "function:util/h2client/client_ja.py:feed",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "target": "function:util/h2client/client_ja.py:pop_messages",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "target": "function:util/h2client/client_ja.py:encrypt_record",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "target": "function:util/h2client/client_ja.py:raise_for_alert",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "target": "function:util/h2client/client_ja.py:u24",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "target": "function:util/h2client/client_ja.py:parse_encrypted_extensions",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:connect_tcp",
+      "target": "function:util/h2client/client_ja.py:connect_tcp_via_proxy",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:send_client_hello_only",
+      "target": "function:util/h2client/client_ja.py:read_tls_record",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:send_client_hello_only",
+      "target": "function:util/h2client/client_ja.py:raise_for_alert",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:main",
+      "target": "function:util/h2client/client_ja.py:parse_args",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:main",
+      "target": "class:util/h2client/client_ja.py:ClientHelloProfile",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:main",
+      "target": "function:util/h2client/client_ja.py:build_client_hello",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:main",
+      "target": "function:util/h2client/client_ja.py:fingerprints_from_client_hello",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:main",
+      "target": "function:util/h2client/client_ja.py:read_targets_from_file",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:main",
+      "target": "function:util/h2client/client_ja.py:print_fingerprint_report",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:main",
+      "target": "function:util/h2client/client_ja.py:connect_tcp",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:main",
+      "target": "function:util/h2client/client_ja.py:complete_tls13_handshake",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/client_ja.py:main",
+      "target": "function:util/h2client/client_ja.py:send_client_hello_only",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/h2connection.py:verify_client_hello_ja",
+      "target": "class:util/h2client/h2connection.py:JAMatch",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/h2connection.py:_parse_request_target",
+      "target": "class:util/h2client/h2connection.py:RequestTarget",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/ja_h2_client.py:_response_errno",
+      "target": "function:util/h2client/ja_h2_client.py:get",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/local_sources.py:_source_address",
+      "target": "function:util/h2client/local_sources.py:_is_usable_source_ip",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/local_sources.py:_discover_sources_with_powershell",
+      "target": "function:util/h2client/local_sources.py:_dedupe_sources",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/local_sources.py:_discover_sources_with_powershell",
+      "target": "function:util/h2client/local_sources.py:_source_address",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/local_sources.py:_discover_sources_with_socket",
+      "target": "function:util/h2client/local_sources.py:_dedupe_sources",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/local_sources.py:_discover_sources_with_socket",
+      "target": "function:util/h2client/local_sources.py:_source_address",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/local_sources.py:discover_interface_source_ips",
+      "target": "function:util/h2client/local_sources.py:_discover_sources_with_socket",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/h2client/local_sources.py:discover_interface_source_ips",
+      "target": "function:util/h2client/local_sources.py:_discover_sources_with_powershell",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/log/LogWeb.py:attach_log_routes",
+      "target": "function:util/log/LogWeb.py:_resolve_log_path",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/log/LogWeb.py:attach_log_routes",
+      "target": "function:util/log/LogWeb.py:_read_log_text",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/log/LogWeb.py:attach_log_routes",
+      "target": "function:util/log/LogWeb.py:_sse",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/log/TerminalRenderer.py:_make_log_item",
+      "target": "function:util/log/TerminalRenderer.py:_extract_message_meta",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/log/TerminalRenderer.py:_make_log_item",
+      "target": "class:util/log/TerminalRenderer.py:LogItem",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/log/TerminalRenderer.py:_can_merge_log_item",
+      "target": "function:util/log/TerminalRenderer.py:_extract_message_meta",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/log/TerminalRenderer.py:_merge_log_item",
+      "target": "function:util/log/TerminalRenderer.py:_extract_message_meta",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/log/TerminalRenderer.py:create_terminal_renderer",
+      "target": "class:util/log/TerminalRenderer.py:PlainTerminalRenderer",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/log/TerminalRenderer.py:create_terminal_renderer",
+      "target": "class:util/log/TerminalRenderer.py:TextualTerminalRenderer",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/log/TerminalRenderer.py:render_message_stream",
+      "target": "function:util/log/TerminalRenderer.py:render_header",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/log/TerminalRenderer.py:render_message_stream",
+      "target": "function:util/log/TerminalRenderer.py:close",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/log/TerminalRenderer.py:render_message_stream",
+      "target": "function:util/log/TerminalRenderer.py:render_state",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/log/TerminalRenderer.py:render_message_stream",
+      "target": "function:util/log/TerminalRenderer.py:render_message",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/notifer/NtfyUtil.py:send_repeat_message",
+      "target": "function:util/notifer/NtfyUtil.py:stop_notification",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/notifer/NtfyUtil.py:send_repeat_message",
+      "target": "class:util/notifer/NtfyUtil.py:RepeatedNotifier",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/proxy/ProxyApiProvider.py:build_proxy_api_url",
+      "target": "function:util/proxy/ProxyApiProvider.py:normalize_proxy_api_protocol",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/proxy/ProxyApiProvider.py:build_proxy_api_url",
+      "target": "class:util/proxy/ProxyApiProvider.py:ProxyApiError",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/proxy/ProxyApiProvider.py:_normalize_proxy_scheme",
+      "target": "function:util/proxy/ProxyApiProvider.py:normalize_proxy_api_protocol",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/proxy/ProxyApiProvider.py:_extract_proxy_parts",
+      "target": "function:util/proxy/ProxyApiProvider.py:normalize_proxy_api_protocol",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/proxy/ProxyApiProvider.py:_extract_proxy_parts",
+      "target": "function:util/proxy/ProxyApiProvider.py:_get_any_key",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/proxy/ProxyApiProvider.py:_extract_proxy_parts",
+      "target": "function:util/proxy/ProxyApiProvider.py:_normalize_proxy_scheme",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/proxy/ProxyApiProvider.py:parse_proxy_api_response",
+      "target": "function:util/proxy/ProxyApiProvider.py:_iter_proxy_items",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/proxy/ProxyApiProvider.py:parse_proxy_api_response",
+      "target": "class:util/proxy/ProxyApiProvider.py:ProxyApiError",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/proxy/ProxyApiProvider.py:parse_proxy_api_response",
+      "target": "function:util/proxy/ProxyApiProvider.py:_extract_proxy_parts",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/proxy/ProxyApiProvider.py:parse_proxy_api_response",
+      "target": "function:util/proxy/ProxyApiProvider.py:_format_proxy_url",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/proxy/ProxyApiProvider.py:fetch_proxy_api",
+      "target": "function:util/proxy/ProxyApiProvider.py:build_proxy_api_url",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/proxy/ProxyApiProvider.py:fetch_proxy_api",
+      "target": "class:util/proxy/ProxyApiProvider.py:ProxyApiResult",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/proxy/ProxyApiProvider.py:fetch_proxy_api",
+      "target": "class:util/proxy/ProxyApiProvider.py:ProxyApiError",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/proxy/ProxyApiProvider.py:fetch_proxy_api",
+      "target": "function:util/proxy/ProxyApiProvider.py:parse_proxy_api_response",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/proxy/ProxyTester.py:test_proxy_connectivity",
+      "target": "class:util/proxy/ProxyTester.py:ProxyTester",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/proxy/ProxyTester.py:test_proxy_connectivity",
+      "target": "function:util/proxy/ProxyTester.py:test_proxy_list",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/proxy/ProxyTester.py:test_proxy_connectivity",
+      "target": "function:util/proxy/ProxyTester.py:format_test_results",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/request/BrowerState.py:generate_browser_navigator_state",
+      "target": "function:util/request/BrowerState.py:build_chrome_user_agent",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/request/BrowerState.py:generate_browser_navigator_state",
+      "target": "function:util/request/BrowerState.py:extract_app_version_from_ua",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/request/BrowerState.py:generate_browser_canvas_state",
+      "target": "function:util/request/BrowerState.py:random_hex",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/request/BrowerState.py:generate_browser_fingerprint_state",
+      "target": "function:util/request/BrowerState.py:generate_browser_window_state",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/request/BrowerState.py:generate_browser_fingerprint_state",
+      "target": "function:util/request/BrowerState.py:generate_browser_display_state",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/request/BrowerState.py:generate_browser_fingerprint_state",
+      "target": "function:util/request/BrowerState.py:generate_browser_navigator_state",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/request/BrowerState.py:generate_browser_fingerprint_state",
+      "target": "function:util/request/BrowerState.py:generate_browser_locale_state",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/request/BrowerState.py:generate_browser_fingerprint_state",
+      "target": "function:util/request/BrowerState.py:generate_browser_location_state",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/request/BrowerState.py:generate_browser_fingerprint_state",
+      "target": "function:util/request/BrowerState.py:generate_browser_webgl_state",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/request/BrowerState.py:generate_browser_fingerprint_state",
+      "target": "function:util/request/BrowerState.py:generate_browser_canvas_state",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/request/BrowerState.py:generate_browser_fingerprint_state",
+      "target": "function:util/request/BrowerState.py:generate_browser_storage_state",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/request/BrowerState.py:build_headers_from_browser_state",
+      "target": "function:util/request/BrowerState.py:_cookie_dict_to_header",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/request/BrowerState.py:build_headers_from_browser_state",
+      "target": "function:util/request/BrowerState.py:_build_sec_ch_ua",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/request/BrowerState.py:build_headers_from_browser_state",
+      "target": "function:util/request/BrowerState.py:_build_sec_ch_ua_platform",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/Storage/CleanupUtil.py:cleanup_runtime_artifacts",
+      "target": "function:util/Storage/CleanupUtil.py:_trim_old_paths",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:util/Storage/CleanupUtil.py:cleanup_runtime_artifacts",
+      "target": "function:util/Storage/CleanupUtil.py:_remove_path",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    }
+  ],
+  "layers": [
+    {
+      "id": "layer:entry-ui",
+      "name": "入口与界面层",
+      "description": "应用入口、命令行/TUI/Gradio 界面模块，以及面向用户的标签页。",
+      "nodeIds": [
+        "file:app_cmd/__init__.py",
+        "file:app_cmd/buy.py",
+        "file:app_cmd/cli_args.py",
+        "file:app_cmd/config/BuyConfig.py",
+        "file:app_cmd/config/ConfigBasic.py",
+        "file:app_cmd/config/NotifierConfig.py",
+        "file:app_cmd/ticker.py",
+        "file:main.py",
+        "file:tab/__init__.py",
+        "file:tab/config.py",
+        "file:tab/go.py",
+        "file:tab/log.py",
+        "file:tab/problems.py",
+        "file:tab/settings.py",
+        "file:tab/update.py"
+      ]
+    },
+    {
+      "id": "layer:ticket-workflows",
+      "name": "购票工作流层",
+      "description": "围绕 B 站购票的项目查询、登录、令牌、任务执行和下单编排模块。",
+      "nodeIds": [
+        "file:cptoken/__init__.py",
+        "file:interface/__init__.py",
+        "file:interface/auth.py",
+        "file:interface/common.py",
+        "file:interface/config.py",
+        "file:interface/execution.py",
+        "file:interface/managed_runner.py",
+        "file:interface/project.py",
+        "file:interface/search.py",
+        "file:interface/types.py",
+        "file:task/__init__.py",
+        "file:task/buy_helpers.py",
+        "file:task/buy_types.py",
+        "file:task/buy.py"
+      ]
+    },
+    {
+      "id": "layer:request-proxy",
+      "name": "请求与代理基础层",
+      "description": "HTTP/2 请求、Cookie、异常、代理池、退避和代理可用性检测等底层能力。",
+      "nodeIds": [
+        "file:util/Constant.py",
+        "file:util/h2client/abstract_h2_client.py",
+        "file:util/h2client/client_ja.py",
+        "file:util/h2client/constants.py",
+        "file:util/h2client/h2connection.py",
+        "file:util/h2client/ja_h2_client.py",
+        "file:util/h2client/local_sources.py",
+        "file:util/proxy/ProxyApiProvider.py",
+        "file:util/proxy/ProxyBackoff.py",
+        "file:util/proxy/ProxyManager.py",
+        "file:util/proxy/ProxyState.py",
+        "file:util/proxy/ProxyTester.py",
+        "file:util/proxy/PushPlusUtil.py",
+        "file:util/request/BiliRequest.py",
+        "file:util/request/BrowerState.py",
+        "file:util/request/CookieManager.py",
+        "file:util/request/exceptions/__init__.py",
+        "file:util/request/exceptions/connection.py",
+        "file:util/request/exceptions/rate_limit.py",
+        "file:util/request/TokenUtil.py"
+      ]
+    },
+    {
+      "id": "layer:notification-storage",
+      "name": "通知与存储层",
+      "description": "通知渠道、随机提示、日志配置、终端渲染、KV 存储和清理工具。",
+      "nodeIds": [
+        "file:util/log/LogConfig.py",
+        "file:util/log/LogWeb.py",
+        "file:util/log/TerminalRenderer.py",
+        "file:util/notifer/AudioUtil.py",
+        "file:util/notifer/BarkUtil.py",
+        "file:util/notifer/MeoWUtil.py",
+        "file:util/notifer/Notifier.py",
+        "file:util/notifer/NtfyUtil.py",
+        "file:util/notifer/RandomMessages.py",
+        "file:util/notifer/ServerChanUtil.py",
+        "file:util/Storage/CleanupUtil.py",
+        "file:util/Storage/KVDatabase.py"
+      ]
+    },
+    {
+      "id": "layer:configuration",
+      "name": "配置层",
+      "description": "项目清单、应用配置模型、模板、运行时设置和仓库配置。",
+      "nodeIds": [
+        "config:.github/ISSUE_TEMPLATE/bug-report.yml",
+        "config:.github/ISSUE_TEMPLATE/feature-request.yml",
+        "config:.github/release-drafter.yml",
+        "config:.pre-commit-config.yaml",
+        "config:assets/fail_messages.json",
+        "config:assets/updater/.env.install",
+        "file:config.json.bak",
+        "file:cookies.json.bak",
+        "file:MANIFEST.in",
+        "config:pyproject.toml"
+      ]
+    },
+    {
+      "id": "layer:tests",
+      "name": "测试层",
+      "description": "覆盖请求恢复、维护态、代理策略、通知、配置、CLI 和购票边界场景的自动化测试。",
+      "nodeIds": [
+        "file:tests/conftest.py",
+        "file:tests/test_app_update.py",
+        "file:tests/test_bili_request_h2_recovery.py",
+        "file:tests/test_bili_request_maintenance.py",
+        "file:tests/test_bili_request_rate_limit.py",
+        "file:tests/test_buy_prepare_token.py",
+        "file:tests/test_buy_refresh_count.py",
+        "file:tests/test_buy_reprepare_reason.py",
+        "file:tests/test_buy_time_sync.py",
+        "file:tests/test_go_ticket_preview.py",
+        "file:tests/test_local_fanout_proxy_strategy.py",
+        "file:tests/test_login_account_defaults.py",
+        "file:tests/test_notifier_join_all.py",
+        "file:tests/test_payment_result_fields.py",
+        "file:tests/test_proxy_api_provider.py",
+        "file:tests/test_settings_ticket_selection.py",
+        "file:tests/test_task_log_controls.py",
+        "file:tests/test_time_util.py"
+      ]
+    },
+    {
+      "id": "layer:assets-scripts",
+      "name": "资源与脚本层",
+      "description": "静态资源、样式、安装脚本、更新脚本和本地运维辅助文件。",
+      "nodeIds": [
+        "file:assets/icon.icns",
+        "file:assets/style.css",
+        "file:assets/updater/update.bat",
+        "file:assets/updater/update.sh",
+        "file:install.sh"
+      ]
+    },
+    {
+      "id": "layer:infrastructure",
+      "name": "基础设施与 CI 层",
+      "description": "Docker、Compose、GitHub Actions、发布流水线和仓库自动化。",
+      "nodeIds": [
+        "resource:.dockerignore",
+        "document:.github/pull_request_template.md",
+        "pipeline:.github/workflows/container-image.yml",
+        "pipeline:.github/workflows/drawer.yml",
+        "pipeline:.github/workflows/publish-pypi.yml",
+        "pipeline:.github/workflows/ruff-check.yml",
+        "pipeline:.github/workflows/ruff-format.yml",
+        "service:docker-compose.yml",
+        "service:Dockerfile"
+      ]
+    },
+    {
+      "id": "layer:documentation",
+      "name": "文档层",
+      "description": "README、安装、Docker 部署、自建代理和项目支持指南。",
+      "nodeIds": [
+        "document:docs/docker-deployment.md",
+        "document:docs/installation.md",
+        "document:docs/proxy-self-hosting.md",
+        "document:README.md",
+        "document:requirements.txt"
+      ]
+    },
+    {
+      "id": "layer:shared-root",
+      "name": "共享工具层",
+      "description": "未归入特定业务层的根模块、通用工具和版本/更新辅助模块。",
+      "nodeIds": [
+        "file:__init__.py",
+        "file:.python-version",
+        "file:.understand-anything/.understandignore",
+        "file:app_update.py",
+        "file:app_version.py",
+        "file:main.spec",
+        "file:util/__init__.py",
+        "file:util/ErrorCodes.py",
+        "file:util/TimeUtil.py"
+      ]
+    }
+  ],
+  "tour": [
+    {
+      "order": 1,
+      "title": "项目概览",
+      "description": "先从 README 理解项目定位：这是一个开源的 B 站会员购/票务辅助工具，并链接到安装、讨论和问题反馈入口。它给后续代码阅读提供业务背景。",
+      "nodeIds": [
+        "document:README.md"
+      ]
+    },
+    {
+      "order": 2,
+      "title": "运行入口",
+      "description": "main.py 是命令行使用路径的主入口，负责把配置和购票流程串起来。结合 pyproject.toml 可以看到项目如何作为 btb 命令暴露给用户。",
+      "nodeIds": [
+        "file:main.py",
+        "config:pyproject.toml"
+      ]
+    },
+    {
+      "order": 3,
+      "title": "命令行购票流",
+      "description": "app_cmd 包把命令行参数、购票配置和 ticker 执行流程连接起来。这里最适合观察用户输入如何转成一次具体的购票任务。",
+      "nodeIds": [
+        "file:app_cmd/buy.py",
+        "file:app_cmd/cli_args.py",
+        "file:app_cmd/ticker.py",
+        "file:app_cmd/config/BuyConfig.py"
+      ]
+    },
+    {
+      "order": 4,
+      "title": "界面标签页",
+      "description": "tab 模块组织图形界面中的配置、执行、日志、设置和更新页面。它把底层接口能力包装成用户能直接操作的 Gradio 页面。",
+      "nodeIds": [
+        "file:tab/config.py",
+        "file:tab/go.py",
+        "file:tab/log.py",
+        "file:tab/settings.py",
+        "file:assets/style.css"
+      ]
+    },
+    {
+      "order": 5,
+      "title": "接口适配层",
+      "description": "interface 包封装登录、项目搜索、项目详情、配置校验和任务执行能力，是 UI 与核心购票逻辑之间的稳定边界。",
+      "nodeIds": [
+        "file:interface/auth.py",
+        "file:interface/project.py",
+        "file:interface/config.py",
+        "file:interface/execution.py",
+        "file:interface/search.py"
+      ]
+    },
+    {
+      "order": 6,
+      "title": "核心购票任务",
+      "description": "task/buy.py 与相关类型、辅助模块承载真正的下单编排逻辑。它依赖请求、代理、令牌和配置模块，是理解业务流程的关键节点。",
+      "nodeIds": [
+        "file:task/buy.py",
+        "file:task/buy_helpers.py",
+        "file:task/buy_types.py"
+      ]
+    },
+    {
+      "order": 7,
+      "title": "请求与 Cookie",
+      "description": "util/request 负责 HTTP 请求封装、Cookie 管理、浏览器状态和异常分类。购票流程中的网络可靠性主要从这一层建立。",
+      "nodeIds": [
+        "file:util/request/BiliRequest.py",
+        "file:util/request/CookieManager.py",
+        "file:util/request/BrowerState.py",
+        "file:util/request/exceptions/__init__.py"
+      ]
+    },
+    {
+      "order": 8,
+      "title": "代理与通知",
+      "description": "代理模块管理代理来源、状态、退避和测速，通知模块负责把关键状态推送到不同渠道。二者共同增强抢票过程的可用性和可观测性。",
+      "nodeIds": [
+        "file:util/proxy/ProxyManager.py",
+        "file:util/proxy/ProxyState.py",
+        "file:util/notifer/Notifier.py",
+        "file:util/notifer/NtfyUtil.py"
+      ]
+    },
+    {
+      "order": 9,
+      "title": "测试覆盖",
+      "description": "tests 目录覆盖请求恢复、限流、维护、代理策略、通知等待、购票准备和 UI 配置等场景。读测试能快速确认项目认为哪些行为必须稳定。",
+      "nodeIds": [
+        "file:tests/test_bili_request_h2_recovery.py",
+        "file:tests/test_bili_request_rate_limit.py",
+        "file:tests/test_buy_prepare_token.py",
+        "file:tests/test_proxy_api_provider.py"
+      ]
+    },
+    {
+      "order": 10,
+      "title": "部署与发布",
+      "description": "Docker、Compose 和 GitHub Actions 描述项目如何容器化、构建镜像、执行检查并发布包。它们把本地代码连接到可复现运行和发布流程。",
+      "nodeIds": [
+        "service:Dockerfile",
+        "service:docker-compose.yml",
+        "pipeline:.github/workflows/container-image.yml",
+        "pipeline:.github/workflows/publish-pypi.yml"
+      ],
+      "languageLesson": "Dockerfile 和 CI YAML 都是声明式配置：文件描述期望的构建/发布步骤，执行器按配置顺序运行。"
+    },
+    {
+      "order": 11,
+      "title": "运维文档",
+      "description": "docs 目录补足安装、Docker 部署和自建代理的实际操作路径。理解代码后再读这些文档，更容易把模块职责映射到真实部署方式。",
+      "nodeIds": [
+        "document:docs/installation.md",
+        "document:docs/docker-deployment.md",
+        "document:docs/proxy-self-hosting.md"
+      ]
+    }
+  ]
+}

--- a/docs/contributor-dashboard.md
+++ b/docs/contributor-dashboard.md
@@ -1,0 +1,81 @@
+# 贡献者代码阅读 Dashboard
+
+本项目使用 [Understand Anything](https://github.com/Egonex-AI/Understand-Anything) 的原版 Dashboard 展示代码知识图谱，帮助贡献者快速理解项目结构、关键模块、函数/类关系和推荐阅读路径。
+
+## 初始化
+
+首次拉取本仓库后，初始化 Dashboard 子模块：
+
+```bash
+git submodule update --init --recursive tools/understand-anything
+```
+
+## 启动
+
+Windows PowerShell：
+
+```powershell
+.\tools\start-understand-dashboard.ps1
+```
+
+脚本会：
+
+1. 确认 `tools/understand-anything` 子模块已初始化。
+2. 使用 `corepack pnpm` 安装 Dashboard 依赖。
+3. 构建 `@understand-anything/core`。
+4. 以仓库根目录作为 `GRAPH_DIR` 启动原版 Dashboard。
+
+启动后终端会输出带 token 的本地地址，例如：
+
+```text
+Dashboard URL: http://127.0.0.1:5173/?token=...
+```
+
+请使用带 `token` 参数的完整 URL 打开页面。
+
+## 代码变更后更新 Dashboard
+
+当新增代码、删除模块、调整目录结构或进行较大重构后，通常只需要更新知识图谱快照：
+
+```text
+.understand-anything/knowledge-graph.json
+```
+
+推荐流程：
+
+1. 在最新代码基础上重新生成 Understand Anything 图谱。
+2. 确认 `.understand-anything/config.json` 中的 `outputLanguage` 仍为 `zh`。
+3. 运行 Dashboard，检查节点数、层级和导览路径是否符合新的代码结构。
+4. 将更新后的 `.understand-anything/knowledge-graph.json` 一并提交。
+
+如果只是新增或重构业务代码，通常不需要更新 `tools/understand-anything` 子模块。
+
+只有在以下情况才建议更新子模块：
+
+- 需要 Understand Anything Dashboard 的新功能或 bug fix。
+- 当前固定的 Dashboard 版本无法正确读取新的图谱格式。
+- 维护者明确希望同步到新的 Understand Anything 上游版本。
+
+更新子模块时，可以在仓库根目录执行：
+
+```bash
+git submodule update --remote tools/understand-anything
+```
+
+然后重新运行 Dashboard，确认页面能正常读取 `.understand-anything/knowledge-graph.json`。
+
+## 当前图谱位置
+
+当前图谱快照位于：
+
+```text
+.understand-anything/knowledge-graph.json
+```
+
+如需让 Dashboard 默认显示简体中文，请保留：
+
+```text
+.understand-anything/config.json
+```
+
+其中的 `outputLanguage` 应为 `zh`。

--- a/tools/start-understand-dashboard.ps1
+++ b/tools/start-understand-dashboard.ps1
@@ -1,0 +1,108 @@
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$submoduleRoot = Join-Path $repoRoot "tools\understand-anything"
+$graphPath = Join-Path $repoRoot ".understand-anything\knowledge-graph.json"
+
+function Test-DashboardRoot {
+    param([string]$Root)
+    if (-not $Root) {
+        return $false
+    }
+    return Test-Path (Join-Path $Root "packages\dashboard\package.json")
+}
+
+function Resolve-PluginRoot {
+    param([string]$Root)
+    if (Test-DashboardRoot $Root) {
+        return (Resolve-Path $Root)
+    }
+
+    $nested = Join-Path $Root "understand-anything-plugin"
+    if (Test-DashboardRoot $nested) {
+        return (Resolve-Path $nested)
+    }
+
+    return $null
+}
+
+function Resolve-DashboardRoot {
+    $submodulePluginRoot = Resolve-PluginRoot $submoduleRoot
+    if ($submodulePluginRoot) {
+        return $submodulePluginRoot
+    }
+
+    Write-Host "Understand Anything submodule is not ready. Trying to initialize it..."
+    git -C $repoRoot submodule update --init --recursive tools/understand-anything
+    $submodulePluginRoot = Resolve-PluginRoot $submoduleRoot
+    if ($LASTEXITCODE -eq 0 -and $submodulePluginRoot) {
+        return $submodulePluginRoot
+    }
+
+    $fallbacks = @(
+        (Join-Path $HOME ".understand-anything\repo\understand-anything-plugin"),
+        (Join-Path $HOME ".understand-anything-plugin"),
+        (Join-Path $HOME "understand-anything\understand-anything-plugin")
+    )
+
+    foreach ($candidate in $fallbacks) {
+        $candidatePluginRoot = Resolve-PluginRoot $candidate
+        if ($candidatePluginRoot) {
+            Write-Host "Using local Understand Anything checkout: $candidate"
+            return $candidatePluginRoot
+        }
+    }
+
+    throw @"
+Could not find Understand Anything dashboard.
+
+The submodule clone failed or is incomplete:
+  $submoduleRoot
+
+Try one of these:
+  git submodule update --init --recursive tools/understand-anything
+  git -C tools/understand-anything pull
+
+If GitHub is unreachable from your network, clone the project manually or place an existing checkout at:
+  $submoduleRoot
+"@
+}
+
+if (-not (Test-Path $graphPath)) {
+    throw "Knowledge graph not found: $graphPath. Generate or commit it first."
+}
+
+if (-not (Get-Command corepack -ErrorAction SilentlyContinue)) {
+    throw "corepack was not found. Install Node.js 22 or newer and try again."
+}
+
+$dashboardRoot = Resolve-DashboardRoot
+$dashboardPackage = Join-Path $dashboardRoot "packages\dashboard"
+
+Write-Host "Installing dashboard dependencies..."
+Push-Location $dashboardRoot
+try {
+    corepack pnpm install --frozen-lockfile
+    if ($LASTEXITCODE -ne 0) {
+        throw "pnpm install failed."
+    }
+
+    corepack pnpm --filter "@understand-anything/core" build
+    if ($LASTEXITCODE -ne 0) {
+        throw "core build failed."
+    }
+}
+finally {
+    Pop-Location
+}
+
+Write-Host "Starting Understand Anything Dashboard..."
+Write-Host "Open the Dashboard URL printed by Vite, including the token query parameter."
+$env:GRAPH_DIR = $repoRoot
+Push-Location $dashboardPackage
+try {
+    corepack pnpm exec vite --host 127.0.0.1
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
﻿## 概述

本 PR 新增贡献者代码阅读入口，使用 Understand Anything 原版 Dashboard 展示本项目的中文代码知识图谱。

调整：

- Dashboard 改为使用 Understand Anything 原版交互界面。
- Dashboard 补齐路径查找、领域图、导出错误、空状态等简体中文文案。
- 图谱快照已补充更细的 Python 函数/类摘要和更多 `calls` 调用关系，Dashboard 默认进入“文件 + 类 + 函数”细节视图。

变更内容：

- 通过 Git submodule 引入 `LingRadiance/Understand-Anything`，路径为 `tools/understand-anything`
- submodule 指向包含简体中文和细节视图补丁的提交：`cd49319`
- 提交当前项目的中文知识图谱快照：`.understand-anything/knowledge-graph.json`
- 提交简体中文 Dashboard 配置：`.understand-anything/config.json`
- 新增中文使用文档：`docs/contributor-dashboard.md`
- 新增 PowerShell 启动脚本：`tools/start-understand-dashboard.ps1`

### 事务

- [ ] 已与维护者在 issues 或其他平台沟通此 PR 大致内容

## 以下内容可在起草 PR 后、合并 PR 前逐步完成

### 功能

- [x] 已使用原版 Understand Anything Dashboard 作为代码阅读界面
- [x] 已补充 Dashboard 简体中文文案缺口
- [x] 已默认展示更细的文件、类、函数级结构
- [x] 已提供更细粒度中文知识图谱快照
- [x] 已提供简体中文配置
- [x] 已编写贡献者使用说明
- [x] 已提供本地启动脚本
- [x] 已说明代码新增或重构后如何更新 Dashboard

使用方式：

```bash
git submodule update --init --recursive tools/understand-anything
```

Windows PowerShell：

```powershell
.\tools\start-understand-dashboard.ps1
```

启动后使用终端输出的带 token URL 打开 Dashboard。

### 代码变更后如何更新 Dashboard

当新增代码、删除模块、调整目录结构或进行较大重构后，通常只需要重新生成并提交：

```text
.understand-anything/knowledge-graph.json
```

推荐流程：

1. 在最新代码基础上重新生成 Understand Anything 图谱。
2. 确认 `.understand-anything/config.json` 中的 `outputLanguage` 仍为 `zh`。
3. 运行 Dashboard，检查节点数、层级和导览路径是否符合新的代码结构。
4. 将更新后的 `.understand-anything/knowledge-graph.json` 一并提交。

一般业务代码新增或重构不需要更新 `tools/understand-anything` 子模块。只有需要 Dashboard 新功能、bug fix、图谱格式兼容更新，或维护者要求同步上游时，才更新子模块。

### 兼容性

- [x] 不影响现有 Python 包、CLI、Gradio 界面或测试流程
- [x] Dashboard 后续可通过 submodule 更新
- [x] 业务代码变化时通常只需要更新 `.understand-anything/knowledge-graph.json`

### 风险

可能导致或已知的问题：

- 贡献者首次使用前需要初始化 submodule。
- 首次启动会安装 Dashboard 的 Node/pnpm 依赖，需要 Node.js/corepack 环境。
- 当前 submodule 指向 `LingRadiance/Understand-Anything` fork 中的中文补丁提交；后续可将该补丁同步回 Understand Anything 上游后再切回上游仓库。
- 默认展示函数级细节会比文件级视图更密集；如需快速浏览架构，可在 Dashboard 顶栏切回“文件”。
- `knowledge-graph.json` 是当前代码结构快照，主分支变化较大时需要重新生成。
- 当前启动脚本优先覆盖 Windows PowerShell；如需 Linux/macOS，可后续补充 shell 脚本。

### 验证

- [x] Dashboard package 构建通过：`corepack pnpm --filter @understand-anything/dashboard build`
- [x] PowerShell 脚本语法检查通过
- [x] PowerShell 脚本保持 ASCII，避免 Windows 编码解析问题
- [x] 使用 Node.js 解析 `.understand-anything/knowledge-graph.json`
- [x] 图谱快照包含 615 个节点、1494 条关系、10 个层级、11 个导览步骤
- [x] `calls` 调用关系增加到 373 条
- [x] 已确认常见泛化英文摘要为 0
- [x] 已确认常见 Dashboard 中文界面硬编码英文已清理
- [x] 已确认 submodule 初始化后路径结构可被启动脚本识别
