### PR TITLE
增加抢票前立即购票校验 防止假开害人

### DIFF
--- a/app_cmd/config/BuyConfig.py
+++ b/app_cmd/config/BuyConfig.py
@@ -170,6 +170,45 @@ class BuyConfig(BasicConfig):
     )
     """Delay after receiving HTTP 429, in milliseconds."""
 
+    wait_for_buy_button: bool = config_field(
+        False,
+        env="BTB_WAIT_FOR_BUY_BUTTON",
+        runtime="wait_for_buy_button",
+        db="waitForBuyButton",
+        cast=str_to_bool,
+        cli_true="--wait-for-buy-button",
+    )
+    """Wait for the mobile page's immediate-buy button before ordering."""
+
+    buy_page_url: str = config_field(
+        "",
+        env="BTB_BUY_PAGE_URL",
+        runtime="buy_page_url",
+        db="buyPageUrl",
+        cli="--buy-page-url",
+    )
+    """Ticket detail URL used by the immediate-buy page gate."""
+
+    buy_page_timeout_seconds: int = config_field(
+        60,
+        env="BTB_BUY_PAGE_TIMEOUT_SECONDS",
+        runtime="buy_page_timeout_seconds",
+        db="buyPageTimeoutSeconds",
+        cli="--buy-page-timeout-seconds",
+        cast=int,
+    )
+    """Maximum post-start wait time for the immediate-buy button."""
+
+    buy_page_check_before_seconds: int = config_field(
+        5,
+        env="BTB_BUY_PAGE_CHECK_BEFORE_SECONDS",
+        runtime="buy_page_check_before_seconds",
+        db="buyPageCheckBeforeSeconds",
+        cli="--buy-page-check-before-seconds",
+        cast=int,
+    )
+    """Seconds before ticket start to begin polling the mobile ticket page."""
+
     refresh_interval_min_count: int = config_field(
         10,
         env="BTB_REFRESH_INTERVAL_MIN_COUNT",

--- a/interface/config.py
+++ b/interface/config.py
@@ -58,6 +58,10 @@ class RuntimeOptions:
     auto_open_payment_url: bool = True
     log_level: str = "standard"
     log_retention_days: int = 7
+    wait_for_buy_button: bool = False
+    buy_page_url: str = ""
+    buy_page_timeout_seconds: int = 60
+    buy_page_check_before_seconds: int = 5
 
     @classmethod
     def from_mapping(cls, data: dict[str, Any]) -> "RuntimeOptions":
@@ -331,6 +335,10 @@ def build_runtime_options(
     auto_open_payment_url: bool = True,
     log_level: str = "standard",
     log_retention_days: int = 7,
+    wait_for_buy_button: bool = False,
+    buy_page_url: str = "",
+    buy_page_timeout_seconds: int = 60,
+    buy_page_check_before_seconds: int = 5,
 ) -> RuntimeOptions:
     return RuntimeOptions(
         interval=normalize_interval(interval),
@@ -389,6 +397,14 @@ def build_runtime_options(
         auto_open_payment_url=auto_open_payment_url,
         log_level=str(log_level or "standard").lower(),
         log_retention_days=normalize_positive_int(log_retention_days, default=7),
+        wait_for_buy_button=bool(wait_for_buy_button),
+        buy_page_url=str(buy_page_url or "").strip(),
+        buy_page_timeout_seconds=normalize_positive_int(
+            buy_page_timeout_seconds, default=60
+        ),
+        buy_page_check_before_seconds=normalize_non_negative_interval(
+            buy_page_check_before_seconds, default=5
+        ),
     )
 
 

--- a/tab/config.py
+++ b/tab/config.py
@@ -4,6 +4,7 @@ import gradio as gr
 from loguru import logger
 
 from app_cmd.config.BuyConfig import BuyConfig
+from task.page_gate import normalize_mobile_ticket_page_url
 from util import (
     ConfigDB,
 )
@@ -251,6 +252,35 @@ def go_settings_tab(header_ui):
     def update_use_local_token(value):
         ConfigDB.insert("useLocalToken", value)
         return gr.update(value=ConfigDB.get("useLocalToken"))
+
+    def update_wait_for_buy_button(value):
+        ConfigDB.insert("waitForBuyButton", bool(value))
+        return gr.update(value=ConfigDB.get_as_bool("waitForBuyButton", False))
+
+    def update_buy_page_url(value):
+        raw = str(value or "").strip()
+        if not raw:
+            ConfigDB.insert("buyPageUrl", "")
+            return gr.update(value="")
+        try:
+            normalized = normalize_mobile_ticket_page_url(raw)
+        except ValueError as exc:
+            gr.Warning(f"抢票链接未保存：{exc}")
+            return gr.update(value=ConfigDB.get("buyPageUrl") or "")
+        ConfigDB.insert("buyPageUrl", normalized)
+        gr.Info("已保存并转换为移动端购票页链接。")
+        return gr.update(value=normalized)
+
+    def update_buy_page_timeout_seconds(value):
+        return _update_positive_int_config("buyPageTimeoutSeconds", value, 60)
+
+    def update_buy_page_check_before_seconds(value):
+        try:
+            parsed = max(0, int(value))
+        except (TypeError, ValueError):
+            parsed = 5
+        ConfigDB.insert("buyPageCheckBeforeSeconds", parsed)
+        return gr.update(value=ConfigDB.get_as_int("buyPageCheckBeforeSeconds", 5))
 
     def update_proxy_assignment_strategy(value):
         ConfigDB.insert("proxyAssignmentStrategy", value)
@@ -761,6 +791,32 @@ def go_settings_tab(header_ui):
                         value=buy_defaults.use_local_token,
                         info="默认关闭。开启后，非 hotproject 直接使用本地生成 token。",
                     )
+                    gr.Markdown("## 开售页面校验")
+                    wait_for_buy_button_ui = gr.Checkbox(
+                        label="等待立即购票后再抢票",
+                        value=buy_defaults.wait_for_buy_button,
+                        info="开启后，在开售前检查移动端购票页；开售时未出现“立即购票/立即购买”不会发送下单请求。",
+                    )
+                    buy_page_url_ui = gr.Textbox(
+                        label="抢票链接",
+                        value=buy_defaults.buy_page_url,
+                        placeholder="支持 PC 或移动端活动详情链接；保存时会自动转换为移动端链接。",
+                        info="留空时会根据上传的抢票配置自动生成对应活动的移动端链接。",
+                    )
+                    with gr.Row():
+                        buy_page_check_before_seconds_ui = gr.Number(
+                            label="抢票前开始同步购票页状态（秒）",
+                            value=buy_defaults.buy_page_check_before_seconds,
+                            minimum=0,
+                            step=1,
+                        )
+                        buy_page_timeout_seconds_ui = gr.Number(
+                            label="等待立即购票超时时间（秒）",
+                            value=buy_defaults.buy_page_timeout_seconds,
+                            minimum=1,
+                            step=1,
+                            info="超过此时间仍未出现立即购票，当前抢票程序会终止。",
+                        )
                     request_interval_ui = gr.Number(
                         label="默认抢票间隔（毫秒）",
                         value=int(buy_defaults.interval or DEFAULT_REQUEST_INTERVAL),
@@ -936,6 +992,29 @@ def go_settings_tab(header_ui):
         inputs=use_local_token_ui,
         outputs=use_local_token_ui,
     )
+    wait_for_buy_button_ui.change(
+        fn=update_wait_for_buy_button,
+        inputs=wait_for_buy_button_ui,
+        outputs=wait_for_buy_button_ui,
+    )
+    buy_page_url_ui.submit(
+        fn=update_buy_page_url,
+        inputs=buy_page_url_ui,
+        outputs=buy_page_url_ui,
+    )
+    buy_page_url_ui.blur(
+        fn=update_buy_page_url,
+        inputs=buy_page_url_ui,
+        outputs=buy_page_url_ui,
+    )
+    _bind_number_commit(
+        buy_page_check_before_seconds_ui,
+        update_buy_page_check_before_seconds,
+    )
+    _bind_number_commit(
+        buy_page_timeout_seconds_ui,
+        update_buy_page_timeout_seconds,
+    )
     _bind_number_commit(
         request_interval_ui,
         update_request_interval,
@@ -1013,6 +1092,10 @@ def go_settings_tab(header_ui):
             gr.update(value=hide_header),
             gr.update(visible=not hide_header),
             gr.update(value=buy_defaults.use_local_token),
+            gr.update(value=buy_defaults.wait_for_buy_button),
+            gr.update(value=buy_defaults.buy_page_url),
+            gr.update(value=buy_defaults.buy_page_check_before_seconds),
+            gr.update(value=buy_defaults.buy_page_timeout_seconds),
             gr.update(value=int(buy_defaults.interval or DEFAULT_REQUEST_INTERVAL)),
             gr.update(value=buy_defaults.h2_connections_per_source_ip),
             gr.update(value=buy_defaults.create_retry_limit),
@@ -1054,6 +1137,10 @@ def go_settings_tab(header_ui):
         hide_header_ui,
         header_ui,
         use_local_token_ui,
+        wait_for_buy_button_ui,
+        buy_page_url_ui,
+        buy_page_check_before_seconds_ui,
+        buy_page_timeout_seconds_ui,
         request_interval_ui,
         h2_connections_per_source_ip_ui,
         create_retry_limit_ui,

--- a/task/buy.py
+++ b/task/buy.py
@@ -45,6 +45,11 @@ from task.buy_helpers import (
     summarize_non_json_response as _summarize_non_json_response,
     wait_until_start as _wait_until_start,
 )
+from task.page_gate import (
+    check_ticket_page_availability,
+    mobile_ticket_page_url,
+    normalize_mobile_ticket_page_url,
+)
 from task.buy_types import (
     BuyStreamEvent,
     BuyStreamState,
@@ -432,6 +437,31 @@ def buy_stream(config: BuyConfig):
     effective_retry_limit = max(1, int(config.create_retry_limit))
     effective_batch_size = max(1, int(config.create_request_batch_size))
     rate_limit_delay_ms = max(0, int(config.rate_limit_delay_ms))
+    wait_for_buy_button = bool(config.wait_for_buy_button)
+    page_status_check = None
+    page_check_before_seconds = max(0, int(config.buy_page_check_before_seconds))
+    page_timeout_seconds = max(1, int(config.buy_page_timeout_seconds))
+    if wait_for_buy_button:
+        configured_page_url = str(config.buy_page_url or "").strip()
+        try:
+            buy_page_url = (
+                normalize_mobile_ticket_page_url(configured_page_url)
+                if configured_page_url
+                else mobile_ticket_page_url(tickets_info["project_id"])
+            )
+        except ValueError as exc:
+            buy_page_url = configured_page_url
+            logger.warning("购票页链接无效，将在校验阶段等待至超时：{}", exc)
+
+        def page_status_check():
+            return check_ticket_page_availability(_request, buy_page_url)
+
+        logger.info(
+            "已开启立即购票校验：移动端链接={}，提前{}秒开始，超时{}秒",
+            buy_page_url,
+            page_check_before_seconds,
+            page_timeout_seconds,
+        )
 
     def emit_reprepare(reason: str):
         message = _format_reprepare_reason(reason)
@@ -493,10 +523,20 @@ def buy_stream(config: BuyConfig):
     for wait_state in _wait_until_start(
         config.time_start,
         warmup=refresh_hot_and_warm,
+        page_status_check=page_status_check,
+        page_check_before_seconds=page_check_before_seconds,
+        page_timeout_seconds=page_timeout_seconds,
     ):
         wait_message = wait_state.get("message")
         countdown_value = wait_state.get("countdown")
         countdown_seconds = wait_state.get("countdown_seconds")
+        if wait_state.get("page_gate_timeout"):
+            yield emit(
+                "error",
+                wait_message,
+                BuyStreamUpdate(status="failed", stage="购票页校验超时"),
+            )
+            return
         stage_value = None
         if isinstance(wait_message, str) and wait_message.startswith("0)"):
             stage_value = "等待开票"

--- a/task/buy_helpers.py
+++ b/task/buy_helpers.py
@@ -74,8 +74,65 @@ def next_countdown_report_at(countdown_seconds: int) -> int:
     return -1
 
 
-def wait_until_start(time_start: str, warmup=None):
+def _page_gate_result_fields(result: Any) -> tuple[bool, str]:
+    """Keep the countdown code independent from the page-check implementation."""
+
+    if isinstance(result, bool):
+        return result, "购票页校验：检测到「立即购票」。" if result else "购票页校验：尚未检测到「立即购票」。"
+    ready = bool(getattr(result, "ready", False))
+    message = getattr(result, "message", None)
+    if not isinstance(message, str) or not message:
+        message = "购票页校验：检测到「立即购票」。" if ready else "购票页校验：尚未检测到「立即购票」。"
+    return ready, message
+
+
+def _wait_for_page_gate(
+    page_status_check: Callable[[], Any],
+    *,
+    timeout_seconds: float,
+    poll_interval_seconds: float,
+):
+    """Poll after the scheduled start until the page is purchasable or times out."""
+
+    deadline = time.perf_counter() + max(1.0, timeout_seconds)
+    while True:
+        try:
+            ready, message = _page_gate_result_fields(page_status_check())
+        except Exception as exc:
+            ready, message = False, f"购票页校验请求失败，继续等待：{exc}"
+        yield {"message": message}
+        if ready:
+            return
+        remaining = deadline - time.perf_counter()
+        if remaining <= 0:
+            yield {
+                "message": "购票页校验超时，未检测到「立即购票」，本次抢票已终止。",
+                "page_gate_timeout": True,
+            }
+            return
+        time.sleep(min(poll_interval_seconds, remaining))
+
+
+def wait_until_start(
+    time_start: str,
+    warmup=None,
+    *,
+    page_status_check: Callable[[], Any] | None = None,
+    page_check_before_seconds: float = 0,
+    page_timeout_seconds: float = 60,
+    page_poll_interval_seconds: float = 0.5,
+):
+    page_check_before_seconds = max(0.0, float(page_check_before_seconds))
+    page_timeout_seconds = max(1.0, float(page_timeout_seconds))
+    page_poll_interval_seconds = max(0.1, float(page_poll_interval_seconds))
     if not time_start:
+        if page_status_check is not None:
+            yield {"message": "0) 未设置开始时间，正在等待购票页出现「立即购票」。"}
+            yield from _wait_for_page_gate(
+                page_status_check,
+                timeout_seconds=page_timeout_seconds,
+                poll_interval_seconds=page_poll_interval_seconds,
+            )
         return
 
     timeoffset = time_service.get_timeoffset()
@@ -132,10 +189,32 @@ def wait_until_start(time_start: str, warmup=None):
     end_time = time.perf_counter() + time_difference
     next_report_at = float("inf")
     warmed = False
+    page_ready = False
+    page_next_check_at = 0.0
     last_countdown_seconds: int | None = None
     while True:
         remaining = end_time - time.perf_counter()
         if remaining <= 0:
+            if page_status_check is not None:
+                try:
+                    page_ready, page_message = _page_gate_result_fields(
+                        page_status_check()
+                    )
+                except Exception as exc:
+                    page_ready, page_message = (
+                        False,
+                        f"购票页校验请求失败，继续等待：{exc}",
+                    )
+                yield {"message": page_message}
+                if not page_ready:
+                    yield {
+                        "message": "抢票时间已到，仍未检测到「立即购票」，继续刷新购票页。"
+                    }
+                    yield from _wait_for_page_gate(
+                        page_status_check,
+                        timeout_seconds=page_timeout_seconds,
+                        poll_interval_seconds=page_poll_interval_seconds,
+                    )
             return
         countdown_seconds = max(0, math.ceil(remaining))
         countdown_text = format_countdown(remaining)
@@ -159,6 +238,25 @@ def wait_until_start(time_start: str, warmup=None):
                     "countdown": countdown_text,
                     "countdown_seconds": countdown_seconds,
                 }
+            continue
+        if (
+            page_status_check is not None
+            and not page_ready
+            and remaining <= page_check_before_seconds
+            and time.perf_counter() >= page_next_check_at
+        ):
+            page_next_check_at = time.perf_counter() + page_poll_interval_seconds
+            try:
+                page_ready, page_message = _page_gate_result_fields(
+                    page_status_check()
+                )
+            except Exception as exc:
+                page_message = f"购票页校验请求失败，继续等待：{exc}"
+            yield {
+                "message": page_message,
+                "countdown": countdown_text,
+                "countdown_seconds": countdown_seconds,
+            }
             continue
         if countdown_seconds <= next_report_at:
             if countdown_seconds > 10:

--- a/task/page_gate.py
+++ b/task/page_gate.py
@@ -1,0 +1,224 @@
+"""Mobile ticket-page availability gate used before creating an order."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+from requests import RequestException
+
+
+MOBILE_TICKET_PAGE_URL = (
+    "https://mall.bilibili.com/neul-next/ticket-renovation/detail.html?id={project_id}"
+)
+MOBILE_USER_AGENT = (
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) "
+    "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 "
+    "Mobile/15E148 Safari/604.1"
+)
+BUY_BUTTON_TEXTS = ("立即购票", "立即购买")
+TICKET_PAGE_STATE_URL = "https://mall.bilibili.com/mall-search-items/items_detail/info"
+
+
+@dataclass(frozen=True, slots=True)
+class TicketPageAvailability:
+    url: str
+    ready: bool
+    status_code: int | None = None
+    matched_text: str | None = None
+    error: str | None = None
+
+    @property
+    def message(self) -> str:
+        if self.ready:
+            return "购票页校验：检测到「{0}」，允许开始抢票。".format(
+                self.matched_text or "立即购票"
+            )
+        if self.error:
+            return "购票页校验请求失败，继续等待：{0}".format(self.error)
+        return "购票页校验：尚未检测到「立即购票」。"
+
+
+def mobile_ticket_page_url(project_id: int | str) -> str:
+    """Build the canonical mobile ticket page URL for a project."""
+
+    try:
+        normalized_id = int(project_id)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("抢票链接缺少有效的活动 id") from exc
+    if normalized_id <= 0:
+        raise ValueError("抢票链接缺少有效的活动 id")
+    return MOBILE_TICKET_PAGE_URL.format(project_id=normalized_id)
+
+
+def normalize_mobile_ticket_page_url(value: str) -> str:
+    """Convert Bilibili desktop/mobile detail URLs to the mobile ticket page."""
+
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    parsed = urlparse(raw)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("抢票链接必须是完整的 http(s) 活动链接")
+    if not parsed.hostname or not parsed.hostname.lower().endswith("bilibili.com"):
+        raise ValueError("抢票链接必须属于 bilibili.com")
+
+    query = parse_qs(parsed.query)
+    project_id = (query.get("id") or query.get("project_id") or [""])[0]
+    return mobile_ticket_page_url(project_id)
+
+
+def _project_id_from_mobile_ticket_page_url(page_url: str) -> int:
+    query = parse_qs(urlparse(page_url).query)
+    return int((query.get("id") or [""])[0])
+
+
+def _ticket_page_state_is_ready(
+    session: Any,
+    *,
+    page_url: str,
+    headers: dict[str, str],
+    cookies: dict[str, str],
+    timeout_seconds: float,
+) -> TicketPageAvailability | None:
+    """Read the official state payload used by the mobile ticket page UI."""
+
+    if not hasattr(session, "post"):
+        return None
+    try:
+        project_id = _project_id_from_mobile_ticket_page_url(page_url)
+        state_headers = {
+            "accept": "application/json, text/plain, */*",
+            "origin": "https://mall.bilibili.com",
+            "referer": page_url,
+            "user-agent": MOBILE_USER_AGENT,
+        }
+        response = session.post(
+            TICKET_PAGE_STATE_URL,
+            json={"itemsId": project_id, "itemsDetailPageType": 3},
+            headers=state_headers,
+            cookies=cookies,
+            timeout=max(0.5, float(timeout_seconds)),
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except (RequestException, ValueError, TypeError) as exc:
+        return TicketPageAvailability(
+            url=page_url,
+            ready=False,
+            error="购票页状态请求失败：{0}: {1}".format(exc.__class__.__name__, exc),
+        )
+
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, dict):
+        code = payload.get("code", payload.get("errno", "unknown")) if isinstance(payload, dict) else "unknown"
+        message = payload.get("message", payload.get("msg", "")) if isinstance(payload, dict) else ""
+        return TicketPageAvailability(
+            url=page_url,
+            ready=False,
+            error="购票页状态响应缺少 data（code={0}, message={1}）".format(
+                code,
+                message or "无",
+            ),
+        )
+    # `canClick` is the official detail-page state that drives the enabled
+    # immediate-buy control seen in the mobile UI.
+    if data.get("canClick") is True:
+        return TicketPageAvailability(
+            url=page_url,
+            ready=True,
+            status_code=response.status_code,
+            matched_text="立即购票（页面状态）",
+        )
+    return TicketPageAvailability(
+        url=page_url,
+        ready=False,
+        status_code=response.status_code,
+    )
+
+
+def check_ticket_page_availability(
+    request: Any,
+    page_url: str,
+    *,
+    timeout_seconds: float = 4.0,
+) -> TicketPageAvailability:
+    """Fetch the rendered mobile page and look for its immediate-buy button text.
+
+    This intentionally uses the existing request session directly: ``BiliRequest``
+    expects JSON responses, while this endpoint returns HTML.  Reusing its session
+    retains the configured proxy and the ticket account's cookies.
+    """
+
+    try:
+        normalized_url = normalize_mobile_ticket_page_url(page_url)
+    except ValueError as exc:
+        return TicketPageAvailability(
+            url=str(page_url or ""), ready=False, error=str(exc)
+        )
+
+    session = getattr(request, "session", None)
+    if session is None or not hasattr(session, "get"):
+        return TicketPageAvailability(
+            url=normalized_url,
+            ready=False,
+            error="当前请求会话不可用",
+        )
+
+    # Do not inherit BiliRequest's desktop browser fingerprint here.  Mixing
+    # desktop `sec-ch-*` headers with a mobile User-Agent can make the mall
+    # detail API return `data: null` even when the mobile UI shows the button.
+    headers = {
+        "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "accept-language": "zh-CN,zh;q=0.9",
+        "referer": normalized_url,
+        "user-agent": MOBILE_USER_AGENT,
+    }
+    cookies: dict[str, str] = {}
+    cookie_manager = getattr(request, "cookieManager", None)
+    if cookie_manager is not None:
+        for cookie in cookie_manager.get_cookies(force=True) or []:
+            name = cookie.get("name")
+            value = cookie.get("value")
+            if name and value is not None:
+                cookies[str(name)] = str(value)
+
+    try:
+        response = session.get(
+            normalized_url,
+            headers=headers,
+            cookies=cookies,
+            timeout=max(0.5, float(timeout_seconds)),
+        )
+        response.raise_for_status()
+    except (RequestException, ValueError) as exc:
+        return TicketPageAvailability(
+            url=normalized_url,
+            ready=False,
+            error="{0}: {1}".format(exc.__class__.__name__, exc),
+        )
+
+    body = response.text or ""
+    for text in BUY_BUTTON_TEXTS:
+        if text in body:
+            return TicketPageAvailability(
+                url=normalized_url,
+                ready=True,
+                status_code=response.status_code,
+                matched_text=text,
+            )
+    page_state = _ticket_page_state_is_ready(
+        session,
+        page_url=normalized_url,
+        headers=headers,
+        cookies=cookies,
+        timeout_seconds=timeout_seconds,
+    )
+    if page_state is not None:
+        return page_state
+    return TicketPageAvailability(
+        url=normalized_url,
+        ready=False,
+        status_code=response.status_code,
+    )

--- a/tests/test_page_gate.py
+++ b/tests/test_page_gate.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from task.buy_helpers import wait_until_start
+from task.page_gate import (
+    check_ticket_page_availability,
+    normalize_mobile_ticket_page_url,
+)
+from app_cmd.config.BuyConfig import BuyConfig
+
+
+TEST_MOBILE_URL = (
+    "https://mall.bilibili.com/neul-next/ticket-renovation/detail.html?id=1002606"
+)
+
+
+class _FakeResponse:
+    def __init__(self, text: str = "", payload=None):
+        self.text = text
+        self.payload = payload
+        self.status_code = 200
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+class _FakeSession:
+    def __init__(self, text: str, payload=None):
+        self.text = text
+        self.payload = payload
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return _FakeResponse(self.text)
+
+    def post(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return _FakeResponse(payload=self.payload)
+
+
+class _FakeCookieManager:
+    def get_cookies(self, *, force: bool):
+        assert force is True
+        return [{"name": "SESSDATA", "value": "session-cookie"}]
+
+
+class _FakeRequest:
+    def __init__(self, text: str, payload=None):
+        self.session = _FakeSession(text, payload)
+        self.headers = {"user-agent": "desktop"}
+        self.cookieManager = _FakeCookieManager()
+
+
+def test_normalize_given_mobile_ticket_link_removes_tracking_parameters():
+    source = (
+        "https://mall.bilibili.com/neul-next/ticket-renovation/detail.html"
+        "?from=newhomepage&id=1002606&msource=bilibiliapp&share_source=WEIXIN"
+        "#themeType=2"
+    )
+    assert normalize_mobile_ticket_page_url(source) == TEST_MOBILE_URL
+
+
+def test_normalize_desktop_ticket_link_to_mobile_page():
+    source = "https://show.bilibili.com/platform/detail.html?id=1002606"
+    assert normalize_mobile_ticket_page_url(source) == TEST_MOBILE_URL
+
+
+def test_page_check_uses_mobile_page_and_detects_immediate_buy_button():
+    request = _FakeRequest("<button>立即购买</button>")
+
+    result = check_ticket_page_availability(
+        request,
+        "https://show.bilibili.com/platform/detail.html?id=1002606",
+    )
+
+    assert result.ready is True
+    assert result.matched_text == "立即购买"
+    url, kwargs = request.session.calls[0]
+    assert url == TEST_MOBILE_URL
+    assert kwargs["headers"]["user-agent"] != "desktop"
+    assert kwargs["cookies"] == {"SESSDATA": "session-cookie"}
+
+
+def test_page_check_uses_mobile_page_state_when_html_is_a_client_shell():
+    request = _FakeRequest(
+        "<div id=app></div>",
+        {"data": {"canClick": True, "isSale": 1}},
+    )
+
+    result = check_ticket_page_availability(request, TEST_MOBILE_URL)
+
+    assert result.ready is True
+    assert result.matched_text == "立即购票（页面状态）"
+    state_url, state_kwargs = request.session.calls[1]
+    assert state_url.endswith("/mall-search-items/items_detail/info")
+    assert state_kwargs["json"] == {"itemsId": 1002606, "itemsDetailPageType": 3}
+
+
+def test_no_start_time_waits_for_the_button_before_returning(monkeypatch):
+    responses = iter([False, True])
+    monkeypatch.setattr("task.buy_helpers.time.sleep", lambda _seconds: None)
+
+    events = list(
+        wait_until_start(
+            "",
+            page_status_check=lambda: next(responses),
+            page_timeout_seconds=10,
+            page_poll_interval_seconds=0.1,
+        )
+    )
+
+    assert not any(event.get("page_gate_timeout") for event in events)
+    assert any("检测到" in str(event.get("message")) for event in events)
+
+
+def test_page_gate_timeout_prevents_the_buy_flow_from_continuing(monkeypatch):
+    class _AdvancingPerfCounter:
+        def __init__(self):
+            self.value = -0.6
+
+        def __call__(self):
+            self.value += 0.6
+            return self.value
+
+    monkeypatch.setattr("task.buy_helpers.time.perf_counter", _AdvancingPerfCounter())
+    monkeypatch.setattr("task.buy_helpers.time.sleep", lambda _seconds: None)
+
+    events = list(
+        wait_until_start(
+            "",
+            page_status_check=lambda: False,
+            page_timeout_seconds=1,
+            page_poll_interval_seconds=0.1,
+        )
+    )
+
+    assert any(event.get("page_gate_timeout") for event in events)
+
+
+def test_page_gate_settings_are_loaded_and_forwarded_to_cli():
+    config = BuyConfig.from_mapping(
+        {
+            "waitForBuyButton": True,
+            "buyPageUrl": "https://show.bilibili.com/platform/detail.html?id=1002606",
+            "buyPageTimeoutSeconds": 75,
+            "buyPageCheckBeforeSeconds": 8,
+        },
+        source_name="db",
+    )
+
+    assert config.wait_for_buy_button is True
+    assert config.buy_page_timeout_seconds == 75
+    assert config.buy_page_check_before_seconds == 8
+    args = config.to_cli_args()
+    assert "--wait-for-buy-button" in args
+    assert args[args.index("--buy-page-url") + 1] == (
+        "https://show.bilibili.com/platform/detail.html?id=1002606"
+    )
+    assert args[args.index("--buy-page-timeout-seconds") + 1] == "75"
+    assert args[args.index("--buy-page-check-before-seconds") + 1] == "8"


### PR DESCRIPTION
## 概述

实现/解决/优化的内容:

#### 背景与问题

部分哔哩哔哩票务活动在配置中的起售时间到达后，页面实际仍可能没有开放“立即购票”。原流程会直接进入 `prepare/create` 下单请求，容易在页面尚未开放时过早请求。

移动端 `neul-next` 活动页由客户端动态渲染：初始 HTML 不一定包含“立即购票”文案。官方详情状态接口返回的 `data.canClick` 才是驱动移动端购票按钮可点击状态的可靠信号。

#### 本 PR 的改动

1. 新增可选的开售页面校验开关 `wait_for_buy_button`（默认关闭），关闭时保持原有抢票行为不变。
2. 新增以下配置，并接入配置库、运行时参数、环境变量和 CLI 参数：

   | 配置 | 配置库键 | 默认值 | 作用 |
   | --- | --- | --- | --- |
   | 等待立即购票 | `waitForBuyButton` | `false` | 开启页面状态校验 |
   | 抢票链接 | `buyPageUrl` | 空 | 指定用于校验的活动链接 |
   | 抢票前开始同步购票页状态 | `buyPageCheckBeforeSeconds` | `5` 秒 | 提前进入轮询窗口 |
   | 等待立即购票超时时间 | `buyPageTimeoutSeconds` | `60` 秒 | 开售后未开放时的最大等待时长 |

3. 在“高级设置 → 杂项”增加“开售页面校验”配置区：
   - 开关“等待立即购票后再抢票”；
   - 抢票链接输入框；
   - 提前校验秒数和超时时间输入框。

4. 支持桌面端和移动端详情链接：保存 PC 链接时自动规范化为移动端 `https://mall.bilibili.com/neul-next/ticket-renovation/detail.html?id=<project_id>`。未填写链接时，按上传抢票配置中的 `project_id` 自动生成。

5. 新增 `task/page_gate.py`：
   - 先兼容识别页面 HTML 中的“立即购票/立即购买”文案；
   - 对客户端渲染页面，请求官方 `mall-search-items/items_detail/info` 状态，使用 `data.canClick == true` 判断页面已开放；
   - 使用独立的移动端请求头，避免桌面端 `sec-ch-*` 指纹头和移动端 User-Agent 混用后接口返回 `code=11119999`、`data=null`；
   - 读取当前账号 Cookie 与代理会话，保证页面校验与抢票任务使用相同登录态和网络出口。

6. 调整等待状态机：

   ```text
   起售前 N 秒开始轮询
       ↓
   起售时最终复检
       ├─ canClick=true → 退出页面校验 → 进入原有 prepare/create 抢票循环
       └─ canClick=false → 每 0.5 秒继续轮询
                                  ├─ 变为 true → 进入原有抢票循环
                                  └─ 到达超时 → 终止当前任务，不发送下单请求
   ```

   一旦校验通过，`wait_until_start()` 会返回；后续只执行原有的下单准备、创建订单和重试逻辑，不会继续检测购票页。即使提前检测到按钮，起售时也会做一次最终复检，避免页面状态回退后仍发送请求。

#### 验证结果

- 新增单元测试，覆盖：
  - PC/移动端链接规范化；
  - HTML 按钮文案识别；
  - 客户端渲染页面的 `canClick` 状态识别；
  - 无起售时间时的等待行为；
  - 超时后阻止流程继续；
  - 配置库加载及 CLI 参数传递。
- 执行：`python -m pytest -q tests/test_page_gate.py tests/test_buy_time_sync.py`，结果：`9 passed`。
- 使用真实移动端活动页验证：
  - `1003451`：状态 `200`、`canClick=true`，识别为 `ready=True`；
  - `1003397`：状态 `200`、未开放，识别为 `ready=False`。

### 事务

- [ ] 已与维护者在 issues 或其他平台沟通此 PR 大致内容

## 以下内容可在起草 PR 后、合并 PR 前逐步完成

### 功能

- [x] 已编写完善的配置文件字段说明（若有新增）
- [x] 已编写面向用户的新功能说明（若有必要）
- [x] 已测试新功能或更改

新增配置字段包含 dataclass 文档字符串、环境变量、CLI 参数和设置页帮助文案；功能行为与使用方法已在本 PR 概述中说明。

### 兼容性

- [x] 已处理版本兼容性
- [x] 已处理插件兼容问题

- 默认关闭校验，现有用户不配置时的抢票路径不变。
- 支持既有 PC 活动链接和移动端活动链接；空链接时自动从抢票配置生成。
- 未涉及插件接口或插件数据格式变更。

### 风险

可能导致或已知的问题:

- 哔哩哔哩移动端详情状态接口、`canClick` 字段或风控策略未来发生变化时，校验可能无法确认开放状态；此时会走超时保护，不会误发下单请求。
- 校验窗口内会额外请求活动页和详情状态接口，默认轮询间隔为 0.5 秒。
- 网络波动、登录态失效或官方接口异常会被记录为校验失败，并持续等待至超时；当前任务会安全结束。
