### PR TITLE
fix:开抢前预热/复检项目详情失败会直接中断抢票流程问题

### DIFF
--- a/task/buy_helpers.py
+++ b/task/buy_helpers.py
@@ -6,6 +6,8 @@ import time
 from collections.abc import Callable
 from typing import Any
 
+from loguru import logger
+
 from cptoken import CTokenRuntimeState, sim_ctoken_state
 
 from util import time_service
@@ -146,7 +148,12 @@ def wait_until_start(time_start: str, warmup=None):
             }
         if not warmed and warmup is not None and remaining <= WARMUP_AT_SECONDS:
             warmed = True
-            for warm_message in warmup() or []:
+            try:
+                warm_messages = warmup() or []
+            except Exception as exc:
+                logger.warning(f"预热/复检失败（忽略）：{exc}")
+                warm_messages = [f"预热/复检失败（忽略）：{exc}"]
+            for warm_message in warm_messages:
                 yield {
                     "message": warm_message,
                     "countdown": countdown_text,

--- a/tests/test_buy_time_sync.py
+++ b/tests/test_buy_time_sync.py
@@ -27,6 +27,35 @@ class _FakeTimeService:
         return 1234567890
 
 
+class _FakeCountdownTimeService:
+    time_source = "fake"
+
+    def __init__(self):
+        self._now = 0.0
+
+    def get_timeoffset(self):
+        return 0.0
+
+    def compute_bili_time_check(self, attempts=2, timeout=1.5):
+        return None
+
+    def countdown_time_source(self):
+        return "fake"
+
+    def countdown_now(self):
+        self._now += 1.0
+        return self._now
+
+
+class _FakePerfCounter:
+    def __init__(self):
+        self._now = -1.0
+
+    def __call__(self):
+        self._now += 1.0
+        return self._now
+
+
 def test_prepare_create_request_uses_calibrated_timestamp(monkeypatch):
     monkeypatch.setattr(buy_helpers, "time_service", _FakeTimeService())
     monkeypatch.setattr(
@@ -59,3 +88,24 @@ def test_prepare_create_request_uses_calibrated_timestamp(monkeypatch):
     assert "sale_start" not in payload
     assert "username" not in payload
     assert "detail" not in payload
+
+
+def test_wait_until_start_reports_warmup_failure_without_raising(monkeypatch):
+    monkeypatch.setattr(buy_helpers, "time_service", _FakeCountdownTimeService())
+    monkeypatch.setattr(buy_helpers.time, "perf_counter", _FakePerfCounter())
+    monkeypatch.setattr(buy_helpers.time, "sleep", lambda seconds: None)
+
+    def fail_warmup():
+        raise RuntimeError("failed to fetch project detail")
+
+    events = list(
+        buy_helpers.wait_until_start(
+            "1970-01-01 08:00:04",
+            warmup=fail_warmup,
+        )
+    )
+
+    messages = [event.get("message") for event in events]
+    assert any(
+        "failed to fetch project detail" in str(message) for message in messages
+    )


### PR DESCRIPTION
﻿## 概述

修复开抢前 warmup/复检项目详情失败会直接中断抢票流程的问题。

报错原因：`wait_until_start()` 在开抢前约 5 秒触发 `refresh_hot_and_warm()`。该 warmup 会重新拉取项目详情并预热连接；当代理服务在新项目详情接口的 HTTPS CONNECT 阶段返回 `410 Gone`（该错误码是代理问题），且旧项目详情接口又返回 HTTP 429 时，`fetch_project_payload()` 会抛出 `RuntimeError`，原逻辑没有兜底，导致任务在进入 prepare/create 下单阶段前异常退出。

修复内容：

- 在 countdown warmup 调用处捕获 warmup 异常。
- 将异常记录为 warning，并向状态流输出“预热/复检失败（忽略）...”提示。
- 保持等待流程继续执行，避免代理瞬时失效或接口限流阻断后续下单尝试。
- 新增回归测试，覆盖 warmup 抛错时不会向外抛出异常，并能返回可见失败消息。

### 事务

- [ ] 已与维护者在 issues 或其他平台沟通此 PR 大致内容

## 以下内容可在起草 PR 后、合并 PR 前逐步完成

### 功能

- [x] 已编写/更新相关测试
- [x] 已测试新功能或更改
- [ ] 已编写完善的配置文件字段说明（无新增配置项）
- [ ] 已编写面向用户的新功能说明（修复项，暂无新增用户功能说明）

### 兼容性

- [x] 未引入新的配置字段或外部接口变更
- [x] 不改变首次项目详情拉取失败的行为，仅让开抢前 warmup 失败非致命

### 风险

可能导致或已知的问题：

- warmup/复检失败会被忽略，后续流程可能使用已有项目配置继续尝试下单；如果项目详情确实发生变化，本次 warmup 不再强制中断任务。
- 已通过 warning 和状态消息保留可观测性，便于用户知道 warmup 曾失败。

### 验证

- [x] `python -m py_compile task\buy_helpers.py tests\test_buy_time_sync.py`
- [x] 依赖桩直接执行 `wait_until_start()` warmup 异常路径，确认异常被转换为状态消息且流程继续

说明：当前本地系统 Python 未安装项目测试依赖，直接运行 pytest 会缺少 `pytest`/`loguru`，因此没有跑完整 pytest suite。
