### PR TITLE
修复预热复检异常退出和直连并发触发 900001

### DIFF
--- a/task/buy.py
+++ b/task/buy.py
@@ -59,6 +59,25 @@ from util.request.exceptions import BiliConnectionError, BiliRateLimitError
 LOCAL_FANOUT_PROXY_STRATEGY = "local_fanout"
 
 
+def _local_fanout_h2_client_config(proxy_string: str | None):
+    from util.h2client.ja_h2_client import ProxyPoolCreateV2FanoutJA3H2Client
+
+    proxy_pool = [
+        proxy
+        for proxy in ProxyManager.parse_proxy_list(proxy_string)
+        if proxy.lower() != "none"
+    ]
+    if not proxy_pool:
+        logger.warning(
+            "代理池并发策略未检测到代理节点，已回退为标准请求，避免直连并发触发 900001"
+        )
+        return None, None
+    return ProxyPoolCreateV2FanoutJA3H2Client, {
+        "proxy_pool": proxy_pool,
+        "connections_per_source_ip": 1,
+    }
+
+
 @dataclass(slots=True)
 class Buy:
     config: BuyConfig
@@ -203,6 +222,40 @@ def _extract_prepare_token(result: dict | None) -> str | None:
 
 def _format_reprepare_reason(reason: str) -> str:
     return f"重新准备订单，原因：{reason}"
+
+
+def _refresh_project_detail_and_warm_connection(
+    *,
+    request: BiliRequest,
+    tickets_info: dict,
+    is_hot_project: bool,
+) -> tuple[bool, list[str]]:
+    logger.info("预热/复检：开始拉取项目详情并预热连接")
+    messages: list[str] = []
+    try:
+        payload = fetch_project_payload(
+            request=request,
+            project_id=int(tickets_info["project_id"]),
+        )
+    except Exception as exc:
+        message = f"预热/复检：拉取项目详情失败，继续使用当前票档配置: {exc}"
+        logger.warning(message)
+        messages.append(message)
+    else:
+        if bool(payload["hotProject"]) and not is_hot_project:
+            is_hot_project = True
+            tickets_info["is_hot_project"] = True
+            logger.info("预热/复检：检测到 hotProject=True，已升级为 hot 抢票策略")
+        else:
+            logger.info("预热/复检完成。")
+
+    try:
+        request.prewarm_h2_connection(f"{base_url}/")
+    except Exception as exc:
+        message = f"预热/复检：预热连接失败，继续抢票: {exc}"
+        logger.warning(message)
+        messages.append(message)
+    return is_hot_project, messages
 
 
 def buy_stream(config: BuyConfig):
@@ -397,15 +450,9 @@ def buy_stream(config: BuyConfig):
     h2_client_type = None
     h2_client_options = None
     if config.create_request_proxy_strategy == LOCAL_FANOUT_PROXY_STRATEGY:
-        from util.h2client.ja_h2_client import ProxyPoolCreateV2FanoutJA3H2Client
-
-        proxy_pool = [
-            proxy
-            for proxy in ProxyManager.parse_proxy_list(config.https_proxys)
-            if proxy.lower() != "none"
-        ]
-        h2_client_type = ProxyPoolCreateV2FanoutJA3H2Client
-        h2_client_options = {"proxy_pool": proxy_pool}
+        h2_client_type, h2_client_options = _local_fanout_h2_client_config(
+            config.https_proxys
+        )
     _request = BiliRequest(
         cookies=cookies,
         proxy=config.https_proxys,
@@ -431,17 +478,12 @@ def buy_stream(config: BuyConfig):
 
     def refresh_hot_and_warm():
         nonlocal is_hot_project
-        logger.info("预热/复检：开始拉取项目详情并预热连接")
-        payload = fetch_project_payload(
-            request=_request, project_id=int(tickets_info["project_id"])
+        is_hot_project, messages = _refresh_project_detail_and_warm_connection(
+            request=_request,
+            tickets_info=tickets_info,
+            is_hot_project=is_hot_project,
         )
-        if bool(payload["hotProject"]) and not is_hot_project:
-            is_hot_project = True
-            tickets_info["is_hot_project"] = True
-            logger.info("预热/复检：检测到 hotProject=True，已升级为 hot 抢票策略")
-        else:
-            logger.info("预热/复检完成。")
-        _request.prewarm_h2_connection(f"{base_url}/")
+        return messages
 
     # 循环内主动复检项目详情：按随机 create 次数触发纯拉取，与 100001 路径共享计数。
     # fetch 落在两次 create 的 sleep 窗口，不与 create 并发。

--- a/tests/test_local_fanout_proxy_strategy.py
+++ b/tests/test_local_fanout_proxy_strategy.py
@@ -4,6 +4,7 @@ import httpx
 
 from app_cmd.config.BuyConfig import BuyConfig
 from interface.config import build_runtime_options
+from task.buy import _local_fanout_h2_client_config
 from tab.go import _build_task_proxy_list
 from util.request.BiliRequest import AbstractH2Client, BiliRequest
 from util.h2client.h2connection import H2Response
@@ -154,6 +155,26 @@ def test_runtime_strategy_flows_into_buy_config():
 
     assert config.create_request_proxy_strategy == "local_fanout"
     assert "--create-request-proxy-strategy" in config.to_cli_args()
+
+
+def test_local_fanout_h2_config_requires_real_proxy_pool():
+    assert _local_fanout_h2_client_config("") == (None, None)
+    assert _local_fanout_h2_client_config("none,direct") == (None, None)
+
+
+def test_local_fanout_h2_config_uses_one_connection_per_proxy():
+    h2_client_type, h2_client_options = _local_fanout_h2_client_config(
+        "none,http://127.0.0.1:18080,direct,socks5://127.0.0.1:19090"
+    )
+
+    assert h2_client_type is ProxyPoolCreateV2FanoutJA3H2Client
+    assert h2_client_options == {
+        "proxy_pool": [
+            "http://127.0.0.1:18080",
+            "socks5://127.0.0.1:19090",
+        ],
+        "connections_per_source_ip": 1,
+    }
 
 
 def test_h2_client_constructor_uses_abstract_client_interface():

--- a/tests/test_local_fanout_proxy_strategy.py
+++ b/tests/test_local_fanout_proxy_strategy.py
@@ -264,7 +264,7 @@ def test_proxy_pool_fanout_builds_one_create_connection_per_proxy():
     ]
 
 
-def test_proxy_pool_fanout_repeats_until_one_proxy_succeeds():
+def test_proxy_pool_fanout_returns_900001_after_one_round():
     FakeH2Connection.instances = []
     FakeH2Connection.post_bodies_by_proxy = {
         "http://127.0.0.1:18080": [b'{"errno":900001}', b'{"errno":900001}'],
@@ -284,11 +284,42 @@ def test_proxy_pool_fanout_repeats_until_one_proxy_succeeds():
         json={"project_id": 1},
     )
 
-    assert response.json()["errno"] == 0
+    assert response.json()["errno"] == 900001
     post_count = sum(
         1
         for instance in FakeH2Connection.instances
         for call in instance.calls
         if call[0] == "POST"
     )
-    assert post_count >= 4
+    assert post_count == 2
+    assert FakeH2Connection.post_bodies_by_proxy == {
+        "http://127.0.0.1:18080": [b'{"errno":900001}'],
+        "http://127.0.0.1:28080": [b'{"errno":0}'],
+    }
+
+
+def test_proxy_pool_fanout_detects_percent_encoded_create_v2_path():
+    FakeH2Connection.instances = []
+    FakeH2Connection.post_bodies_by_proxy = {}
+    client = ProxyPoolCreateV2FanoutJA3H2Client(
+        proxy_pool=[
+            "http://127.0.0.1:18080",
+            "http://127.0.0.1:28080",
+        ],
+        connection_factory=FakeH2Connection,
+        connections_per_source_ip=1,
+    )
+    encoded_url = "https://show.bilibili.com/api/%74icket/order/crea%74eV%32"
+
+    response = client.post(encoded_url, json={"project_id": 1})
+
+    assert response.status_code == 200
+    business_connections = [
+        instance
+        for instance in FakeH2Connection.instances
+        if instance.calls and instance.calls[-1][1] == encoded_url
+    ]
+    assert sorted(instance.proxy_url for instance in business_connections) == [
+        "http://127.0.0.1:18080",
+        "http://127.0.0.1:28080",
+    ]

--- a/tests/test_warmup_resilience.py
+++ b/tests/test_warmup_resilience.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+try:
+    import qrcode  # noqa: F401
+except ModuleNotFoundError:
+    sys.modules["qrcode"] = types.ModuleType("qrcode")
+
+buy_module = importlib.import_module("task.buy")
+
+
+class FakeRequest:
+    def __init__(self) -> None:
+        self.prewarmed_urls: list[str] = []
+
+    def prewarm_h2_connection(self, url: str) -> None:
+        self.prewarmed_urls.append(url)
+
+
+def test_refresh_project_detail_failure_does_not_abort_warmup(monkeypatch):
+    request = FakeRequest()
+    tickets_info = {"project_id": 1003349, "is_hot_project": False}
+
+    def fail_fetch_project_payload(*, request, project_id):
+        raise RuntimeError("new=410 Gone; old=HTTP 429")
+
+    monkeypatch.setattr(
+        buy_module,
+        "fetch_project_payload",
+        fail_fetch_project_payload,
+    )
+
+    is_hot_project, messages = buy_module._refresh_project_detail_and_warm_connection(
+        request=request,
+        tickets_info=tickets_info,
+        is_hot_project=False,
+    )
+
+    assert is_hot_project is False
+    assert request.prewarmed_urls == ["https://show.bilibili.com/"]
+    assert len(messages) == 1
+    assert "410 Gone" in messages[0]
+    assert "HTTP 429" in messages[0]
+
+
+def test_refresh_project_detail_can_upgrade_hot_project(monkeypatch):
+    request = FakeRequest()
+    tickets_info = {"project_id": 1003349, "is_hot_project": False}
+
+    def fetch_hot_project(*, request, project_id):
+        return {"hotProject": True}
+
+    monkeypatch.setattr(buy_module, "fetch_project_payload", fetch_hot_project)
+
+    is_hot_project, messages = buy_module._refresh_project_detail_and_warm_connection(
+        request=request,
+        tickets_info=tickets_info,
+        is_hot_project=False,
+    )
+
+    assert is_hot_project is True
+    assert tickets_info["is_hot_project"] is True
+    assert request.prewarmed_urls == ["https://show.bilibili.com/"]
+    assert messages == []

--- a/util/h2client/ja_h2_client.py
+++ b/util/h2client/ja_h2_client.py
@@ -184,12 +184,6 @@ def _response_errno(response: httpx.Response) -> int | None:
         return None
 
 
-def _is_create_success_response(response: httpx.Response) -> bool:
-    if response.status_code != 200:
-        return False
-    return _response_errno(response) == 0
-
-
 class _SourcePoolJA3H2Client(AbstractH2Client):
     def __init__(
         self,
@@ -701,9 +695,11 @@ class _CreateV2FanoutJA3H2Client(_SourcePoolJA3H2Client):
 
     def _should_fanout_create_v2(self, url: str) -> bool:
         parsed = urllib.parse.urlsplit(url)
+        decoded_path = urllib.parse.unquote(parsed.path)
         return (
-            parsed.hostname or ""
-        ).lower() == self._healthcheck_host.lower() and "createV2" in parsed.path
+            (parsed.hostname or "").lower() == self._healthcheck_host.lower()
+            and "createv2" in decoded_path.lower()
+        )
 
     def _send_fanout_request(
         self,
@@ -819,64 +815,61 @@ class ProxyPoolCreateV2FanoutJA3H2Client(_CreateV2FanoutJA3H2Client):
         first_other: httpx.Response | None = None
         last_exc: Exception | None = None
 
-        while True:
-            pool = list(self._ensure_pool(host, port))
-            if not pool:
-                if first_other is not None:
-                    return first_other
-                if first_900001 is not None:
-                    return first_900001
-                if first_429 is not None:
-                    return first_429
-                if first_412 is not None:
-                    return first_412
-                raise self._to_httpx_error(method, url, last_exc)
+        pool = list(self._ensure_pool(host, port))
+        if not pool:
+            raise self._to_httpx_error(method, url, None)
 
-            executor = ThreadPoolExecutor(
-                max_workers=len(pool),
-                thread_name_prefix="btb-proxy-createv2-fanout",
+        executor = ThreadPoolExecutor(
+            max_workers=len(pool),
+            thread_name_prefix="btb-proxy-createv2-fanout",
+        )
+        futures = [
+            executor.submit(
+                self._send_fanout_request,
+                slot,
+                method,
+                url,
+                request_headers,
+                content,
+                request,
             )
-            futures = [
-                executor.submit(
-                    self._send_fanout_request,
-                    slot,
-                    method,
-                    url,
-                    request_headers,
-                    content,
-                    request,
+            for slot in pool
+        ]
+        for future in futures:
+            future.add_done_callback(
+                lambda done, host=host, port=port: self._handle_fanout_done(
+                    host,
+                    port,
+                    done,
                 )
-                for slot in pool
-            ]
-            for future in futures:
-                future.add_done_callback(
-                    lambda done, host=host, port=port: self._handle_fanout_done(
-                        host,
-                        port,
-                        done,
-                    )
-                )
+            )
 
-            try:
-                for future in as_completed(futures):
-                    outcome = future.result()
-                    if outcome.response is None:
-                        last_exc = outcome.exc
-                        continue
+        try:
+            for future in as_completed(futures):
+                outcome = future.result()
+                if outcome.response is None:
+                    last_exc = outcome.exc
+                    continue
 
-                    if _is_create_success_response(outcome.response):
-                        executor.shutdown(wait=False, cancel_futures=False)
-                        return outcome.response
+                status_code = outcome.response.status_code
+                errno = _response_errno(outcome.response)
+                if status_code == 200 and errno == 900001 and first_900001 is None:
+                    first_900001 = outcome.response
+                elif status_code == 429 and first_429 is None:
+                    first_429 = outcome.response
+                elif status_code == 412 and first_412 is None:
+                    first_412 = outcome.response
+                elif status_code not in {412, 429} and first_other is None:
+                    first_other = outcome.response
 
-                    status_code = outcome.response.status_code
-                    errno = _response_errno(outcome.response)
-                    if status_code == 200 and errno == 900001 and first_900001 is None:
-                        first_900001 = outcome.response
-                    elif status_code == 429 and first_429 is None:
-                        first_429 = outcome.response
-                    elif status_code == 412 and first_412 is None:
-                        first_412 = outcome.response
-                    elif status_code not in {412, 429} and first_other is None:
-                        first_other = outcome.response
-            finally:
-                executor.shutdown(wait=True, cancel_futures=False)
+            if first_other is not None:
+                return first_other
+            if first_900001 is not None:
+                return first_900001
+            if first_429 is not None:
+                return first_429
+            if first_412 is not None:
+                return first_412
+            raise self._to_httpx_error(method, url, last_exc)
+        finally:
+            executor.shutdown(wait=True, cancel_futures=False)


### PR DESCRIPTION
﻿## 概述

修复两个抢票流程稳定性问题：

- 开售前预热/复检拉取项目详情失败时，不再让异常冒泡中断 `wait_until_start`，改为记录告警并继续使用当前票档配置抢票。
- 代理池并发策略在没有真实代理节点时回退标准请求，避免直连出口被 fanout 放大后稳定触发 `900001`；有真实代理池时每个代理节点只使用 1 条 createV2 并发连接。

### 事项

- [x] 已与维护者在 issues 或其他平台沟通此 PR 大致内容

## 以下内容可在起草 PR 后、合并 PR 前逐步完成

### 功能

- [x] 已编写完善的配置文件字段说明（若有新增）
- [x] 已编写面向用户的新功能说明（若有必要）
- [x] 已测试新功能或更改

### 兼容性

- [x] 已处理版本兼容性
- [x] 已处理插件兼容问题

### 风险

可能导致或已知的问题:

- 未配置代理池但选择代理池并发策略时，会回退为标准请求，不再进行直连 fanout。
- 预热/复检失败会继续抢票，可能沿用启动时已有的票档配置；日志会保留失败原因用于排查。

### 验证

```powershell
.venv\Scripts\python.exe -m pytest --confcutdir=tests tests/test_warmup_resilience.py tests/test_local_fanout_proxy_strategy.py tests/test_bili_request_h2_recovery.py tests/test_bili_request_rate_limit.py tests/test_proxy_api_provider.py
# 25 passed

.venv\Scripts\python.exe -m compileall -q task\buy.py tests\test_warmup_resilience.py tests\test_local_fanout_proxy_strategy.py
# exit 0
```
