### PR TITLE
重构代理服务商API获取代理IP模块逻辑以兼容更多代理服务商API

### DIFF
--- a/demos/proxy-api/provider-demos.md
+++ b/demos/proxy-api/provider-demos.md
@@ -1,0 +1,147 @@
+# Proxy API Provider Demos
+
+All examples are sanitized. Credential-like query values are intentionally left blank.
+
+## Youdaili
+
+Demo URL shape, with credential values omitted:
+
+```text
+http://api.youdaili.com/v1/proxy/get?count=5&format=json&protocol=http
+```
+
+Representative JSON:
+
+```json
+{
+  "code": 0,
+  "msg": "OK",
+  "data": {
+    "count": 1,
+    "proxy_list": [
+      { "ip": "8.8.8.8", "port": 12234 }
+    ]
+  }
+}
+```
+
+## Kuaidaili
+
+Demo URL shape, with credential and signature values omitted:
+
+```text
+https://dps.kdlapi.com/api/getdps/?num=5&format=json&sep=1
+```
+
+Text output often uses one proxy per line:
+
+```text
+192.0.2.10:15818
+192.0.2.11:15819
+```
+
+## Zhima HTTP
+
+Demo URL shape:
+
+```text
+https://webapi.http.zhimacangku.com/getip?num=5&type=2&pro=&city=0&yys=0&port=1&ts=1&ys=0&cs=0&lb=1&sb=0&pb=4&mr=1&regions=
+```
+
+Representative JSON:
+
+```json
+{
+  "code": 0,
+  "success": true,
+  "data": [
+    { "ip": "192.0.2.20", "port": 15820 }
+  ]
+}
+```
+
+## Xiaoxiang
+
+Demo URL shape:
+
+```text
+https://api.xiaoxiangdaili.com/ip/get?cnt=5&wt=json
+```
+
+Representative JSON:
+
+```json
+{
+  "code": 200,
+  "success": true,
+  "data": [
+    { "ip": "192.0.2.30", "port": 15830 }
+  ]
+}
+```
+
+## Xiequ
+
+Demo URL shape, with account values omitted:
+
+```text
+http://api.xiequ.cn/VAD/GetIp.aspx?act=get&num=5&time=30&plat=0&re=0&type=2&so=1&ow=1&spl=1&addr=&db=1
+```
+
+Text output can be plain `ip:port` lines.
+
+## Juliang
+
+Demo URL shape:
+
+```text
+https://v2.api.juliangip.com/dynamic/getips?filter=1&num=5&pt=1&result_type=json
+```
+
+Representative JSON:
+
+```json
+{
+  "code": 200,
+  "msg": "success",
+  "data": {
+    "proxy_list": [
+      "192.0.2.40:15840"
+    ]
+  }
+}
+```
+
+## Pinyi
+
+Demo URL shape:
+
+```text
+http://tiqu.pyhttp.taolop.com/getflowip?count=5&neek=NEEK&type=1&yys=0&port=1&sb=&mr=1&sep=1
+```
+
+Text output can be plain `ip:port` lines.
+
+## Zdaye
+
+Demo URL shape:
+
+```text
+https://www.zdaye.com/dayProxy/ip/PORT/?count=5&returnType=2
+```
+
+Representative JSON:
+
+```json
+{
+  "code": "10001",
+  "msg": "获取成功",
+  "data": {
+    "proxy_list": [
+      { "ip": "192.0.2.50", "port": 15850 }
+    ]
+  }
+}
+```
+
+Response formats vary by package; generic JSON and text parsing are used as fallback.

--- a/docs/proxy-api-compatibility.md
+++ b/docs/proxy-api-compatibility.md
@@ -1,0 +1,45 @@
+# 代理 API 兼容说明
+
+代理 API 模块支持直接粘贴代理服务商后台生成的提取 API/demo 链接，并把不同服务商的返回统一转换成 `ProxyManager` 使用的代理地址格式。
+
+## 兼容模型
+
+1. **自动识别**：根据域名、路径和参数名识别常见服务商。
+2. **服务商 Profile**：只在已知规则下补齐为空或缺失的数量、返回格式、协议参数。
+3. **通用兜底解析**：从 JSON、数组、嵌套对象、XML、纯文本、CSV 样式文本中提取代理。
+
+模块不会再把所有 URL 强行改写成 `count/format/protocol`。很多服务商后台生成的链接带签名或特殊参数，随意改写可能导致链接失效。
+
+## 初始 Profile
+
+| Profile | 常见域名 | 数量参数 | 格式参数 | 说明 |
+| --- | --- | --- | --- | --- |
+| `youdaili` | `youdaili.com` | `count` | `format` | 保留已有有代理 JSON 结构支持。 |
+| `kuaidaili` | `kdlapi.com`, `kuaidaili.com` | `num` | `format` | 支持文本和 JSON 返回。 |
+| `zhima` | `zhimacangku.com`, `zhimahttp.com` | `num` | `type` | 常见 demo 中 `type=2` 表示 JSON。 |
+| `xiaoxiang` | `xiaoxiangdaili.com` | `cnt` | `wt` | 常见 demo 中 `wt=json` 表示 JSON。 |
+| `xiequ` | `xiequ.cn` | `num` | `type` | 后台生成链接包含较多服务商开关，默认保留。 |
+| `juliang` | `juliangip.com` | `num` | `result_type` | 常见返回把代理放在 `data.proxy_list`。 |
+| `qingguo` | `qg.net`, `qingguo` 相关域名 | `num`, `count` | 通用兜底 | 强兼容常见青果代理链接。 |
+| `yiniuyun` | `16yun.cn`, `yiniuyun` 相关域名 | `num`, `count` | 通用兜底 | 强兼容常见亿牛云代理链接。 |
+| `pinyi` | `pyhttp`, `pinyi` 相关域名 | `count`, `num` | `type` | 文本返回较常见。 |
+| `taiyang` | `taiyang` 相关域名 | `num`, `count` | 通用兜底 | 走历史/通用兜底解析。 |
+| `mogu` | `mogu`, `mogumiao` 相关域名 | `num`, `count` | 通用兜底 | 走历史/通用兜底解析。 |
+| `xundaili` | `xundaili` 相关域名 | `num`, `count` | 通用兜底 | 走历史/通用兜底解析。 |
+| `zdaye` | `zdaye.com` | `count`, `num` | `returnType` | 将服务商成功码 `10001` 视为成功，再走通用提取。 |
+| `generic` | 未识别 | 只补已有且为空的兼容参数 | 只补已有且为空的兼容参数 | 不强行添加服务商参数。 |
+
+## 标准输出
+
+解析器返回以下格式：
+
+```text
+http://192.0.2.10:15818
+socks5://192.0.2.11:1080
+```
+
+非法条目会被忽略。重复代理会去重，并保留第一次出现的顺序。
+
+`fetch_proxy_api()` 仍返回兼容旧调用方的 `proxies: list[str]`，同时在 `proxy_records` 中保留解析到的结构化代理元数据，例如 `ttl`、`expire_time`、`deadline` 等有效期字段。
+
+设置页获取代理 API 后会展示脱敏后的 API URL，常见凭据参数如 `key`、`token`、`signature` 会显示为 `***`。

--- a/docs/superpowers/plans/2026-07-07-proxy-api-compatibility.md
+++ b/docs/superpowers/plans/2026-07-07-proxy-api-compatibility.md
@@ -1,0 +1,100 @@
+# Proxy API Compatibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a three-layer proxy API compatibility system with automatic provider recognition, provider profiles, and generic fallback parsing.
+
+**Architecture:** Keep `fetch_proxy_api` as the stable public entry point. Split request preparation, profile detection, success detection, and response extraction into focused helpers inside `util/proxy/ProxyApiProvider.py` unless the file becomes too large, then extract profile constants to a sibling module.
+
+**Tech Stack:** Python 3.11, `requests`, `pytest`, existing `ProxyManager` normalized proxy strings.
+
+## Global Constraints
+
+- Preserve existing callers in `tab/config.py` and `task/buy.py`.
+- Do not force all provider URLs into `count/format/protocol`.
+- Keep sanitized demos only; never commit real tokens, app keys, or secrets.
+- Every behavior change must have a focused pytest case.
+
+---
+
+### Task 1: Compatibility Fixtures And Docs
+
+**Files:**
+- Create: `demos/proxy-api/provider-demos.md`
+- Create: `docs/proxy-api-compatibility.md`
+- Modify: `tests/test_proxy_api_provider.py`
+
+**Interfaces:**
+- Consumes: existing `build_proxy_api_url`, `parse_proxy_api_response`, `fetch_proxy_api`.
+- Produces: failing tests for `detect_proxy_api_profile`, `build_proxy_api_request`, `parse_proxy_api_response_text`, and widened `fetch_proxy_api`.
+
+- [x] **Step 1: Add sanitized provider demo notes**
+
+- [x] **Step 2: Add failing tests for new request and parsing behavior**
+
+- [x] **Step 3: Run focused tests and verify failures are from missing new behavior**
+
+### Task 2: Profile Detection And Conservative Request Builder
+
+**Files:**
+- Modify: `util/proxy/ProxyApiProvider.py`
+- Test: `tests/test_proxy_api_provider.py`
+
+**Interfaces:**
+- Produces:
+  - `detect_proxy_api_profile(api_url: str) -> ProxyApiProfile`
+  - `build_proxy_api_request(api_url: str, *, count: int, protocol: str) -> ProxyApiRequest`
+  - `build_proxy_api_url(api_url: str, *, count: int, protocol: str) -> str`
+
+- [ ] **Step 1: Implement dataclasses and profile table**
+
+- [ ] **Step 2: Preserve existing `build_proxy_api_url` as a compatibility wrapper**
+
+- [ ] **Step 3: Run request-builder tests**
+
+### Task 3: Generic JSON And Text Parser
+
+**Files:**
+- Modify: `util/proxy/ProxyApiProvider.py`
+- Test: `tests/test_proxy_api_provider.py`
+
+**Interfaces:**
+- Produces:
+  - `parse_proxy_api_response(payload: Any, *, protocol: str, profile: ProxyApiProfile | str | None = None) -> list[str]`
+  - `parse_proxy_api_response_text(text: str, *, protocol: str, profile: ProxyApiProfile | str | None = None) -> list[str]`
+
+- [ ] **Step 1: Add text response support**
+
+- [ ] **Step 2: Broaden JSON traversal and provider failure detection**
+
+- [ ] **Step 3: Run parser tests**
+
+### Task 4: Fetch Integration And UI Copy
+
+**Files:**
+- Modify: `util/proxy/ProxyApiProvider.py`
+- Modify: `tab/config.py`
+- Test: `tests/test_proxy_api_provider.py`
+
+**Interfaces:**
+- Consumes: `build_proxy_api_request`, `parse_proxy_api_response_text`.
+- Produces: `fetch_proxy_api` that supports JSON and text responses while returning existing `ProxyApiResult`.
+
+- [ ] **Step 1: Update `fetch_proxy_api` to parse response text**
+
+- [ ] **Step 2: Update proxy API UI help copy to describe demo URL support**
+
+- [ ] **Step 3: Run integration-facing tests**
+
+### Task 5: Regression Verification
+
+**Files:**
+- Existing tests only unless failures reveal a bug.
+
+- [ ] **Step 1: Run focused proxy tests**
+
+- [ ] **Step 2: Run local fanout proxy strategy tests**
+
+- [ ] **Step 3: Run full pytest suite**
+
+- [ ] **Step 4: Inspect git diff for accidental unrelated changes**

--- a/docs/superpowers/specs/2026-07-07-proxy-api-compatibility-design.md
+++ b/docs/superpowers/specs/2026-07-07-proxy-api-compatibility-design.md
@@ -1,0 +1,54 @@
+# Proxy API Compatibility Design
+
+## Goal
+
+Refactor proxy API fetching into an automatic recognition, provider profile, and generic fallback parser pipeline. Users should be able to paste a provider's generated extraction API demo URL and get a normalized proxy list without hand-editing provider-specific parameters.
+
+## Architecture
+
+The public entry point remains `fetch_proxy_api(api_url, count, protocol, timeout=15)` so UI and buy-task code do not need broad changes. Internally it will resolve a `ProxyApiProfile`, build a conservative request URL, fetch text, and parse the response through provider-aware success checks plus a generic extractor.
+
+The request builder will preserve the user's URL by default. A profile may fill blank or missing count, format, or protocol parameters only when that behavior is known for that provider. Unknown providers use `generic`, which never forces `count/format/protocol` onto the URL unless an existing compatible key is blank.
+
+The parser accepts JSON objects, JSON arrays, and plain text. It extracts proxies from common fields and free-form text, normalizes them to `scheme://[user[:pass]@]host:port`, de-duplicates while preserving order, and raises clear Chinese errors when the provider reports failure or no proxy can be parsed.
+
+## Provider Profiles
+
+Initial first-class profiles:
+
+- `youdaili`
+- `kuaidaili`
+- `zhima`
+- `xiaoxiang`
+- `xiequ`
+- `juliang`
+- `pinyi`
+- `zdaye`
+- `generic`
+
+Profiles recognize URL domains and known parameter names. Profiles should stay small: host/path matching, request parameter aliases, success-code hints, and optional protocol mapping.
+
+## Data Flow
+
+1. UI or buy task calls `fetch_proxy_api`.
+2. `detect_proxy_api_profile(api_url)` chooses a profile.
+3. `build_proxy_api_request(api_url, count, protocol)` returns a URL and profile metadata.
+4. `requests.get` fetches the provider response as text.
+5. The parser tries JSON first, then text.
+6. Parsed proxies are passed unchanged to `ProxyManager.replace_proxy_list` or displayed in the UI.
+
+## Error Handling
+
+- Empty API URL raises `ProxyApiError("请先填写代理 API 地址")`.
+- HTTP status errors continue to use `requests` exceptions.
+- Provider failure payloads surface `msg`, `message`, `reason`, `ERRORMSG`, or similar fields.
+- Successful responses without parseable proxies raise `ProxyApiError("代理 API 返回成功，但没有解析到代理 IP 和端口")`.
+- Invalid proxy entries are ignored rather than aborting the whole response.
+
+## Testing
+
+Tests cover request-building conservatism, profile detection, JSON extraction, text extraction, provider failure detection, auth formats, IPv6, de-duplication, and the unchanged public `fetch_proxy_api` interface.
+
+## Documentation Artifacts
+
+Provider API demos and sanitized response samples live under `demos/proxy-api/`. Compatibility notes live in `docs/proxy-api-compatibility.md`.

--- a/tab/config.py
+++ b/tab/config.py
@@ -56,9 +56,16 @@ def go_settings_tab(header_ui):
     def get_proxy_api_url():
         return ConfigDB.get("proxyApiUrl") or ""
 
+    def normalize_proxy_api_protocol_choice(protocol):
+        protocol = str(protocol or "auto").strip().lower()
+        if protocol in {"socks", "socks5"}:
+            return "socks5"
+        if protocol == "http":
+            return "http"
+        return "auto"
+
     def get_proxy_api_protocol():
-        protocol = str(ConfigDB.get("proxyApiProtocol") or "http").lower()
-        return "socks5" if protocol in {"socks", "socks5"} else "http"
+        return normalize_proxy_api_protocol_choice(ConfigDB.get("proxyApiProtocol"))
 
     def input_https_proxy(_https_proxy):
         normalized_proxy = _serialize_proxy_text(_https_proxy)
@@ -90,9 +97,7 @@ def go_settings_tab(header_ui):
         try:
             from util.proxy.ProxyApiProvider import fetch_proxy_api, mask_proxy_api_url
 
-            protocol = (
-                "socks5" if str(protocol).lower() in {"socks", "socks5"} else "http"
-            )
+            protocol = normalize_proxy_api_protocol_choice(protocol)
             ConfigDB.insert("proxyApiUrl", str(api_url or "").strip())
             ConfigDB.insert("proxyApiProtocol", protocol)
             count = ConfigDB.get_as_int("queueConcurrencyLimit", 0)
@@ -116,7 +121,7 @@ def go_settings_tab(header_ui):
             )
 
     def save_proxy_api_config(api_url, protocol):
-        protocol = "socks5" if str(protocol).lower() in {"socks", "socks5"} else "http"
+        protocol = normalize_proxy_api_protocol_choice(protocol)
         ConfigDB.insert("proxyApiUrl", str(api_url or "").strip())
         ConfigDB.insert("proxyApiProtocol", protocol)
         gr.Info("代理 API 配置已保存。")
@@ -431,7 +436,8 @@ def go_settings_tab(header_ui):
                     proxy_api_protocol_ui = gr.Dropdown(
                         label="代理地址类型",
                         choices=[
-                            ("HTTP / HTTPS", "http"),
+                            ("自动识别（推荐）", "auto"),
+                            ("HTTP", "http"),
                             ("SOCKS5", "socks5"),
                         ],
                         value=get_proxy_api_protocol(),

--- a/tab/config.py
+++ b/tab/config.py
@@ -88,7 +88,7 @@ def go_settings_tab(header_ui):
 
     def fetch_proxy_from_api(api_url, protocol):
         try:
-            from util.proxy.ProxyApiProvider import fetch_proxy_api
+            from util.proxy.ProxyApiProvider import fetch_proxy_api, mask_proxy_api_url
 
             protocol = (
                 "socks5" if str(protocol).lower() in {"socks", "socks5"} else "http"
@@ -104,7 +104,10 @@ def go_settings_tab(header_ui):
             ConfigDB.insert("https_proxy", ",".join(result.proxies))
             gr.Info(f"已从代理 API 获取 {len(result.proxies)} 个代理。")
             return gr.update(value="\n".join(result.proxies)), gr.update(
-                value=f"✅ 已获取 {len(result.proxies)} 个代理",
+                value=(
+                    f"✅ 已获取 {len(result.proxies)} 个代理\n"
+                    f"API: {mask_proxy_api_url(api_url)}"
+                ),
                 visible=True,
             )
         except Exception as e:
@@ -422,7 +425,7 @@ def go_settings_tab(header_ui):
                     gr.Markdown("### 通过代理 API 获取")
                     proxy_api_url_ui = gr.Textbox(
                         label="代理 API 地址",
-                        placeholder="例如：http://api.youdaili.com/v1/proxy/get?app_key=...&app_secret=...&count=&format=&protocol=",
+                        placeholder="粘贴代理服务商后台生成的提取 API/demo 链接，例如：http://api.youdaili.com/v1/proxy/get?count=&format=&protocol=",
                         value=get_proxy_api_url(),
                     )
                     proxy_api_protocol_ui = gr.Dropdown(
@@ -458,7 +461,7 @@ def go_settings_tab(header_ui):
                           <p><strong>带账号密码的 HTTP 代理示例：</strong><code>http://proxyuser:proxypass@xx.xx.xx.xx:8080</code></p>
                           <p><strong>程序什么时候会用代理：</strong>当抢票流程检测到风控时，会按你填写的顺序切换到下一个代理；当前请求不会在请求层立刻自动重试，下一次抢票重试才会使用新代理。</p>
                           <p><strong>代理失效怎么处理：</strong>同一代理在短时间内连续失败会被暂时冷却；如果所有代理都不可用，程序会按递增时间休息后再试。</p>
-                          <p><strong>代理 API：</strong>保存 API 地址后，程序会在代理全部不可用时自动按并发数请求新代理；请求会自动带上 <code>format=json</code>、<code>count</code> 和所选 <code>protocol</code>。</p>
+                          <p><strong>代理 API：</strong>建议直接粘贴服务商后台生成的提取 API/demo 链接。程序会自动识别常见服务商，优先保留原始参数，只在已知且为空或缺失时补充数量、返回格式或协议参数；识别不到时使用通用解析兜底。</p>
                           <p><strong>建议先测试再开抢：</strong>保存后点击上方“测试代理连通性”，确认代理能正常访问哔哩哔哩接口。</p>
                           <p><strong>自建代理：</strong>如果你没有现成代理，可以自己在 Ubuntu / Debian 服务器上搭建 Squid HTTP 代理。</p>
                           <p><strong>完整搭建说明：</strong><a href="https://github.com/mikumifa/biliTickerBuy/blob/main/docs/proxy-self-hosting.md" target="_blank" rel="noopener noreferrer">GitHub 查看自建代理指南</a></p>

--- a/tests/test_proxy_api_provider.py
+++ b/tests/test_proxy_api_provider.py
@@ -1,9 +1,15 @@
 import pytest
 
+from util.proxy.ProxyManager import ProxyManager
 from util.proxy.ProxyApiProvider import (
     ProxyApiError,
+    build_proxy_api_request,
     build_proxy_api_url,
+    detect_proxy_api_profile,
+    fetch_proxy_api,
+    mask_proxy_api_url,
     parse_proxy_api_response,
+    parse_proxy_api_response_text,
 )
 
 
@@ -11,16 +17,76 @@ def _proxy_url(scheme: str, username: str, password: str, host: str, port: int) 
     return f"{scheme}://" + f"{username}:{password}@" + f"{host}:{port}"
 
 
-def test_build_proxy_api_url_overrides_required_params():
+def test_build_proxy_api_url_preserves_existing_provider_demo_params():
+    original_url = (
+        "https://dps.kdlapi.com/api/getdps/?client_id=demo"
+        "&signed_value=a%2fb%2b%3d&num=7&format=text&sep=1"
+    )
     url = build_proxy_api_url(
-        "http://api.example.com/get?app_key=abc&count=&format=text&protocol=http",
+        original_url,
+        count=3,
+        protocol="socks5",
+    )
+
+    assert url == original_url
+
+
+def test_build_proxy_api_url_fills_blank_known_params_only():
+    url = build_proxy_api_url(
+        "http://api.youdaili.com/v1/proxy/get?client_id=&count=&format=&protocol=",
         count=3,
         protocol="socks5",
     )
 
     assert url == (
-        "http://api.example.com/get?app_key=abc&count=3&format=json&protocol=socks5"
+        "http://api.youdaili.com/v1/proxy/get?client_id=&count=3&format=json&protocol=socks5"
     )
+
+
+def test_detect_proxy_api_profile_by_common_provider_hosts():
+    samples = {
+        "http://api.youdaili.com/v1/proxy/get?count=1": "youdaili",
+        "https://dps.kdlapi.com/api/getdps/?num=1": "kuaidaili",
+        "https://webapi.http.zhimacangku.com/getip?num=1&type=2": "zhima",
+        "https://api.xiaoxiangdaili.com/ip/get?cnt=1&wt=json": "xiaoxiang",
+        "http://api.xiequ.cn/VAD/GetIp.aspx?num=1": "xiequ",
+        "https://v2.api.juliangip.com/dynamic/getips?num=1": "juliang",
+        "https://share.proxy.qg.net/get?num=1": "qingguo",
+        "https://proxy.16yun.cn/api?num=1": "yiniuyun",
+        "http://tiqu.pyhttp.taolop.com/getflowip?count=1": "pinyi",
+        "https://taiyang.example.com/api?num=1": "taiyang",
+        "https://mogumiao.example.com/proxy?num=1": "mogu",
+        "https://xundaili.example.com/api?num=1": "xundaili",
+        "https://www.zdaye.com/dayProxy/ip/123/demo?count=1": "zdaye",
+        "https://proxy.example.com/api?qty=1": "generic",
+    }
+
+    for url, expected_profile in samples.items():
+        assert detect_proxy_api_profile(url).name == expected_profile
+
+
+def test_build_proxy_api_request_adds_profile_specific_missing_params():
+    request = build_proxy_api_request(
+        "https://api.xiaoxiangdaili.com/ip/get",
+        count=6,
+        protocol="http",
+    )
+
+    assert request.profile.name == "xiaoxiang"
+    assert request.url == (
+        "https://api.xiaoxiangdaili.com/ip/get?cnt=6&wt=json"
+    )
+
+
+def test_build_proxy_api_request_does_not_add_params_for_unknown_provider():
+    request = build_proxy_api_request(
+        "https://proxy.example.com/api?client_id=demo",
+        count=6,
+        protocol="socks5",
+    )
+
+    assert request.profile.name == "generic"
+    assert request.url == "https://proxy.example.com/api?client_id=demo"
 
 
 def test_parse_youdaili_success_response_as_http_proxy():
@@ -130,6 +196,190 @@ def test_parse_proxy_api_keeps_auth_for_socks5_url():
     }
 
     assert parse_proxy_api_response(payload, protocol="socks5") == [proxy]
+
+
+def test_parse_proxy_api_response_text_extracts_plain_lines():
+    payload = """
+    192.0.2.50:15115
+    192.0.2.51:15116
+    192.0.2.50:15115
+    """
+
+    assert parse_proxy_api_response_text(payload, protocol="http") == [
+        "http://192.0.2.50:15115",
+        "http://192.0.2.51:15116",
+    ]
+
+
+def test_parse_proxy_api_response_text_extracts_csv_like_rows():
+    payload = "ip,port\n192.0.2.54,15119\n"
+
+    assert parse_proxy_api_response_text(payload, protocol="http") == [
+        "http://192.0.2.54:15119"
+    ]
+
+
+def test_parse_proxy_api_response_walks_nested_provider_payloads():
+    payload = {
+        "ERRORCODE": "0",
+        "RESULT": {
+            "rows": [
+                {
+                    "IP": "192.0.2.60",
+                    "PORT": "15120",
+                }
+            ]
+        },
+    }
+
+    assert parse_proxy_api_response(payload, protocol="http") == [
+        "http://192.0.2.60:15120"
+    ]
+
+
+def test_parse_proxy_api_response_accepts_json_list_root():
+    payload = [
+        {"ip": "192.0.2.61", "port": 15121},
+        "192.0.2.62:15122",
+    ]
+
+    assert parse_proxy_api_response(payload, protocol="socks5") == [
+        "socks5://192.0.2.61:15121",
+        "socks5://192.0.2.62:15122",
+    ]
+
+
+def test_parse_proxy_api_response_extracts_more_proxy_fields_and_ttl_metadata():
+    payload = {
+        "code": 0,
+        "data": [
+            {
+                "server": "192.0.2.64:15124",
+                "proxy_ip": "198.51.100.64",
+                "deadline": "2026-07-07 12:30:00",
+                "ttl": 120,
+            }
+        ],
+    }
+
+    assert parse_proxy_api_response(payload, protocol="http") == [
+        "http://192.0.2.64:15124"
+    ]
+
+
+def test_parse_proxy_api_response_text_accepts_xml_payload():
+    payload = """
+    <root>
+      <code>0</code>
+      <data>
+        <item>
+          <ip>192.0.2.65</ip>
+          <port>15125</port>
+          <expire_time>2026-07-07 12:30:00</expire_time>
+        </item>
+      </data>
+    </root>
+    """
+
+    assert parse_proxy_api_response_text(payload, protocol="socks5") == [
+        "socks5://192.0.2.65:15125"
+    ]
+
+
+def test_parse_proxy_api_response_detects_provider_failure_codes():
+    payload = {"ERRORCODE": "10055", "ERRORMSG": "提取数量不足"}
+
+    with pytest.raises(ProxyApiError, match="提取数量不足"):
+        parse_proxy_api_response(payload, protocol="http")
+
+
+def test_parse_zdaye_success_code_10001_as_success():
+    payload = {
+        "code": "10001",
+        "msg": "获取成功",
+        "data": {
+            "proxy_list": [
+                {"ip": "192.0.2.63", "port": 15123},
+            ],
+        },
+    }
+
+    assert parse_proxy_api_response(payload, protocol="http", profile="zdaye") == [
+        "http://192.0.2.63:15123"
+    ]
+
+
+def test_fetch_proxy_api_parses_text_response(monkeypatch):
+    class Response:
+        text = "192.0.2.70:15130\n192.0.2.71:15131"
+
+        def raise_for_status(self):
+            return None
+
+    captured = {}
+
+    def fake_request(method, url, headers, data, timeout):
+        captured["method"] = method
+        captured["url"] = url
+        captured["timeout"] = timeout
+        return Response()
+
+    monkeypatch.setattr("util.proxy.ProxyApiProvider.requests.request", fake_request)
+
+    result = fetch_proxy_api(
+        "https://dps.kdlapi.com/api/getdps/?num=2&format=text",
+        count=9,
+        protocol="http",
+        timeout=3,
+    )
+
+    assert captured == {
+        "method": "GET",
+        "url": "https://dps.kdlapi.com/api/getdps/?num=2&format=text",
+        "timeout": 3,
+    }
+    assert result.proxies == [
+        "http://192.0.2.70:15130",
+        "http://192.0.2.71:15131",
+    ]
+    assert result.response == {"raw": Response.text}
+
+
+def test_fetch_proxy_api_result_can_replace_proxy_manager_pool(monkeypatch):
+    class Response:
+        text = "192.0.2.80:15140\n192.0.2.80:15140\n"
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(
+        "util.proxy.ProxyApiProvider.requests.request",
+        lambda method, url, headers, data, timeout: Response(),
+    )
+
+    manager = ProxyManager("none")
+    result = fetch_proxy_api(
+        "http://api.youdaili.com/v1/proxy/get?count=1&format=text",
+        count=1,
+        protocol="http",
+    )
+    manager.replace_proxy_list(",".join(result.proxies))
+
+    assert manager.proxy_list == ["http://192.0.2.80:15140"]
+    assert result.proxy_records == [
+        {
+            "proxy": "http://192.0.2.80:15140",
+            "host": "192.0.2.80",
+            "port": "15140",
+            "scheme": "http",
+        }
+    ]
+
+
+def test_mask_proxy_api_url_redacts_sensitive_query_values():
+    assert mask_proxy_api_url(
+        "https://example.com/get?key=&token=&num=2&signature="
+    ) == "https://example.com/get?key=***&token=***&num=2&signature=***"
 
 
 def test_parse_youdaili_failure_response_raises():

--- a/tests/test_proxy_api_provider.py
+++ b/tests/test_proxy_api_provider.py
@@ -249,6 +249,36 @@ def test_parse_proxy_api_response_accepts_json_list_root():
     ]
 
 
+def test_parse_proxy_api_response_auto_defaults_bare_proxy_to_http():
+    payload = {
+        "code": 0,
+        "data": [
+            {"ip": "192.0.2.66", "port": 15126},
+            "192.0.2.67:15127",
+        ],
+    }
+
+    assert parse_proxy_api_response(payload, protocol="auto") == [
+        "http://192.0.2.66:15126",
+        "http://192.0.2.67:15127",
+    ]
+
+
+def test_parse_proxy_api_response_auto_keeps_explicit_proxy_scheme():
+    payload = {
+        "code": 0,
+        "data": [
+            "socks5://192.0.2.68:15128",
+            "http://192.0.2.69:15129",
+        ],
+    }
+
+    assert parse_proxy_api_response(payload, protocol="auto") == [
+        "socks5://192.0.2.68:15128",
+        "http://192.0.2.69:15129",
+    ]
+
+
 def test_parse_proxy_api_response_extracts_more_proxy_fields_and_ttl_metadata():
     payload = {
         "code": 0,

--- a/util/proxy/ProxyApiProvider.py
+++ b/util/proxy/ProxyApiProvider.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass
 from typing import Any
+from xml.etree import ElementTree
 from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit, urlunsplit
 
 import requests
@@ -13,9 +15,228 @@ class ProxyApiError(RuntimeError):
 
 
 @dataclass(frozen=True)
+class ProxyApiProfile:
+    name: str
+    host_keywords: tuple[str, ...] = ()
+    count_keys: tuple[str, ...] = ()
+    format_defaults: tuple[tuple[str, str], ...] = ()
+    protocol_defaults: tuple[tuple[str, tuple[tuple[str, str], ...]], ...] = ()
+    success_codes: tuple[str, ...] = ("0", "1", "200", "10000", "success", "ok")
+    fill_missing_params: bool = True
+
+
+@dataclass(frozen=True)
+class ProxyApiRequest:
+    url: str
+    profile: ProxyApiProfile
+
+
+@dataclass(frozen=True)
 class ProxyApiResult:
     proxies: list[str]
     response: dict[str, Any]
+    proxy_records: list[dict[str, Any]] | None = None
+
+
+_COMMON_COUNT_KEYS = ("count", "num", "cnt", "getnum")
+_COMMON_FORMAT_DEFAULTS = (
+    ("format", "json"),
+    ("type", "2"),
+    ("wt", "json"),
+    ("result_type", "json"),
+    ("datatype", "json"),
+)
+_COMMON_PROTOCOL_DEFAULTS = (
+    ("protocol", (("http", "http"), ("socks5", "socks5"))),
+)
+
+_PROFILES: tuple[ProxyApiProfile, ...] = (
+    ProxyApiProfile(
+        name="youdaili",
+        host_keywords=("youdaili.com",),
+        count_keys=("count",),
+        format_defaults=(("format", "json"),),
+        protocol_defaults=_COMMON_PROTOCOL_DEFAULTS,
+    ),
+    ProxyApiProfile(
+        name="kuaidaili",
+        host_keywords=("kdlapi.com", "kuaidaili.com"),
+        count_keys=("num",),
+        format_defaults=(("format", "json"),),
+    ),
+    ProxyApiProfile(
+        name="zhima",
+        host_keywords=("zhimacangku.com", "zhimahttp.com", "zmhttp.com"),
+        count_keys=("num",),
+        format_defaults=(("type", "2"),),
+    ),
+    ProxyApiProfile(
+        name="xiaoxiang",
+        host_keywords=("xiaoxiangdaili.com",),
+        count_keys=("cnt",),
+        format_defaults=(("wt", "json"),),
+    ),
+    ProxyApiProfile(
+        name="xiequ",
+        host_keywords=("xiequ.cn",),
+        count_keys=("num",),
+        format_defaults=(("type", "2"),),
+    ),
+    ProxyApiProfile(
+        name="juliang",
+        host_keywords=("juliangip.com",),
+        count_keys=("num",),
+        format_defaults=(("result_type", "json"),),
+    ),
+    ProxyApiProfile(
+        name="qingguo",
+        host_keywords=("qg.net", "qingguo", "qingguodaili"),
+        count_keys=("num", "count"),
+    ),
+    ProxyApiProfile(
+        name="yiniuyun",
+        host_keywords=("16yun.cn", "yiniuyun"),
+        count_keys=("num", "count"),
+    ),
+    ProxyApiProfile(
+        name="pinyi",
+        host_keywords=("pyhttp", "pinyi", "taolop.com"),
+        count_keys=("count", "num"),
+    ),
+    ProxyApiProfile(
+        name="taiyang",
+        host_keywords=("taiyang", "taiyangdaili"),
+        count_keys=("num", "count"),
+    ),
+    ProxyApiProfile(
+        name="mogu",
+        host_keywords=("mogu", "mogumiao"),
+        count_keys=("num", "count"),
+    ),
+    ProxyApiProfile(
+        name="xundaili",
+        host_keywords=("xundaili",),
+        count_keys=("num", "count"),
+    ),
+    ProxyApiProfile(
+        name="zdaye",
+        host_keywords=("zdaye.com",),
+        count_keys=("count", "num"),
+        format_defaults=(("returnType", "2"),),
+        success_codes=("10001",),
+    ),
+    ProxyApiProfile(
+        name="duomi",
+        host_keywords=("duomi", "duoip"),
+        count_keys=("getnum", "num", "count"),
+    ),
+)
+
+_GENERIC_PROFILE = ProxyApiProfile(
+    name="generic",
+    host_keywords=(),
+    count_keys=_COMMON_COUNT_KEYS,
+    format_defaults=_COMMON_FORMAT_DEFAULTS,
+    protocol_defaults=_COMMON_PROTOCOL_DEFAULTS,
+    fill_missing_params=False,
+)
+
+_SUCCESS_CODES = {"0", "1", "200", "10000", "success", "ok", "true", "none", ""}
+_CODE_KEYS = (
+    "code",
+    "errno",
+    "errorcode",
+    "error_code",
+    "status",
+    "status_code",
+    "ret",
+)
+_SUCCESS_KEYS = ("success", "ok")
+_MESSAGE_KEYS = (
+    "msg",
+    "message",
+    "errmsg",
+    "errormsg",
+    "error_msg",
+    "error",
+    "reason",
+    "desc",
+)
+_PROXY_VALUE_KEYS = (
+    "proxy",
+    "addr",
+    "address",
+    "ipport",
+    "ip_port",
+    "server",
+    "proxyip",
+    "proxy_ip",
+    "ip_port_str",
+)
+_HOST_KEYS = ("ip", "host", "hostname", "proxy_ip", "proxyip")
+_PORT_KEYS = ("port", "proxy_port", "proxyport")
+_USERNAME_KEYS = (
+    "username",
+    "user",
+    "account",
+    "authkey",
+    "auth_key",
+    "userid",
+    "user_name",
+)
+_PASSWORD_KEYS = (
+    "password",
+    "pass",
+    "pwd",
+    "authpwd",
+    "auth_pwd",
+    "passwd",
+)
+_SCHEME_KEYS = ("protocol", "scheme", "proxy_type", "proxytype", "httptype")
+_TTL_KEYS = (
+    "ttl",
+    "life",
+    "lifetime",
+    "survival",
+    "expire",
+    "expires",
+    "expired",
+    "expire_time",
+    "expiretime",
+    "deadline",
+    "valid_time",
+    "validtime",
+)
+_SENSITIVE_QUERY_KEYS = {
+    "appkey",
+    "app_key",
+    "appsecret",
+    "app_secret",
+    "auth",
+    "authkey",
+    "authpwd",
+    "key",
+    "pack",
+    "password",
+    "passwd",
+    "pwd",
+    "secret",
+    "secret_id",
+    "sign",
+    "signature",
+    "token",
+    "trade_no",
+    "uid",
+    "user",
+    "username",
+    "vkey",
+}
+_HOST_PATTERN = r"(?:\d{1,3}(?:\.\d{1,3}){3}|[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+|\[[0-9A-Fa-f:.]+\])"
+_URL_CANDIDATE_RE = re.compile(r"[a-zA-Z][a-zA-Z0-9+.-]*://[^\s,;|]+")
+_PROXY_CANDIDATE_RE = re.compile(
+    rf"(?:[^\s:@,;|]+(?::[^\s@,;|]*)?@)?{_HOST_PATTERN}:\d{{2,5}}"
+    rf"(?::[^\s,;|]+(?::[^\s,;|]+)?)?"
+)
 
 
 def normalize_proxy_api_protocol(protocol: str | None) -> str:
@@ -25,17 +246,171 @@ def normalize_proxy_api_protocol(protocol: str | None) -> str:
     return "http"
 
 
-def build_proxy_api_url(api_url: str, *, count: int, protocol: str) -> str:
+def mask_proxy_api_url(api_url: str) -> str:
+    target = str(api_url or "").strip()
+    if not target:
+        return ""
+    parts = urlsplit(target)
+    query = []
+    for key, value in parse_qsl(parts.query, keep_blank_values=True):
+        query.append((key, "***" if key.lower() in _SENSITIVE_QUERY_KEYS else value))
+    return urlunsplit(
+        (
+            parts.scheme,
+            parts.netloc,
+            parts.path,
+            urlencode(query, doseq=True, safe="*"),
+            parts.fragment,
+        )
+    )
+
+
+def _normalize_count(count: int) -> int:
+    try:
+        return max(1, int(count))
+    except (TypeError, ValueError):
+        return 1
+
+
+def detect_proxy_api_profile(api_url: str) -> ProxyApiProfile:
+    target = str(api_url or "").strip().lower()
+    parts = urlsplit(target)
+    haystack = f"{parts.netloc}{parts.path}"
+    for profile in _PROFILES:
+        if any(keyword in haystack for keyword in profile.host_keywords):
+            return profile
+    return _GENERIC_PROFILE
+
+
+def _query_has_key(query: list[tuple[str, str]], keys: tuple[str, ...]) -> bool:
+    lower_keys = {key.lower() for key in keys}
+    return any(key.lower() in lower_keys for key, _value in query)
+
+
+def _fill_query_keys(
+    query: list[tuple[str, str]],
+    keys: tuple[str, ...],
+    value: str,
+    *,
+    allow_missing: bool,
+) -> bool:
+    lower_keys = {key.lower() for key in keys}
+    found = False
+    for index, (key, current_value) in enumerate(query):
+        if key.lower() not in lower_keys:
+            continue
+        found = True
+        if str(current_value).strip() == "":
+            query[index] = (key, value)
+            return True
+        break
+    if allow_missing and not found and keys:
+        query.append((keys[0], value))
+        return True
+    return False
+
+
+def _fill_query_defaults(
+    query: list[tuple[str, str]],
+    defaults: tuple[tuple[str, str], ...],
+    *,
+    allow_missing: bool,
+) -> bool:
+    if not defaults:
+        return False
+    matched_existing_key = False
+    for default_key, default_value in defaults:
+        for index, (key, current_value) in enumerate(query):
+            if key.lower() != default_key.lower():
+                continue
+            matched_existing_key = True
+            if str(current_value).strip() == "":
+                query[index] = (key, default_value)
+                return True
+            break
+    if allow_missing and not matched_existing_key:
+        query.append(defaults[0])
+        return True
+    return False
+
+
+def _fill_protocol_defaults(
+    query: list[tuple[str, str]],
+    defaults: tuple[tuple[str, tuple[tuple[str, str], ...]], ...],
+    *,
+    protocol: str,
+    allow_missing: bool,
+) -> bool:
+    if not defaults:
+        return False
+    normalized_protocol = normalize_proxy_api_protocol(protocol)
+    matched_existing_key = False
+    for key, mapping_items in defaults:
+        mapping = dict(mapping_items)
+        value = mapping.get(normalized_protocol)
+        if value is None:
+            continue
+        for index, (current_key, current_value) in enumerate(query):
+            if current_key.lower() != key.lower():
+                continue
+            matched_existing_key = True
+            if str(current_value).strip() == "":
+                query[index] = (current_key, value)
+                return True
+            break
+    if allow_missing and not matched_existing_key:
+        key, mapping_items = defaults[0]
+        value = dict(mapping_items).get(normalized_protocol)
+        if value is not None:
+            query.append((key, value))
+            return True
+    return False
+
+
+def build_proxy_api_request(
+    api_url: str,
+    *,
+    count: int,
+    protocol: str,
+) -> ProxyApiRequest:
     target = str(api_url or "").strip()
     if not target:
         raise ProxyApiError("请先填写代理 API 地址")
 
+    profile = detect_proxy_api_profile(target)
     parts = urlsplit(target)
-    query = dict(parse_qsl(parts.query, keep_blank_values=True))
-    query["count"] = str(max(1, int(count)))
-    query["format"] = "json"
-    query["protocol"] = normalize_proxy_api_protocol(protocol)
-    return urlunsplit(
+    query = parse_qsl(parts.query, keep_blank_values=True)
+    allow_missing = profile.fill_missing_params
+    count_value = str(_normalize_count(count))
+
+    changed = _fill_query_keys(
+        query,
+        profile.count_keys,
+        count_value,
+        allow_missing=allow_missing,
+    )
+    changed = (
+        _fill_query_defaults(
+            query,
+            profile.format_defaults,
+            allow_missing=allow_missing,
+        )
+        or changed
+    )
+    changed = (
+        _fill_protocol_defaults(
+            query,
+            profile.protocol_defaults,
+            protocol=protocol,
+            allow_missing=allow_missing,
+        )
+        or changed
+    )
+
+    if not changed:
+        return ProxyApiRequest(url=target, profile=profile)
+
+    request_url = urlunsplit(
         (
             parts.scheme,
             parts.netloc,
@@ -44,33 +419,16 @@ def build_proxy_api_url(api_url: str, *, count: int, protocol: str) -> str:
             parts.fragment,
         )
     )
+    return ProxyApiRequest(url=request_url, profile=profile)
 
 
-def _iter_proxy_items(payload: Any) -> list[Any]:
-    if isinstance(payload, dict):
-        data = payload.get("data")
-        if isinstance(data, dict):
-            for key in ("proxy_list", "list", "proxies", "items"):
-                value = data.get(key)
-                if isinstance(value, list):
-                    return value
-            if any(key in data for key in ("ip", "host", "port", "proxy")):
-                return [data]
-        elif isinstance(data, list):
-            return data
-
-        for key in ("proxy_list", "list", "proxies", "items"):
-            value = payload.get(key)
-            if isinstance(value, list):
-                return value
-    if isinstance(payload, list):
-        return payload
-    return []
+def build_proxy_api_url(api_url: str, *, count: int, protocol: str) -> str:
+    return build_proxy_api_request(api_url, count=count, protocol=protocol).url
 
 
 def _normalize_proxy_scheme(scheme: str | None, fallback_protocol: str) -> str:
     text = str(scheme or "").strip().lower()
-    if text in {"socks", "socks5"}:
+    if text in {"socks", "socks5", "socks5h"}:
         return "socks5"
     if text == "socks4":
         return "socks4"
@@ -113,13 +471,76 @@ def _get_any_key(item: dict[str, Any], *keys: str) -> Any:
     return None
 
 
+def _is_valid_port(port: str) -> bool:
+    if not str(port or "").isdigit():
+        return False
+    value = int(port)
+    return 1 <= value <= 65535
+
+
+def _parse_host_port_auth_text(
+    text: str,
+    *,
+    protocol: str,
+) -> tuple[str, str, str, str, str] | None:
+    value = text.strip().strip("\"'<>")
+    if not value:
+        return None
+
+    scheme = normalize_proxy_api_protocol(protocol)
+    scheme_match = re.match(r"^([a-zA-Z][a-zA-Z0-9+.-]*)://(.+)$", value)
+    if scheme_match:
+        scheme = _normalize_proxy_scheme(scheme_match.group(1), protocol)
+        value = scheme_match.group(2)
+
+    value = value.split("/", 1)[0].split("?", 1)[0].split("#", 1)[0]
+    username = ""
+    password = ""
+    if "@" in value:
+        auth, value = value.rsplit("@", 1)
+        username, _, password = auth.partition(":")
+        username = unquote(username).strip()
+        password = unquote(password)
+
+    bracketed_ipv6 = re.match(r"^\[([0-9A-Fa-f:.]+)]:(\d{1,5})(?::(.*))?$", value)
+    if bracketed_ipv6:
+        extra_username = ""
+        extra_password = ""
+        if bracketed_ipv6.group(3):
+            extra_username, _, extra_password = bracketed_ipv6.group(3).partition(":")
+        return (
+            scheme,
+            bracketed_ipv6.group(1),
+            bracketed_ipv6.group(2),
+            username or extra_username.strip(),
+            password or extra_password,
+        )
+
+    parts = value.split(":")
+    if len(parts) >= 4 and parts[1].isdigit():
+        return (
+            scheme,
+            parts[0].strip(),
+            parts[1].strip(),
+            username or parts[2].strip(),
+            password or ":".join(parts[3:]),
+        )
+
+    if ":" not in value:
+        return None
+    host, port = value.rsplit(":", 1)
+    if ":" in host and "::" in host:
+        return scheme, host.strip(), port.strip(), username, password
+    return scheme, host.strip(), port.strip(), username, password
+
+
 def _extract_proxy_parts(
     item: Any,
     *,
     protocol: str,
 ) -> tuple[str, str, str, str, str] | None:
     if isinstance(item, dict):
-        proxy_value = _get_any_key(item, "proxy", "addr", "address")
+        proxy_value = _get_any_key(item, *_PROXY_VALUE_KEYS)
         if proxy_value:
             proxy_parts = _extract_proxy_parts(str(proxy_value), protocol=protocol)
             if proxy_parts is None:
@@ -127,12 +548,10 @@ def _extract_proxy_parts(
             scheme, host, port, username, password = proxy_parts
             if username:
                 return proxy_parts
-            username = (
-                _get_any_key(item, "username", "user", "account", "authkey") or ""
-            )
-            password = _get_any_key(item, "password", "pass", "pwd", "authpwd") or ""
+            username = _get_any_key(item, *_USERNAME_KEYS) or ""
+            password = _get_any_key(item, *_PASSWORD_KEYS) or ""
             scheme = _normalize_proxy_scheme(
-                _get_any_key(item, "protocol", "scheme", "type") or scheme,
+                _get_any_key(item, *_SCHEME_KEYS) or scheme,
                 protocol,
             )
             return (
@@ -143,20 +562,15 @@ def _extract_proxy_parts(
                 str(password),
             )
 
-        host = _get_any_key(item, "ip", "host")
-        port = _get_any_key(item, "port")
-        if host and port:
-            username = (
-                _get_any_key(item, "username", "user", "account", "authkey") or ""
-            )
-            password = _get_any_key(item, "password", "pass", "pwd", "authpwd") or ""
-            scheme = _normalize_proxy_scheme(
-                _get_any_key(item, "protocol", "scheme", "type"),
-                protocol,
-            )
+        host = _get_any_key(item, *_HOST_KEYS)
+        port = _get_any_key(item, *_PORT_KEYS)
+        if host is not None and port is not None:
+            username = _get_any_key(item, *_USERNAME_KEYS) or ""
+            password = _get_any_key(item, *_PASSWORD_KEYS) or ""
+            scheme = _normalize_proxy_scheme(_get_any_key(item, *_SCHEME_KEYS), protocol)
             return (
                 scheme,
-                str(host).strip(),
+                str(host).strip().strip("[]"),
                 str(port).strip(),
                 str(username).strip(),
                 str(password),
@@ -182,66 +596,337 @@ def _extract_proxy_parts(
                 unquote(parsed.password or ""),
             )
 
-    scheme = normalize_proxy_api_protocol(protocol)
-    schema_match = re.match(r"^([a-zA-Z][a-zA-Z0-9+.-]*)://(.+)$", text)
-    if schema_match:
-        scheme = _normalize_proxy_scheme(schema_match.group(1), protocol)
-        text = schema_match.group(2)
+    return _parse_host_port_auth_text(text, protocol=protocol)
 
-    text = text.split("/", 1)[0].split("?", 1)[0].split("#", 1)[0]
-    username = ""
-    password = ""
-    if "@" in text:
-        auth, text = text.rsplit("@", 1)
-        username, _, password = auth.partition(":")
 
-    parts = text.split(":")
-    if len(parts) >= 4:
-        return (
-            scheme,
-            parts[0].strip(),
-            parts[1].strip(),
-            username or parts[2].strip(),
-            password or ":".join(parts[3:]),
+def _extract_ttl_metadata(item: Any) -> dict[str, Any]:
+    if not isinstance(item, dict):
+        return {}
+    metadata = {}
+    for key in _TTL_KEYS:
+        value = _get_any_key(item, key)
+        if value not in (None, ""):
+            metadata[key] = value
+    return metadata
+
+
+def _coerce_profile(profile: ProxyApiProfile | str | None) -> ProxyApiProfile:
+    if isinstance(profile, ProxyApiProfile):
+        return profile
+    if isinstance(profile, str):
+        for candidate in _PROFILES:
+            if candidate.name == profile:
+                return candidate
+    return _GENERIC_PROFILE
+
+
+def _message_from_payload(payload: dict[str, Any]) -> str:
+    message = _get_any_key(payload, *_MESSAGE_KEYS)
+    if message not in (None, ""):
+        return str(message)
+    return str(payload)
+
+
+def _raise_if_provider_failure(payload: Any, profile: ProxyApiProfile) -> None:
+    if not isinstance(payload, dict):
+        return
+
+    success_value = _get_any_key(payload, *_SUCCESS_KEYS)
+    if success_value is False or str(success_value).strip().lower() == "false":
+        raise ProxyApiError(f"代理 API 返回失败: {_message_from_payload(payload)}")
+
+    code_found = False
+    code_value: Any = None
+    for key in _CODE_KEYS:
+        value = _get_any_key(payload, key)
+        if value is not None:
+            code_found = True
+            code_value = value
+            break
+
+    if not code_found:
+        return
+
+    success_codes = _SUCCESS_CODES | {str(code).strip().lower() for code in profile.success_codes}
+    code_text = str(code_value).strip().lower()
+    if code_text not in success_codes:
+        raise ProxyApiError(f"代理 API 返回失败: {_message_from_payload(payload)}")
+
+
+def _add_proxy(
+    proxies: list[str],
+    seen: set[str],
+    proxy_parts: tuple[str, str, str, str, str] | None,
+    records: list[dict[str, Any]] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    if not proxy_parts:
+        return
+    scheme, host, port, username, password = proxy_parts
+    if not host or not _is_valid_port(port):
+        return
+    proxy = _format_proxy_url(
+        scheme=scheme,
+        host=host,
+        port=port,
+        username=username,
+        password=password,
+    )
+    key = proxy.lower()
+    if key in seen:
+        return
+    seen.add(key)
+    proxies.append(proxy)
+    if records is not None:
+        record: dict[str, Any] = {
+            "proxy": proxy,
+            "host": host,
+            "port": port,
+            "scheme": scheme,
+        }
+        if username:
+            record["username"] = username
+        if metadata:
+            record.update(metadata)
+        records.append(record)
+
+
+def _csv_row_to_item(header: list[str], row: list[str]) -> dict[str, str] | None:
+    if not header or len(row) < 2:
+        return None
+    lower_header = [column.strip().lower() for column in header]
+    if not any(column in {"ip", "host", "hostname"} for column in lower_header):
+        return None
+    if "port" not in lower_header and "proxy_port" not in lower_header:
+        return None
+    return {
+        header[index].strip(): row[index].strip()
+        for index in range(min(len(header), len(row)))
+        if header[index].strip()
+    }
+
+
+def _split_csv_line(line: str) -> list[str]:
+    return [part.strip() for part in line.split(",")]
+
+
+def _collect_from_text(
+    text: str,
+    *,
+    protocol: str,
+    proxies: list[str],
+    seen: set[str],
+    records: list[dict[str, Any]] | None = None,
+) -> None:
+    lines = [line.strip() for line in str(text or "").splitlines() if line.strip()]
+    csv_header: list[str] | None = None
+    for line in lines:
+        if "," in line:
+            columns = _split_csv_line(line)
+            if csv_header is not None:
+                _add_proxy(
+                    proxies,
+                    seen,
+                    _extract_proxy_parts(
+                        _csv_row_to_item(csv_header, columns) or "",
+                        protocol=protocol,
+                    ),
+                    records,
+                )
+                continue
+            lower_columns = [column.lower() for column in columns]
+            if any(column in {"ip", "host", "hostname"} for column in lower_columns):
+                csv_header = columns
+                continue
+            if len(columns) >= 4 and _is_valid_port(columns[1]):
+                _add_proxy(
+                    proxies,
+                    seen,
+                    _extract_proxy_parts(
+                        {
+                            "ip": columns[0],
+                            "port": columns[1],
+                            "username": columns[2],
+                            "password": columns[3],
+                        },
+                        protocol=protocol,
+                    ),
+                    records,
+                )
+
+        candidates = [match.group(0) for match in _URL_CANDIDATE_RE.finditer(line)]
+        candidates.extend(match.group(0) for match in _PROXY_CANDIDATE_RE.finditer(line))
+        if not candidates:
+            candidates.append(line)
+        for candidate in candidates:
+            _add_proxy(
+                proxies,
+                seen,
+                _extract_proxy_parts(candidate, protocol=protocol),
+                records,
+            )
+
+
+def _collect_from_payload(
+    payload: Any,
+    *,
+    protocol: str,
+    proxies: list[str],
+    seen: set[str],
+    records: list[dict[str, Any]] | None = None,
+    depth: int = 0,
+) -> None:
+    if depth > 8:
+        return
+    if isinstance(payload, dict):
+        proxy_parts = _extract_proxy_parts(payload, protocol=protocol)
+        _add_proxy(
+            proxies,
+            seen,
+            proxy_parts,
+            records,
+            _extract_ttl_metadata(payload),
+        )
+        for value in payload.values():
+            if proxy_parts is not None and not isinstance(value, (dict, list)):
+                continue
+            _collect_from_payload(
+                value,
+                protocol=protocol,
+                proxies=proxies,
+                seen=seen,
+                records=records,
+                depth=depth + 1,
+            )
+        return
+    if isinstance(payload, list):
+        for item in payload:
+            _collect_from_payload(
+                item,
+                protocol=protocol,
+                proxies=proxies,
+                seen=seen,
+                records=records,
+                depth=depth + 1,
+            )
+        return
+    if isinstance(payload, str):
+        _collect_from_text(
+            payload,
+            protocol=protocol,
+            proxies=proxies,
+            seen=seen,
+            records=records,
         )
 
-    if ":" not in text:
-        return None
-    host, port = text.rsplit(":", 1)
-    return scheme, host.strip(), port.strip(), username.strip(), password
+
+def _raise_no_proxy_error() -> None:
+    raise ProxyApiError("代理 API 返回成功，但没有解析到代理 IP 和端口")
 
 
-def parse_proxy_api_response(payload: dict[str, Any], *, protocol: str) -> list[str]:
-    code = payload.get("code", payload.get("errno", 0))
-    success = payload.get("success")
-    if success is False or str(code) not in {"0", "200", "None"}:
-        message = payload.get("msg") or payload.get("message") or payload
-        raise ProxyApiError(f"代理 API 返回失败: {message}")
+def parse_proxy_api_response(
+    payload: Any,
+    *,
+    protocol: str,
+    profile: ProxyApiProfile | str | None = None,
+) -> list[str]:
+    proxies, _records = _parse_proxy_payload(
+        payload,
+        protocol=protocol,
+        profile=profile,
+    )
+    return proxies
+
+
+def _parse_proxy_payload(
+    payload: Any,
+    *,
+    protocol: str,
+    profile: ProxyApiProfile | str | None = None,
+) -> tuple[list[str], list[dict[str, Any]]]:
+    profile_obj = _coerce_profile(profile)
+    _raise_if_provider_failure(payload, profile_obj)
 
     proxies: list[str] = []
     seen: set[str] = set()
-    for item in _iter_proxy_items(payload):
-        proxy_parts = _extract_proxy_parts(item, protocol=protocol)
-        if not proxy_parts:
-            continue
-        scheme, host, port, username, password = proxy_parts
-        if not host or not port.isdigit():
-            continue
-        proxy = _format_proxy_url(
-            scheme=scheme,
-            host=host,
-            port=port,
-            username=username,
-            password=password,
-        )
-        key = proxy.lower()
-        if key in seen:
-            continue
-        seen.add(key)
-        proxies.append(proxy)
-
+    records: list[dict[str, Any]] = []
+    _collect_from_payload(
+        payload,
+        protocol=normalize_proxy_api_protocol(protocol),
+        proxies=proxies,
+        seen=seen,
+        records=records,
+    )
     if not proxies:
-        raise ProxyApiError("代理 API 返回成功，但没有解析到代理 IP 和端口")
+        _raise_no_proxy_error()
+    return proxies, records
+
+
+def _load_json_payload(text: str) -> Any | None:
+    try:
+        return json.loads(text)
+    except (TypeError, ValueError):
+        return None
+
+
+def _xml_element_to_value(element: ElementTree.Element) -> Any:
+    children = list(element)
+    if not children:
+        return (element.text or "").strip()
+
+    grouped: dict[str, list[Any]] = {}
+    for child in children:
+        grouped.setdefault(child.tag.lower(), []).append(_xml_element_to_value(child))
+
+    result: dict[str, Any] = {}
+    for key, values in grouped.items():
+        result[key] = values[0] if len(values) == 1 else values
+    return result
+
+
+def _load_xml_payload(text: str) -> Any | None:
+    raw = str(text or "").strip()
+    if not raw.startswith("<"):
+        return None
+    try:
+        root = ElementTree.fromstring(raw)
+    except ElementTree.ParseError:
+        return None
+    return {root.tag.lower(): _xml_element_to_value(root)}
+
+
+def parse_proxy_api_response_text(
+    text: str,
+    *,
+    protocol: str,
+    profile: ProxyApiProfile | str | None = None,
+) -> list[str]:
+    profile_obj = _coerce_profile(profile)
+    payload = _load_json_payload(str(text or ""))
+    if payload is not None:
+        return parse_proxy_api_response(payload, protocol=protocol, profile=profile_obj)
+    payload = _load_xml_payload(str(text or ""))
+    if payload is not None:
+        return parse_proxy_api_response(payload, protocol=protocol, profile=profile_obj)
+
+    proxies: list[str] = []
+    seen: set[str] = set()
+    _collect_from_text(
+        str(text or ""),
+        protocol=normalize_proxy_api_protocol(protocol),
+        proxies=proxies,
+        seen=seen,
+    )
+    if not proxies:
+        first_line = next(
+            (line.strip() for line in str(text or "").splitlines() if line.strip()),
+            "",
+        )
+        if first_line:
+            raise ProxyApiError(
+                f"代理 API 返回成功，但没有解析到代理 IP 和端口。原始返回: {first_line[:120]}"
+            )
+        _raise_no_proxy_error()
     return proxies
 
 
@@ -252,15 +937,57 @@ def fetch_proxy_api(
     protocol: str,
     timeout: int = 15,
 ) -> ProxyApiResult:
-    request_url = build_proxy_api_url(api_url, count=count, protocol=protocol)
+    request = build_proxy_api_request(api_url, count=count, protocol=protocol)
     response = requests.request(
-        "GET", request_url, headers={}, data={}, timeout=timeout
+        "GET", request.url, headers={}, data={}, timeout=timeout
     )
     response.raise_for_status()
-    payload = response.json()
-    if not isinstance(payload, dict):
-        raise ProxyApiError("代理 API 未返回 JSON 对象")
+
+    raw_text = response.text
+    payload = _load_json_payload(raw_text)
+    if payload is not None:
+        proxies, records = _parse_proxy_payload(
+            payload,
+            protocol=protocol,
+            profile=request.profile,
+        )
+        return ProxyApiResult(
+            proxies=proxies,
+            response=payload if isinstance(payload, dict) else {"data": payload},
+            proxy_records=records,
+        )
+
+    payload = _load_xml_payload(raw_text)
+    if payload is not None:
+        proxies, records = _parse_proxy_payload(
+            payload,
+            protocol=protocol,
+            profile=request.profile,
+        )
+        return ProxyApiResult(
+            proxies=proxies,
+            response=payload if isinstance(payload, dict) else {"data": payload},
+            proxy_records=records,
+        )
+
+    proxies: list[str] = []
+    seen: set[str] = set()
+    records: list[dict[str, Any]] = []
+    _collect_from_text(
+        raw_text,
+        protocol=normalize_proxy_api_protocol(protocol),
+        proxies=proxies,
+        seen=seen,
+        records=records,
+    )
+    if not proxies:
+        parse_proxy_api_response_text(
+            raw_text,
+            protocol=protocol,
+            profile=request.profile,
+        )
     return ProxyApiResult(
-        proxies=parse_proxy_api_response(payload, protocol=protocol),
-        response=payload,
+        proxies=proxies,
+        response={"raw": raw_text},
+        proxy_records=records,
     )

--- a/util/proxy/ProxyApiProvider.py
+++ b/util/proxy/ProxyApiProvider.py
@@ -241,6 +241,8 @@ _PROXY_CANDIDATE_RE = re.compile(
 
 def normalize_proxy_api_protocol(protocol: str | None) -> str:
     text = str(protocol or "http").strip().lower()
+    if text == "auto":
+        return "auto"
     if text in {"socks", "socks5"}:
         return "socks5"
     return "http"
@@ -434,7 +436,10 @@ def _normalize_proxy_scheme(scheme: str | None, fallback_protocol: str) -> str:
         return "socks4"
     if text in {"http", "https"}:
         return text
-    return normalize_proxy_api_protocol(fallback_protocol)
+    normalized_fallback = normalize_proxy_api_protocol(fallback_protocol)
+    if normalized_fallback == "auto":
+        return "http"
+    return normalized_fallback
 
 
 def _format_proxy_url(
@@ -487,7 +492,7 @@ def _parse_host_port_auth_text(
     if not value:
         return None
 
-    scheme = normalize_proxy_api_protocol(protocol)
+    scheme = _normalize_proxy_scheme(None, protocol)
     scheme_match = re.match(r"^([a-zA-Z][a-zA-Z0-9+.-]*)://(.+)$", value)
     if scheme_match:
         scheme = _normalize_proxy_scheme(scheme_match.group(1), protocol)
@@ -754,8 +759,14 @@ def _collect_from_text(
                     records,
                 )
 
-        candidates = [match.group(0) for match in _URL_CANDIDATE_RE.finditer(line)]
-        candidates.extend(match.group(0) for match in _PROXY_CANDIDATE_RE.finditer(line))
+        url_matches = list(_URL_CANDIDATE_RE.finditer(line))
+        url_spans = [match.span() for match in url_matches]
+        candidates = [match.group(0) for match in url_matches]
+        for match in _PROXY_CANDIDATE_RE.finditer(line):
+            start, end = match.span()
+            if any(span_start <= start and end <= span_end for span_start, span_end in url_spans):
+                continue
+            candidates.append(match.group(0))
         if not candidates:
             candidates.append(line)
         for candidate in candidates:


### PR DESCRIPTION
## 概述

重构代理 API 获取模块，改为“自动识别 + 服务商 Profile + 通用兜底解析”的三层兼容模式，并补齐 XML、TTL 元数据、API URL 脱敏展示和更多国内服务商兼容。

本 PR 主要优化：

- 不再强行把所有服务商 URL 改写成 `count/format/protocol`。
- 支持直接粘贴服务商后台生成的提取 API/demo 链接。
- 强兼容 有代理、快代理、巨量 HTTP、青果、亿牛云、携趣等常见服务商。
- 芝麻、品易、太阳、蘑菇、讯代理、站大爷、duomi 等走 Profile 或通用兜底解析。
- 支持 JSON、JSON list、嵌套字段、XML、纯文本、CSV 样式、`ip:port` 等返回格式。
- 扩展代理字段识别，并在 `proxy_records` 中保留 `ttl`、`expire_time`、`deadline` 等有效期元数据。
- 新增代理 API URL 脱敏展示，隐藏 `key`、`token`、`signature` 等敏感参数值。
- 补充代理 API demos 和兼容说明文档。
- 更新代理 API 输入框和获取结果文案。

### 事务

- [ ] 已与维护者在 issues 或其他平台沟通此 PR 大致内容

## 以下内容可在起草 PR 后、合并 PR 前逐步完成

### 功能

- [x] 已编写完善的配置文件字段说明（若有新增）
  - 无新增配置字段；新增 `docs/proxy-api-compatibility.md` 说明代理 API 兼容策略。
- [x] 已编写面向用户的新功能说明（若有必要）
  - 新增 `demos/proxy-api/provider-demos.md`，并更新设置页代理 API 文案。
- [x] 已测试新功能或更改
  - `python -m pytest tests\test_proxy_api_provider.py -q` -> 24 passed
  - `python -m py_compile util\proxy\ProxyApiProvider.py tab\config.py tests\test_proxy_api_provider.py` -> passed

### 兼容性

- [x] 已处理版本兼容性
  - 保留 `fetch_proxy_api` 和 `build_proxy_api_url` 外部调用接口，避免影响现有 UI 和抢票补池流程。
  - `fetch_proxy_api()` 继续返回 `proxies: list[str]`，新增 `proxy_records` 作为可选元数据，不打断旧调用方。
- [x] 已处理插件兼容问题
  - 不涉及插件接口变更；代理 API 输出仍是 `ProxyManager` 可消费的标准代理列表。

### 风险

可能导致或已知的问题：

- 代理服务商 API 差异较多，本 PR 优先覆盖常见国内服务商和通用格式；未知服务商仍走 generic 兜底解析。
- Profile 只在规则明确时补齐空参数或缺失参数，避免破坏签名 URL；因此部分服务商仍需要用户粘贴后台生成的完整 demo 链接。
- TTL/过期时间目前作为 `proxy_records` 元数据保留，暂未参与代理池调度和自动淘汰逻辑。
- 本地运行过全量 `python -m pytest -q`，仍存在与本 PR 无关的既有失败：`rate_limit_delay_ms` 默认值预期、H2 fanout URL/randomized fanout 断言、Windows 下 `os.getpgid` 测试。
